### PR TITLE
Replace moment with date-fns/format

### DIFF
--- a/packages/core/lib/logger.js
+++ b/packages/core/lib/logger.js
@@ -1,5 +1,5 @@
 var winston = require('winston');
-var moment = require('moment');
+var format = require('date-fns/format')
 
 var logger;
 
@@ -26,7 +26,7 @@ if (process.env.LAMBDA_TASK_ROOT) {
 /* eslint-enable no-console */
 
 function timestampFormatter() {
-  return moment().format('YYYY-MM-DD HH:mm:ss.SSSS Z');
+  return format(new Date(), 'YYYY-MM-DD HH:mm:ss.SSS Z');
 }
 
 function outputFormatter(options) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "continuation-local-storage": "^3.2.0",
-    "moment": "^2.15.2",
+    "date-fns": "^1.29.0",
     "pkginfo": "^0.4.0",
     "semver": "^5.3.0",
     "underscore": "^1.8.3",


### PR DESCRIPTION
Replace `moment` with `date-fns/format` to help optimize dependencies (see #10)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
