### PR TITLE
Make Node 4 requirement explicit in README and package.json files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Installing
 
-The AWS X-Ray SDK for Node.js is compatible with Node.js version 0.8 and later.
+The AWS X-Ray SDK for Node.js is compatible with Node.js version 4 and later.
 
 The SDK is available from NPM. For local development, install the SDK in your project directory with npm.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,7 @@
   ],
   "main": "lib/index.js",
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 4.x <= 10.x"
   },
   "directories": {
     "test": "test"

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -8,7 +8,7 @@
   ],
   "main": "lib/index.js",
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 4.x <= 10.x"
   },
   "directories": {
     "test": "test"

--- a/packages/full_sdk/package.json
+++ b/packages/full_sdk/package.json
@@ -8,7 +8,7 @@
   ],
   "main": "lib/index.js",
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 4.x <= 10.x"
   },
   "dependencies": {
     "aws-xray-sdk-core": "^1.2.0",

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -8,7 +8,7 @@
   ],
   "main": "lib/index.js",
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 4.x <= 10.x"
   },
   "directories": {
     "test": "test"

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -8,7 +8,7 @@
   ],
   "main": "lib/index.js",
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 4.x <= 10.x"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
Only Node >= 4 is tested and supported by some files still had the 0.8 requirement listed. Here is confirmation that only 4.x is supported: https://github.com/aws/aws-xray-sdk-node/pull/35#issuecomment-403626247

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
