### PR TITLE
feat: switches continuation-local-storage to cls-hooked for async support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,14 @@ node_js:
 
 sudo: false
 
+matrix:
+  include:
+    - node_js: "8"
+      env: TEST_ASYNC=test-async
+    - node_js: "10"
+      env: TEST_ASYNC=test-async
+
 script:
   - lerna bootstrap --hoist
   - lerna run test
+  - "if [[ $TEST_ASYNC == 'test-async' ]]; then lerna run $TEST_ASYNC || exit 0; fi"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "license": "Apache-2.0",
   "devDependencies": {
-    "aws-xray-sdk-core": "^2.0.1",
     "chai": "^3.5.0",
     "eslint": "^3.10.2",
     "grunt": "^1.0.3",

--- a/packages/core/lib/context_utils.js
+++ b/packages/core/lib/context_utils.js
@@ -2,7 +2,7 @@
  * @module context_utils
  */
 
-var cls = require('continuation-local-storage');
+var cls = require('cls-hooked');
 
 var logger = require('./logger');
 var Segment = require('./segments/segment');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "atomic-batcher": "^1.0.2",
     "aws-sdk": "^2.304.0",
-    "continuation-local-storage": "^3.2.0",
+    "cls-hooked": "^4.2.2",
     "date-fns": "^1.29.0",
     "lodash": "^4.17.10",
     "pkginfo": "^0.4.0",
@@ -35,7 +35,8 @@
     "sinon-chai": "^2.8.0"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha --recursive ./test/ -R spec"
+    "test": "./node_modules/.bin/mocha --recursive ./test/ -R spec",
+    "test-async": "./node_modules/.bin/mocha --recursive ./test_async/ -R spec"
   },
   "keywords": [
     "amazon",

--- a/packages/core/test_async/integration/segment_maintained_across_awaited.test.js
+++ b/packages/core/test_async/integration/segment_maintained_across_awaited.test.js
@@ -1,0 +1,85 @@
+var assert = require('chai').assert;
+var http = require('http');
+var AWSXRay = require('../../');
+var Segment = AWSXRay.Segment;
+
+AWSXRay.enableAutomaticMode();
+
+describe('Integration', function() {
+  describe('#async', function() {
+    it('should maintain segment in async functions', function(done) {
+      var sharedPromise = null;
+
+      var requestCount = 0;
+      var server = http
+        .createServer(function(req, res) {
+          var ns = AWSXRay.getNamespace();
+          ns.bindEmitter(req);
+          ns.bindEmitter(res);
+
+          ns.run(function () {
+            var segment = new Segment('root');
+
+            AWSXRay.setSegment(segment);
+
+            if (!sharedPromise) {
+              sharedPromise = Promise.resolve();
+            }
+
+            // execute an async task
+            sharedPromise.then(async () => {
+
+              await sleep(0);
+
+              var retrievedSegment = AWSXRay.getSegment();
+              res.end();
+
+              // setTimeout so the assertion isn't caught by the promise
+              setTimeout(function() {
+                assert.equal(segment.id, retrievedSegment.id);
+                if (++requestCount === 2){ 
+                  done();
+                }
+              });
+            });
+          });
+        }).listen(8080, '0.0.0.0', function() {
+
+          var address = server.address();
+
+          var count = 0;
+          function cb(err) {
+            if (err) {
+              throw err;
+            }
+
+            if (++count === 2) {
+              server.close();
+            }
+          }
+          sendRequest(address, cb);
+          sendRequest(address, cb);
+        });
+    })
+  });
+});
+
+function sendRequest(address, cb) {
+  http
+    .request({
+      hostname: address.address,
+      port: address.port,
+      path: '/'
+    })
+    .on('response', function(res) {
+      res.on('end', cb).resume();
+    })
+    .on('error', cb)
+    .end();
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/packages/restify/package.json
+++ b/packages/restify/package.json
@@ -17,6 +17,7 @@
     "aws-xray-sdk-core": "^2.1.0"
   },
   "devDependencies": {
+    "aws-xray-sdk-core": "^2.1.0",
     "chai": "^3.5.0",
     "eslint": "^3.10.2",
     "mocha": "^3.0.2",


### PR DESCRIPTION
*Issue #, if available:*
#60 
*Description of changes:*
Switch `continuation-local-storage` dependency to `cls-hooked`.

I tested against the 3 scenarios listed out in #11.
First, I tested using just promises. With the updated dependency, I no longer needed to call `xray.capturePromise()` to get the correct hierarchy of subsegments to segments. Continuing to call `capturePromise()` also does not change the the segment hierarchy.

Secondly, I update my express routes to use async functions and await https requests. This resulted in the same segment hierarchy as the promises example.

I have not looked too far into the concern pointed out in #60 with using cls-hooked, namely: https://github.com/Jeff-Lewis/cls-hooked/issues/23

This probably warrants some more investigation into how cls-* libraries get around some of these issues, and if they are truly unique to cls-hooked.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
