### PR TITLE
Prepares SDK for 2.1.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "Apache-2.0",
   "devDependencies": {
-    "aws-xray-sdk-core": "^1.3.0",
+    "aws-xray-sdk-core": "^2.0.1",
     "chai": "^3.5.0",
     "eslint": "^3.10.2",
     "grunt": "^1.0.3",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog for AWS X-Ray Core SDK for JavaScript
-<!--LATEST=2.0.1-->
+<!--LATEST=2.1.0-->
 <!--ENTRYINSERT-->
+## 2.1.0
+* bugfix: Fixed an undefined method in `DaemonConfig`. [#ISSUE52](https://github.com/aws/aws-xray-sdk-node/issues/52)
+* bugfix: Fixed an issue in transforming sampling rule definition file from v1 to v2. [#PR70](https://github.com/aws/aws-xray-sdk-node/pull/70)
+* bugfix: Fixed a type safety issue when processing malformed trace header. [#PR69](https://github.com/aws/aws-xray-sdk-node/pull/69)
 
 ## 2.0.1
 * bugfix: Added a missing commit in the previous release for [#ISSUE2](https://github.com/aws/aws-xray-sdk-node/issues/2).

--- a/packages/express/CHANGELOG.md
+++ b/packages/express/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog for AWS X-Ray SDK Express for JavaScript
-<!--LATEST=2.0.0-->
+<!--LATEST=2.1.0-->
 <!--ENTRYINSERT-->
 
 ## 1.1.5

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -14,7 +14,7 @@
     "test": "test"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^2.0.1"
+    "aws-xray-sdk-core": "^2.1.0"
   },
   "devDependencies": {
     "aws-xray-sdk-core": "^2.0.1",

--- a/packages/full_sdk/CHANGELOG.md
+++ b/packages/full_sdk/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog for AWS X-Ray SDK for JavaScript
-<!--LATEST=2.0.1-->
+<!--LATEST=2.1.0-->
 <!--ENTRYINSERT-->
+## 2.1.0
+* change: Updated aws-xray-sdk-core to 2.1.0. See aws-xray-sdk-core's CHANGELOG.md for package changes.
+* change: Updated aws-xray-sdk-express to 2.1.0. No further changes.
+* change: Updated aws-xray-sdk-mysql to 2.1.0. Added Promise support on `mysql2`. [#PR62](https://github.com/aws/aws-xray-sdk-node/pull/62)
+* change: Updated aws-xray-sdk-postgres to 2.1.0. Added Promise support for `pg`. [#PR64](https://github.com/aws/aws-xray-sdk-node/pull/64)
 
 ## 2.0.1
 * change: Updated aws-xray-sdk-core to 2.0.1. See aws-xray-sdk-core's CHANGELOG.md for package changes.

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -14,7 +14,7 @@
     "test": "test"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^2.0.1"
+    "aws-xray-sdk-core": "^2.1.0"
   },
   "devDependencies": {
     "aws-xray-sdk-core": "^2.0.1",

--- a/packages/postgres/lib/postgres_p.js
+++ b/packages/postgres/lib/postgres_p.js
@@ -41,7 +41,7 @@ function resolveArguments(argsObj) {
     } else {
       args.sql = argsObj[0];
       args.values = typeof argsObj[1] !== 'function' ? argsObj[1] : null;
-      args.callback = !args.values ? argsObj[1] : (typeof argsObj[2] === 'function' ? argsObj[2] : undefined);
+      args.callback = typeof argsObj[1] === 'function' ? argsObj[1] : (typeof argsObj[2] === 'function' ? argsObj[2] : undefined);
     }
 
     args.segment = (argsObj[argsObj.length-1].constructor && (argsObj[argsObj.length-1].constructor.name === 'Segment' ||

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -14,7 +14,7 @@
     "test": "test"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^2.0.1"
+    "aws-xray-sdk-core": "^2.1.0"
   },
   "devDependencies": {
     "aws-xray-sdk-core": "^2.0.1",

--- a/packages/restify/package.json
+++ b/packages/restify/package.json
@@ -14,7 +14,7 @@
     "test": "test"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^2.0.1"
+    "aws-xray-sdk-core": "^2.1.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
This change stages the release for v2.1.0 of the SDK. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
