### PR TITLE
simple support for mysql2 promise version of query

### DIFF
--- a/packages/mysql/lib/mysql_p.js
+++ b/packages/mysql/lib/mysql_p.js
@@ -36,9 +36,18 @@ function patchCreateConnection(mysql) {
 
   mysql['createConnection'] = function patchedCreateConnection() {
     var connection = mysql[baseFcn].apply(connection, arguments);
-    connection.__query = connection.query;
-    connection.query = captureQuery;
-
+    if (connection instanceof Promise) {
+      connection = connection.then((result) => {
+        if (result.connection.query instanceof Function) {
+          result.connection.__query = result.connection.query;
+          result.connection.query = captureQuery;
+        }
+        return result;
+      });
+    } else if (connection.query instanceof Function) {
+      connection.__query = connection.query;
+      connection.query = captureQuery;
+    }
     return connection;
   };
 }
@@ -60,9 +69,16 @@ function resolveArguments(argsObj) {
   var args = {};
 
   if (argsObj && argsObj.length > 0) {
-    args.sql = argsObj[0];
-    args.values = typeof argsObj[1] !== 'function' ? argsObj[1] : null;
-    args.callback = !args.values ? argsObj[1] : (typeof argsObj[2] === 'function' ? argsObj[2] : undefined);
+    if (argsObj[0] instanceof Object) {
+      args.sql = argsObj[0].sql;
+      args.values = argsObj[0].values;
+      args.callback = argsObj[1];
+    } else {
+      args.sql = argsObj[0];
+      args.values = typeof argsObj[1] !== 'function' ? argsObj[1] : null;
+      args.callback = !args.values ? argsObj[1] : (typeof argsObj[2] === 'function' ? argsObj[2] : undefined);
+    }
+
     args.segment = (argsObj[argsObj.length-1].constructor && (argsObj[argsObj.length-1].constructor.name === 'Segment' ||
       argsObj[argsObj.length-1].constructor.name === 'Subsegment')) ? argsObj[argsObj.length-1] : null;
   }

--- a/packages/mysql/test/unit/mysql_p.test.js
+++ b/packages/mysql/test/unit/mysql_p.test.js
@@ -176,7 +176,7 @@ describe('captureMySQL', function() {
         mysql = captureMySQL(mysql);
       });
 
-      beforeEach(async function() {
+      beforeEach(function(done) {
         sandbox = sinon.sandbox.create();
         segment = new Segment('test');
         subsegment = segment.addNewSubsegment('testSub');
@@ -190,50 +190,53 @@ describe('captureMySQL', function() {
         stubAddNew = sandbox.stub(segment, 'addNewSubsegment').returns(subsegment);
         sandbox.stub(AWSXRay, 'isAutomaticMode').returns(true);
 
-        resolvedConn = await mysql.createConnection();
-        stubBaseQuery = sandbox.stub(resolvedConn.connection, '__query').returns(queryObj);
+        mysql.createConnection().then(function (result) {
+          resolvedConn = result;
+          stubBaseQuery = sandbox.stub(resolvedConn.connection, '__query').returns(queryObj);
+          done();
+        });
       });
 
       afterEach(function() {
         sandbox.restore();
       });
 
-      it('should create a new subsegment using database and host', async function() {
+      it('should create a new subsegment using database and host', function() {
         var config = resolvedConn.connection.config;
-        await resolvedConn.query('sql here');
-
-        stubAddNew.should.have.been.calledWithExactly(config.database + '@' + config.host);
+        resolvedConn.query('sql here').then(function() {
+          stubAddNew.should.have.been.calledWithExactly(config.database + '@' + config.host);
+        });
       });
 
-      it('should add the sql data to the subsegment', async function() {
+      it('should add the sql data to the subsegment', function() {
         var stubAddSql = sandbox.stub(subsegment, 'addSqlData');
         var stubDataInit = sandbox.stub(SqlData.prototype, 'init');
         var config = resolvedConn.connection.config;
 
-        await resolvedConn.query('sql here');
-
-        stubDataInit.should.have.been.calledWithExactly(undefined, undefined, config.user,
-          config.host + ':' + config.port + '/' + config.database, 'statement');
-        stubAddSql.should.have.been.calledWithExactly(sinon.match.instanceOf(SqlData));
-      });
-
-      it('should close the subsegment via the event', async function() {
-        var stubClose = sandbox.stub(subsegment, 'close');
-        await resolvedConn.query();
-
-        queryObj.emit('end');
-        stubClose.should.always.have.been.calledWithExactly();
-      });
-
-      it('should capture the error via the event', async function() {
-        var stubClose = sandbox.stub(subsegment, 'close');
-        await resolvedConn.query();
-
-        assert.throws(function() {
-          queryObj.emit('error', err);
+        resolvedConn.query('sql here').then(function() {
+          stubDataInit.should.have.been.calledWithExactly(undefined, undefined, config.user,
+            config.host + ':' + config.port + '/' + config.database, 'statement');
+          stubAddSql.should.have.been.calledWithExactly(sinon.match.instanceOf(SqlData));
         });
+      });
 
-        stubClose.should.have.been.calledWithExactly(err);
+      it('should close the subsegment via the event', function() {
+        var stubClose = sandbox.stub(subsegment, 'close');
+        resolvedConn.query().then(function() {
+          queryObj.emit('end');
+          stubClose.should.always.have.been.calledWithExactly();
+        });
+      });
+
+      it('should capture the error via the event', function() {
+        var stubClose = sandbox.stub(subsegment, 'close');
+        resolvedConn.query().then(function() {
+          assert.throws(function() {
+            queryObj.emit('error', err);
+          });
+
+          stubClose.should.have.been.calledWithExactly(err);
+        });
       });
 
     });


### PR DESCRIPTION
*Issue #, if available:*

Missing support for mysql2 promises.

*Description of changes:*

The change in `patchCreateConnection()` detects a Promise and patches through to the actual Connection object.

The change in `resolveArguments()` adds support for passing `{sql,values}` as a single argument to `query()`, which is supported by mysql2.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
