### PR TITLE
chore: prepares release of 2.1.0-experimental.1 branch

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-core",
-  "version": "2.1.0",
+  "version": "2.1.0-experimental.1",
   "description": "AWS X-Ray SDK for Javascript",
   "author": "Amazon Web Services",
   "contributors": [

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-express",
-  "version": "2.1.0",
+  "version": "2.1.0-experimental.1",
   "description": "AWS X-Ray Middleware for Express (Javascript)",
   "author": "Amazon Web Services",
   "contributors": [
@@ -14,10 +14,10 @@
     "test": "test"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^2.1.0"
+    "aws-xray-sdk-core": "2.1.0-experimental.1"
   },
   "devDependencies": {
-    "aws-xray-sdk-core": "^2.1.0",
+    "aws-xray-sdk-core": "2.1.0-experimental.1",
     "chai": "^3.5.0",
     "eslint": "^3.10.2",
     "grunt": "^1.0.3",

--- a/packages/full_sdk/package.json
+++ b/packages/full_sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk",
-  "version": "2.1.0",
+  "version": "2.1.0-experimental.1",
   "description": "AWS X-Ray SDK for Javascript",
   "author": "Amazon Web Services",
   "contributors": [
@@ -11,10 +11,10 @@
     "node": ">= 4.x <= 10.x"
   },
   "dependencies": {
-    "aws-xray-sdk-core": "^2.1.0",
-    "aws-xray-sdk-express": "^2.1.0",
-    "aws-xray-sdk-mysql": "^2.1.0",
-    "aws-xray-sdk-postgres": "^2.1.0",
+    "aws-xray-sdk-core": "2.1.0-experimental.1",
+    "aws-xray-sdk-express": "2.1.0-experimental.1",
+    "aws-xray-sdk-mysql": "2.1.0-experimental.1",
+    "aws-xray-sdk-postgres": "2.1.0-experimental.1",
     "pkginfo": "^0.4.0"
   },
   "keywords": [

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-mysql",
-  "version": "2.1.0",
+  "version": "2.1.0-experimental.1",
   "description": "AWS X-Ray Patcher for MySQL (Javascript)",
   "author": "Amazon Web Services",
   "contributors": [
@@ -14,10 +14,10 @@
     "test": "test"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^2.1.0"
+    "aws-xray-sdk-core": "2.1.0-experimental.1"
   },
   "devDependencies": {
-    "aws-xray-sdk-core": "^2.1.0",
+    "aws-xray-sdk-core": "2.1.0-experimental.1",
     "chai": "^3.5.0",
     "eslint": "^3.10.2",
     "grunt": "^1.0.3",

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-postgres",
-  "version": "2.1.0",
+  "version": "2.1.0-experimental.1",
   "description": "AWS X-Ray Patcher for Postgres (Javascript)",
   "author": "Amazon Web Services",
   "contributors": [
@@ -14,7 +14,7 @@
     "test": "test"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^2.1.0"
+    "aws-xray-sdk-core": "2.1.0-experimental.1"
   },
   "devDependencies": {
     "aws-xray-sdk-core": "^2.1.0",


### PR DESCRIPTION
My plan is to publish the packages in the experimental-hooks branch to NPM with the `experimental` tag. I've added `-experimental.1` to the version of each package in this repo.

This will make it easier to allow testing without having to clone this repository, and we can deprecate these tagged versions once we merge into master.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
