### PR TITLE
Unref poller timers to avoid keeping node.js alive

### DIFF
--- a/packages/core/lib/middleware/sampling/rule_poller.js
+++ b/packages/core/lib/middleware/sampling/rule_poller.js
@@ -16,6 +16,7 @@ var RulePoller = {
     // Refresh sampling rules cache with no jitter upon start.
     refresh(false);
     this.poller = setInterval(refresh, DEFAULT_INTERVAL);
+    this.poller.unref();
   },
 };
 

--- a/packages/core/lib/middleware/sampling/target_poller.js
+++ b/packages/core/lib/middleware/sampling/target_poller.js
@@ -16,6 +16,7 @@ var TargetPoller = {
 
   start: function start() {
     this.poller = setInterval(refreshWithFirewall, DEFAULT_INTERVAL + getJitter());
+    this.poller.unref();
   },
 };
 


### PR DESCRIPTION
### Problem solved:

Currently the timers in the pollers keeps a node.js application alive indefinitely.

I myself encountered this when running my Mocha tests as all of the sudden they wouldn't shut down on their own, as Mocha tests nowadays default to do graceful shutdowns. I pinpointed the issue toi this module and tested this specific solution.

###  Solution:

Node.js offers a way to indicate that a timer should not keep the application alive: [`.unref()`](https://nodejs.org/api/timers.html#timers_timeout_unref)

I've added these to the two pollers and this solved my issue.

### <del>Automated tests:</del>

I've not come up with an automated way to test this, so unfortunately there are no tests added here.

### Legal:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
