### PR TITLE
When the persistent socket is disabled, batch segment sends and share a UDP socket for each batch

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,6 +14,7 @@
     "test": "test"
   },
   "dependencies": {
+    "atomic-batcher": "^1.0.2",
     "continuation-local-storage": "^3.2.0",
     "moment": "^2.15.2",
     "pkginfo": "^0.4.0",
@@ -29,7 +30,7 @@
     "grunt-jsdoc": "^2.1.0",
     "mocha": "^3.0.2",
     "nock": "^8.0.0",
-    "sinon": "^1.17.5",
+    "sinon": "^4.0.0",
     "sinon-chai": "^2.8.0"
   },
   "scripts": {


### PR DESCRIPTION
When running in a Lambda function and when a segment contains a *lot* of sub-segments, it's possible to exhaust the number of file descriptors and have errors reporting the segments. This change will allow many segments that are sent at the same time to share a single socket. This change means many fewer sockets will be created and should have at least two advantages:

1. Should be more efficient, but I have not measured it
2. It avoids the errors of running out of file handles for large segments. I have verified this by deploying  patched version in our our environment and seeing the fix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
