### PR TITLE
fix: handle null/undefined as last query value

### DIFF
--- a/packages/mysql/lib/mysql_p.js
+++ b/packages/mysql/lib/mysql_p.js
@@ -92,7 +92,7 @@ function resolveArguments(argsObj) {
       args.callback = typeof argsObj[1] === 'function' ? argsObj[1] : (typeof argsObj[2] === 'function' ? argsObj[2] : undefined);
     }
 
-    args.segment = (argsObj[argsObj.length-1].constructor && (argsObj[argsObj.length-1].constructor.name === 'Segment' ||
+    args.segment = (argsObj[argsObj.length-1] != null && argsObj[argsObj.length-1].constructor && (argsObj[argsObj.length-1].constructor.name === 'Segment' ||
       argsObj[argsObj.length-1].constructor.name === 'Subsegment')) ? argsObj[argsObj.length-1] : null;
   }
 


### PR DESCRIPTION
*Description of changes:*

Was beforehand throwing a TypeError when trying to access the constructor property on `null` or `undefined`:

```js
connection.query('SELECT a FROM b', null);
// without xray --> resolves query
// with xray    --> throws TypeError: Cannot read property 'constructor' of null  
```

As far as I know null and undefined are the only data types that will encounter this problem, hence a loose null check should suffice.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
