### PR TITLE
WIP: work around cls handling of Promises

### DIFF
--- a/packages/core/lib/patchers/promise_p.js
+++ b/packages/core/lib/patchers/promise_p.js
@@ -1,0 +1,35 @@
+/**
+ * @module promise_p
+ */
+
+/**
+ * This module patches Promise libraries to correct tracing attribution for http requests.
+ */
+
+var contextUtils = require('../context_utils');
+
+function patchPromise(Promise) {
+  var then = Promise.prototype.then;
+  Promise.prototype.then = function(onFulfilled, onRejected) {
+    if (contextUtils.isAutomaticMode()
+      && tryGetCurrentSegment()
+    ) {
+      var ns = contextUtils.getNamespace();
+
+      onFulfilled = onFulfilled && ns.bind(onFulfilled);
+      onRejected = onRejected && ns.bind(onRejected);
+    }
+
+    return then.call(this, onFulfilled, onRejected);
+  };
+}
+
+function tryGetCurrentSegment() {
+  var segment = null;
+  try {
+    segment = contextUtils.getSegment();
+  } catch(e) { /**/ }
+  return segment;
+}
+
+module.exports = patchPromise;

--- a/packages/core/test/integration/segment_maintained_across_shared_promise.test.js
+++ b/packages/core/test/integration/segment_maintained_across_shared_promise.test.js
@@ -1,0 +1,73 @@
+/* global Promise */
+
+if (!global.Promise) {
+  process.exit(0);
+}
+
+var assert = require('chai').assert;
+var http = require('http');
+
+var AWSXRay = require('../../');
+var Segment = AWSXRay.Segment;
+
+require('../../lib/patchers/promise_p')(Promise);
+
+AWSXRay.enableAutomaticMode();
+
+var sharedPromise = null;
+
+var server = http
+  .createServer(function(req, res) {
+    var ns = AWSXRay.getNamespace();
+    ns.bindEmitter(req);
+    ns.bindEmitter(res);
+
+    ns.run(function () {
+      var segment = new Segment('foo');
+
+      AWSXRay.setSegment(segment);
+
+      if (!sharedPromise) {
+        sharedPromise = Promise.resolve();
+      }
+
+      sharedPromise.then(function() {
+        var retrievedSegment = AWSXRay.getSegment();
+        res.end();
+
+        // setTimeout so the assertion isn't caught by the promise
+        setTimeout(function() {
+          assert.equal(segment.id, retrievedSegment.id);
+        });
+      });
+    });
+  }).listen(0, function() {
+    var address = server.address();
+
+    var count = 0;
+    function cb(err) {
+      if (err) {
+        throw err;
+      }
+
+      if (++count === 2) {
+        server.close();
+      }
+    }
+    sendRequest(address, cb);
+    sendRequest(address, cb);
+  });
+
+function sendRequest(address, cb) {
+  http
+    .request({
+      hostname: address.address,
+      port: address.port,
+      path: '/'
+    })
+    .on('response', function(res) {
+      res.on('end', cb).resume();
+    })
+    .on('error', cb)
+    .end();
+}


### PR DESCRIPTION
continuation-local-storage chooses to bind the context to the Promise
constructor and passes this to any and all reactions to that promise.
While this might make sense in some cases, it very much doesn't when
it comes to tracing an HTTP request context. Provide a patcher for
Promises which will bind the reaction handler to the active segment
when "then" or "catch" is called.

Hey X-Ray team

Didn't expose this patcher or go through the work of integrating it, but wanted to write up a test exposing the issue, and share a possible solution to it.

In the current state, if a Promise is created in request/segment A, and waited upon in request/segment B, than all metadata/errors/subsegments etc. after the fact will be added to segment A instead of B. This is due to the way continuation-local-storage opts to bind Promises, leaning more strictly towards execution paths, which I don't believe fits for a product like X-Ray.

Certainly not the first APM-style product to have this problem, since they all use cls :)

Let me know your thoughts, I'll point our TAMs this way as well.

- Owen