### PR TITLE
Call getLogger()

### DIFF
--- a/packages/core/lib/middleware/sampling/default_sampler.js
+++ b/packages/core/lib/middleware/sampling/default_sampler.js
@@ -35,7 +35,7 @@ var DefaultSampler = {
         return this.localSampler.shouldSample(sampleRequest);
       }
     } catch (err) {
-      logger.getLogger.error('Unhandled exception by the SDK during making sampling decisions: ' + err);
+      logger.getLogger().error('Unhandled exception by the SDK during making sampling decisions: ' + err);
     }
   },
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix TypeError where `getLogger.error` is undefined. It should call `getLogger` and then call `error`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
