### PR TITLE
fix: updates aws-xray-sdk-core to import xray client directly

### DIFF
--- a/packages/core/lib/middleware/sampling/service_connector.js
+++ b/packages/core/lib/middleware/sampling/service_connector.js
@@ -1,5 +1,6 @@
 var crypto = require('crypto');
-var AWS = require('aws-sdk');
+var AWS = require('aws-sdk/global');
+var Xray = require('aws-sdk/clients/xray');
 var logger = require('../../logger');
 var SamplingRule = require('./sampling_rule');
 var DaemonConfig = require('../../daemon_config')
@@ -16,7 +17,7 @@ var ServiceConnector = {
   // identifying the SDK instance and is generated during SDK initialization/
   // This is required when reporting sampling to X-Ray back-end.
   clientId: crypto.randomBytes(12).toString('hex'),
-  client: new AWS.XRay({endpoint: util.format('http://%s:%d', DaemonConfig.tcp_ip, DaemonConfig.tcp_port)}),
+  client: new Xray({endpoint: util.format('http://%s:%d', DaemonConfig.tcp_ip, DaemonConfig.tcp_port)}),
 
   fetchSamplingRules: function fetchSamplingRules(callback) {
 


### PR DESCRIPTION
*Issue #54 , if available:*

*Description of changes:*
This change updates the `aws-xray-sdk-core` package to import the `xray` client from the `aws-sdk` directly.

To test the effect this had on the size of the SDK, I created a node.js bundle using the following webpack command using  webpack@4.25.1 and webpack-cli@3.1.2:
```bash
npx webpack ./packages/core/lib/index.js -o ./bundle.js --mode production --target node --output-library commonjs2
```
Without any changes, the bundle size of core was __2.78 MB__.
After these changes, the bundle size decreased to __416 KB__.

While this change doesn't affect the code size on disk (from npm install), it does greatly reduce bundle sizes which can be useful when packaging functions for Lambda.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
