### PR TITLE
Forward the same input arguments to pg query

### DIFF
--- a/packages/postgres/lib/postgres_p.js
+++ b/packages/postgres/lib/postgres_p.js
@@ -84,7 +84,8 @@ function captureQuery() {
     }
   }
 
-  var result = this.__query.call(this, args.sql, args.values, args.callback);
+  var sqlInput = (arguments && arguments.length > 0) ?  arguments[0] : args.sql;
+  var result = this.__query.call(this, sqlInput, args.values, args.callback);
 
   var query = result;
   if (query instanceof Promise && this._queryable && !this._ending) {


### PR DESCRIPTION
*Issue #, if available:*
When some libs are used (like [pg-copy-streams](https://github.com/brianc/node-pg-copy-streams)), `aws-xray-sdk` cause an error (cf [lambda below](#lambda)).

**Error when using `aws-xray-sdk-postgres`:**
```
Error: uncaughtException: connection.query is not a function
at CopyStreamQuery.submit (node_modules/pg-copy-streams/index.js:29:14),
at node_modules/aws-xray-sdk-postgres/lib/postgres_p.js:80:11,
at Namespace.run (node_modules/continuation-local-storage/context.js:48:5),
at Result.autoContext [as callback] (node_modules/aws-xray-sdk-postgres/lib/postgres_p.js:78:17),
at Result.Query.handleError (node_modules/pg/lib/query.js:161:17),
at Client.<anonymous> (node_modules/pg/lib/client.js:188:26),
at emitOne (events.js:96:13),
at Connection.emit (events.js:188:7),
at Socket.<anonymous> (node_modules/pg/lib/connection.js:133:12),
at emitOne (events.js:96:13)]
```

*Description of changes:*
`aws-xray-sdk-postgres` should forward arguments to `pg.Client.prototype.query` without transformation. In this example, instead of forwarding the stream, the lib forward only the sql text ([l38](https://github.com/aws/aws-xray-sdk-node/blob/master/packages/postgres/lib/postgres_p.js#L38)).

This changes shouldn't affect anything, let me know if I missed something or some tests.


<a name="lambda"></a>
### Lambda function

```js
const AWSXRay = require('aws-xray-sdk');
const AWS = require('aws-sdk');
const copyFrom = require('pg-copy-streams').from;
const fs = require('fs');

// const { Pool } = require('pg'); // Works
const { Pool } = AWSXRay.capturePostgres(require('pg')); // Doesn't work

exports.handler = async (event) => {
  const pool = new Pool(/* Your connection params go there */);
  const client = await pool.connect();

  const sql = 'COPY table_name FROM STDIN DELIMITER \',\' ESCAPE \'\\\' null as \'NULL\' CSV HEADER ENCODING \'UTF8\';';
  const stream = await client.query(copyFrom(sql));
  const fileStream = fs.createReadStream('./file.csv');

  const end = new Promise((resolve, reject) => {
    stream.on('end', resolve);
    fileStream.on('error', reject);
  });

  fileStream.pipe(stream);

  return await end;
};
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
