### PR TITLE
Improved Utils#processTraceData type safety

### DIFF
--- a/packages/core/lib/utils.js
+++ b/packages/core/lib/utils.js
@@ -4,6 +4,7 @@
 
 var each = require('lodash/each');
 var isNull = require('lodash/isNull');
+var isString = require('lodash/isString');
 var isUndefined = require('lodash/isUndefined');
 
 var logger = require('./logger');
@@ -163,9 +164,17 @@ var utils = {
   processTraceData: function processTraceData(traceData) {
     var amznTraceData = {};
 
+    if (!(isString(traceData) && traceData))
+      return amznTraceData;
+
     each(traceData.split(';'), function(header) {
+      if (!header)
+        return;
+
       var pair = header.split('=');
-      amznTraceData[pair[0].trim()] = pair[1].trim();
+
+      if (pair[0] && pair[1])
+        amznTraceData[pair[0].trim()] = pair[1].trim();
     });
 
     return amznTraceData;

--- a/packages/core/test/unit/utils.test.js
+++ b/packages/core/test/unit/utils.test.js
@@ -37,6 +37,38 @@ describe('Utils', function() {
       assert.propertyVal(parsed, 'Parent', '48af77592b6dd73f');
       assert.propertyVal(parsed, 'Sampled', '1');
     });
+
+    it('should bail out for missing trace values', function() {
+        assert.deepEqual(Utils.processTraceData(), {});
+    });
+
+    it('should bail out for empty trace values', function() {
+        assert.deepEqual(Utils.processTraceData(''), {});
+    });
+
+    it('should handle trace header values with excess semicolons correctly', function() {
+        assert.deepEqual(Utils.processTraceData('Root=1-58ed6027-14afb2e09172c337713486c0;'), {
+          Root: '1-58ed6027-14afb2e09172c337713486c0'
+        });
+    });
+
+    it('should handle malformed key=value pairs correctly (missing value)', function() {
+        assert.deepEqual(Utils.processTraceData('Root=1-58ed6027-14afb2e09172c337713486c0;Parent'), {
+          Root: '1-58ed6027-14afb2e09172c337713486c0'
+        });
+    });
+
+    it('should handle malformed key=value pairs correctly (empty key)', function() {
+        assert.deepEqual(Utils.processTraceData('Root=1-58ed6027-14afb2e09172c337713486c0;=48af77592b6dd73f'), {
+          Root: '1-58ed6027-14afb2e09172c337713486c0'
+        });
+    });
+
+    it('should handle malformed key=value pairs correctly (empty value)', function() {
+        assert.deepEqual(Utils.processTraceData('Root=1-58ed6027-14afb2e09172c337713486c0;Parent='), {
+          Root: '1-58ed6027-14afb2e09172c337713486c0'
+        });
+    });
   });
 
   describe('#processTraceData', function() {


### PR DESCRIPTION
*Issue #, if available:* #67

*Description of changes:*
* This adds type safety by checking for empty/malformed values.
* Earlier, stirng trim and split were being called indiscriminately.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
