### PR TITLE
fix: set callback to undefined in mysql capture

### DIFF
--- a/packages/mysql/lib/mysql_p.js
+++ b/packages/mysql/lib/mysql_p.js
@@ -62,7 +62,7 @@ function resolveArguments(argsObj) {
   if (argsObj && argsObj.length > 0) {
     args.sql = argsObj[0];
     args.values = typeof argsObj[1] !== 'function' ? argsObj[1] : null;
-    args.callback = !args.values ? argsObj[1] : (typeof argsObj[2] === 'function' ? argsObj[2] : null);
+    args.callback = !args.values ? argsObj[1] : (typeof argsObj[2] === 'function' ? argsObj[2] : undefined);
     args.segment = (argsObj[argsObj.length-1].constructor && (argsObj[argsObj.length-1].constructor.name === 'Segment' ||
       argsObj[argsObj.length-1].constructor.name === 'Subsegment')) ? argsObj[argsObj.length-1] : null;
   }


### PR DESCRIPTION
Current version is causing errors when trying to use streaming queries with MySQL because [the mysql package hard checks for undefined](https://github.com/mysqljs/mysql/blob/7e0acb6724149ac217f1aed97f2689b68063e6e4/lib/Connection.js#L60).

*Description of changes:*

Changes the `args.callback` in `resolveArguments` to default to undefined instead of null.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
