### PR TITLE
Export patchPromise function to allow capturing third-party promises (e.g. Bluebird)

### DIFF
--- a/packages/core/lib/patchers/promise_p.js
+++ b/packages/core/lib/patchers/promise_p.js
@@ -3,8 +3,8 @@
  */
 
 /**
- * This module patches native Promise libraries provided by V8 engine 
- * so all subsegments generated within Promise are attached to the correct parent. 
+ * This module patches native Promise libraries provided by V8 engine
+ * so all subsegments generated within Promise are attached to the correct parent.
  */
 
 var contextUtils = require('../context_utils');
@@ -37,6 +37,6 @@ function capturePromise() {
   patchPromise(Promise);
 }
 
-capturePromise.patchPromiseImpl = patchPromise;
+capturePromise.patchThirdPartyPromise = patchPromise;
 
 module.exports.capturePromise = capturePromise;

--- a/packages/core/lib/patchers/promise_p.js
+++ b/packages/core/lib/patchers/promise_p.js
@@ -37,4 +37,6 @@ function capturePromise() {
   patchPromise(Promise);
 }
 
+capturePromise.patchPromiseImpl = patchPromise;
+
 module.exports.capturePromise = capturePromise;


### PR DESCRIPTION
Exposes patchPromise() as a property of of capturePromise(), ```patchPromiseImpl()```

This allows me to use this method to capture promises from third party promise libraries (e.g. Bluebird) without having to duplicate this logic into our codebase.  We need this exposed because  we use Bluebird promises throughout our system, including the promises returned by the AWS SDK by way of calling aws.config.setPromisesDependency().

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.