### PR TITLE
Remove non sequitur mixing segment logic with captureAWS (#20)

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -287,11 +287,7 @@ a new context, see: https://github.com/othiym23/node-continuation-local-storage.
 
     var AWS = captureAWS(require('aws-sdk'));
 
-    //Create new clients as usual
-    //Be sure any outgoing calls that are dependent on another async
-    //function are wrapped with captureAsyncFunc, or duplicate segments might
-    leak
-    //See usages for clients in manual and automatic modes
+    // Create new AWS clients as usual.
 
 ### Configure AWSXRay to automatically capture EC2 instance data
 


### PR DESCRIPTION
After some discussion (see #20) and testing I have removed the commentary about `captureAsyncFunction` usage attached to the the `captureAWS` documentation:

> Create new clients as usual. Be sure any outgoing calls that are dependent on another async function are wrapped, or duplicate segments might leak.

It seems that this is about logical grouping (subsegments) in general, and there's nothing special about the `captureAWS` that function would need you to use these wrappers any differently than you normally would. And, in fact, the clients created from this function all behave perfectly without them (of course, they don't generate their own subsegements, but then, nothing else does).