### PR TITLE
Add support for s3 in parameter whitelist file

### DIFF
--- a/packages/core/lib/resources/aws_whitelist.json
+++ b/packages/core/lib/resources/aws_whitelist.json
@@ -330,6 +330,619 @@
           ]
         }
       }
+    },
+    "s3": {
+      "operations": {
+        "abortMultipartUpload": {
+          "request_parameters": [
+            "Key"
+          ],
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "completeMultipartUpload": {
+          "request_parameters": [
+            "Key"
+          ],
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "copyObject": {
+          "request_parameters": [
+            "CopySource",
+            "Key"
+          ],
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "createBucket": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "createMultipartUpload": {
+          "request_parameters": [
+            "Key"
+          ],
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "deleteBucket": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "deleteBucketAnalyticsConfiguration": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "deleteBucketCors": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "deleteBucketEncryption": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "deleteBucketInventoryConfiguration": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "deleteBucketLifecycle": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "deleteBucketMetricsConfiguration": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "deleteBucketPolicy": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "deleteBucketReplication": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "deleteBucketTagging": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "deleteBucketWebsite": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "deleteObject": {
+          "request_parameters": [
+            "Key",
+            "VersionId"
+          ],
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "deleteObjectTagging": {
+          "request_parameters": [
+            "Key",
+            "VersionId"
+          ],
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "deleteObjects": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "getBucketAccelerateConfiguration": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "getBucketAcl": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "getBucketAnalyticsConfiguration": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "getBucketCors": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "getBucketEncryption": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "getBucketInventoryConfiguration": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "getBucketLifecycle": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "getBucketLifecycleConfiguration": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "getBucketLocation": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "getBucketLogging": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "getBucketMetricsConfiguration": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "getBucketNotification": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "getBucketNotificationConfiguration": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "getBucketPolicy": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "getBucketReplication": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "getBucketRequestPayment": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "getBucketTagging": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "getBucketVersioning": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "getBucketWebsite": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "getObject": {
+          "request_parameters": [
+            "Key",
+            "VersionId"
+          ],
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "getObjectAcl": {
+          "request_parameters": [
+            "Key",
+            "VersionId"
+          ],
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "getObjectTagging": {
+          "request_parameters": [
+            "Key",
+            "VersionId"
+          ],
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "getObjectTorrent": {
+          "request_parameters": [
+            "Key"
+          ],
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "headBucket": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "headObject": {
+          "request_parameters": [
+            "Key",
+            "VersionId"
+          ],
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "listBucketAnalyticsConfigurations": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "listBucketInventoryConfigurations": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "listBucketMetricsConfigurations": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "listMultipartUploads": {
+          "request_parameters": [
+            "Prefix"
+          ],
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "listObjectVersions": {
+          "request_parameters": [
+            "Prefix"
+          ],
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "listObjects": {
+          "request_parameters": [
+            "Prefix"
+          ],
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "listObjectsV2": {
+          "request_parameters": [
+            "Prefix"
+          ],
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "listParts": {
+          "request_parameters": [
+            "Key"
+          ],
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "putBucketAccelerateConfiguration": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "putBucketAcl": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "putBucketAnalyticsConfiguration": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "putBucketCors": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "putBucketEncryption": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "putBucketInventoryConfiguration": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "putBucketLifecycle": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "putBucketLifecycleConfiguration": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "putBucketLogging": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "putBucketMetricsConfiguration": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "putBucketNotification": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "putBucketNotificationConfiguration": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "putBucketPolicy": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "putBucketReplication": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "putBucketRequestPayment": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "putBucketTagging": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "putBucketVersioning": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "putBucketWebsite": {
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "putObject": {
+          "request_parameters": [
+            "Key"
+          ],
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "putObjectAcl": {
+          "request_parameters": [
+            "Key",
+            "VersionId"
+          ],
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "putObjectTagging": {
+          "request_parameters": [
+            "Key",
+            "VersionId"
+          ],
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "restoreObject": {
+          "request_parameters": [
+            "Key",
+            "VersionId"
+          ],
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "uploadPart": {
+          "request_parameters": [
+            "Key"
+          ],
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        },
+        "uploadPartCopy": {
+          "request_parameters": [
+            "CopySource",
+            "Key"
+          ],
+          "request_descriptors": {
+            "Bucket": {
+              "rename_to": "bucket_name"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/packages/core/test/unit/segments/attributes/aws.test.js
+++ b/packages/core/test/unit/segments/attributes/aws.test.js
@@ -5,11 +5,17 @@ var sinon = require('sinon');
 
 describe('Aws', function() {
   var serviceName = 's3';
+  var bucketName = 'test-bucket';
+  var keyName = 'test-key';
   var req = {
     request: {
       operation: 'putObject',
       httpRequest: {
         region: 'us-east-1'
+      },
+      params: {
+        Bucket: bucketName,
+        Key: keyName
       }
     },
     requestId: 'C9336616C948DC3C',
@@ -17,11 +23,11 @@ describe('Aws', function() {
   };
 
   describe('#init', function() {
-    var sandbox;
+    var sandbox, addDataStub;
 
     beforeEach(function() {
       sandbox = sinon.sandbox.create();
-      sandbox.stub(Aws.prototype, 'addData');
+      addDataStub = sandbox.stub(Aws.prototype, 'addData');
     });
 
     afterEach(function() {
@@ -49,6 +55,14 @@ describe('Aws', function() {
     it('should format the operation name', function() {
       var aws = new Aws(req, serviceName);
       assert.propertyVal(aws, 'operation', 'PutObject');
+    });
+
+    it('should capture s3 params: bucket, key', function() {
+      var aws = new Aws(req, serviceName);
+      addDataStub.should.have.been.calledWith({
+        bucket_name: bucketName,
+        key: keyName
+      });
     });
   });
 


### PR DESCRIPTION
Hi,

Similar to my pull request for [java sdk](https://github.com/aws/aws-xray-sdk-java/pull/9) here is the whitelist file with s3 support for nodejs.

Fields I've included in the request_parameters: Bucket (renamed to bucket_name), Key, VersionId, Prefix, CopySource. 

I've used the following js script to generate the S3 paramters: https://github.com/functionalone/aws-xray-parameter-whitelist-node/blob/master/src/util/generate-param-whitelist.ts 

Best,

Guy