### PR TITLE
Move aws-sdk out of the dependencies list

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "atomic-batcher": "^1.0.2",
-    "aws-sdk": "^2.304.0",
     "continuation-local-storage": "^3.2.0",
     "date-fns": "^1.29.0",
     "lodash": "^4.17.10",
@@ -24,6 +23,7 @@
     "winston": "^2.4.4"
   },
   "devDependencies": {
+    "aws-sdk": "^2.304.0",
     "chai": "^3.5.0",
     "eslint": "^3.10.2",
     "grunt": "^1.0.3",
@@ -33,6 +33,9 @@
     "nock": "^8.0.0",
     "sinon": "^4.0.0",
     "sinon-chai": "^2.8.0"
+  },
+  "peerDependencies": {
+    "aws-sdk": "^2.304.0"
   },
   "scripts": {
     "test": "./node_modules/.bin/mocha --recursive ./test/ -R spec"


### PR DESCRIPTION
*Issue #, if available:* Resolves #54

*Description of changes:* Moves `aws-sdk` out of the `aws-xray-sdk-core` package dependencies, so as to not bloat project bundles that will be deployed to AWS Lambda Node.js runtime.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
