### PR TITLE
dep(core): updates lodash lowerbound to 4.17.11

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,7 @@
     "aws-sdk": "^2.304.0",
     "continuation-local-storage": "^3.2.0",
     "date-fns": "^1.29.0",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.11",
     "pkginfo": "^0.4.0",
     "semver": "^5.3.0",
     "winston": "^2.4.4"


### PR DESCRIPTION
*Issue #, if available:*
#96 

*Description of changes:*
Bumps patch version of lodash to one that is not affected by the vulnerability in #96 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
