### PR TITLE
fix: handle undefined in query values

### DIFF
--- a/packages/mysql/lib/mysql_p.js
+++ b/packages/mysql/lib/mysql_p.js
@@ -76,7 +76,7 @@ function resolveArguments(argsObj) {
     } else {
       args.sql = argsObj[0];
       args.values = typeof argsObj[1] !== 'function' ? argsObj[1] : null;
-      args.callback = !args.values ? argsObj[1] : (typeof argsObj[2] === 'function' ? argsObj[2] : undefined);
+      args.callback = typeof argsObj[1] === 'function' ? argsObj[1] : (typeof argsObj[2] === 'function' ? argsObj[2] : undefined);
     }
 
     args.segment = (argsObj[argsObj.length-1].constructor && (argsObj[argsObj.length-1].constructor.name === 'Segment' ||


### PR DESCRIPTION
Will now more closely follow the logic of the mysql package, [see here](https://github.com/mysqljs/mysql/blob/master/lib/Connection.js#L43).

Was beforehand not calling the callback when calling the query function like this:

```js
connection.query('SELECT * FROM some_table', undefined, () => {console.log('yay')});
```

Since in this case it puts the undefined (falsy value) in the callback parameter, whilst the mysql package only ever checks if it is a function or not.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
