### PR TITLE
dont add error for `null` when closing segments

### DIFF
--- a/packages/core/lib/segments/segment.js
+++ b/packages/core/lib/segments/segment.js
@@ -315,7 +315,7 @@ Segment.prototype.close = function(err, remote) {
   if (!this.end_time)
     this.end_time = SegmentUtils.getCurrentTime();
 
-  if (!_.isUndefined(err))
+  if (err)
     this.addError(err, remote);
 
   delete this.in_progress;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

If the value of the first argument to segment.close is `null`, then it throws an exception. This makes it a bit harder to use, as I have to check the errors myself before passing them in after any callback. I am re-using the same check that's in attributes/subsegment.js, where anything that's falsey is ignored.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
