### PR TITLE
Update winston to 2.4.4 to reduce library size by megabytes

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
     "lodash": "^4.17.10",
     "pkginfo": "^0.4.0",
     "semver": "^5.3.0",
-    "winston": "^2.2.0"
+    "winston": "^2.4.4"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
*Issue #, if available:* #10 

*Description of changes:*

See https://github.com/winstonjs/winston/issues/1405

This removes ~16 MB of code and ~1.5 MB when Lambda is zipped

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


![image](https://user-images.githubusercontent.com/3817380/44432074-3316fa00-a5a9-11e8-9adf-9ce2c46b547c.png)
