### PR TITLE
feat: patch connections created by a pool's getConnection

### DIFF
--- a/packages/mysql/lib/mysql_p.js
+++ b/packages/mysql/lib/mysql_p.js
@@ -80,6 +80,18 @@ function patchCreatePoolCluster(mysql) {
   };
 }
 
+function patchOf(poolCluster) {
+  var baseFcn = '__of';
+  poolCluster[baseFcn] = poolCluster['of'];
+
+  poolCluster['of'] = function patchedOf() {
+    var args = arguments;
+
+    var resultPool = poolCluster[baseFcn].apply(poolCluster, args);
+    return patchObject(resultPool);
+  }
+}
+
 function patchGetConnection(pool) {
   var baseFcn = '__getConnection';
   pool[baseFcn] = pool['getConnection'];
@@ -114,6 +126,10 @@ function patchObject(connection) {
 
   if(connection.getConnection instanceof Function && !connection.__getConnection){
     patchGetConnection(connection);
+  }
+
+  if (connection.of instanceof Function && !connection.__of) {
+    patchOf(connection);
   }
   return connection;
 }

--- a/packages/mysql/lib/mysql_p.js
+++ b/packages/mysql/lib/mysql_p.js
@@ -88,17 +88,17 @@ function patchGetConnection(pool) {
 }
 
 function patchObject(connection) {
-  if (connection.query instanceof Function) {
+  if (connection.query instanceof Function && !connection.__query) {
     connection.__query = connection.query;
     connection.query = captureOperation('query');
   }
 
-  if (connection.execute instanceof Function) {
+  if (connection.execute instanceof Function && !connection.__execute) {
     connection.__execute = connection.execute;
     connection.execute = captureOperation('execute');
   }
 
-  if(connection.getConnection instanceof Function){
+  if(connection.getConnection instanceof Function && !connection.__getConnection){
     patchGetConnection(connection);
   }
   return connection;

--- a/packages/mysql/lib/mysql_p.js
+++ b/packages/mysql/lib/mysql_p.js
@@ -108,7 +108,7 @@ function patchGetConnection(pool) {
     }
 
     var result = pool[baseFcn].apply(pool, args);
-    if (result instanceof Promise) return result.then(patchObject);
+    if (result.then instanceof Function) return result.then(patchObject);
     else return result;
   }
 }

--- a/packages/mysql/lib/mysql_p.js
+++ b/packages/mysql/lib/mysql_p.js
@@ -128,6 +128,7 @@ function patchObject(connection) {
     patchGetConnection(connection);
   }
 
+  // Patches the of function on a mysql PoolCluster which returns a pool
   if (connection.of instanceof Function && !connection.__of) {
     patchOf(connection);
   }

--- a/packages/mysql/lib/mysql_p.js
+++ b/packages/mysql/lib/mysql_p.js
@@ -101,7 +101,7 @@ function patchGetConnection(pool) {
     var callback = args[args.length-1];
 
     if (callback instanceof Function) {
-      args[0] = (err, connection) => {
+      args[args.length-1] = (err, connection) => {
         if(connection) patchObject(connection);
         return callback(err, connection);
       }

--- a/packages/mysql/lib/mysql_p.js
+++ b/packages/mysql/lib/mysql_p.js
@@ -74,14 +74,16 @@ function patchGetConnection(pool) {
     var args = arguments;
     var callback = args[0];
 
-    if(callback instanceof Function){
+    if (callback instanceof Function) {
       args[0] = (err, connection) => {
         if(connection) patchObject(connection);
         return callback(err, connection);
       }
     }
 
-    return pool[baseFcn].apply(pool, args);
+    var result = pool[baseFcn].apply(pool, args);
+    if (result instanceof Promise) return result.then(patchObject);
+    else return result;
   }
 }
 
@@ -99,6 +101,7 @@ function patchObject(connection) {
   if(connection.getConnection instanceof Function){
     patchGetConnection(connection);
   }
+  return connection;
 }
 
 function resolveArguments(argsObj) {

--- a/packages/mysql/test/unit/mysql_p.test.js
+++ b/packages/mysql/test/unit/mysql_p.test.js
@@ -347,43 +347,6 @@ describe('captureMySQL', function() {
           done();
         }, 50);
       });
-
-      it('should capture the error via the callback if supplied', function(done) {
-        var stubClose = sandbox.stub(subsegment, 'close');
-
-        query.call(connectionObj, 'sql here', function() {});
-        stubBaseQuery.args[0][2].call(queryObj, err);
-
-        setTimeout(function() {
-          stubClose.should.have.been.calledWithExactly(err);
-          done();
-        }, 50);
-      });
-
-      it('should close the subsegment via the event if the callback is missing', function() {
-        var stubClose = sandbox.stub(subsegment, 'close');
-        query.call(connectionObj);
-
-        queryObj.emit('end');
-        stubClose.should.always.have.been.calledWithExactly();
-      });
-
-      it('should capture the error via the event if the callback is missing', function() {
-        var stubClose = sandbox.stub(subsegment, 'close');
-        query.call(connectionObj);
-
-        assert.throws(function() {
-          queryObj.emit('error', err);
-        });
-
-        stubClose.should.have.been.calledWithExactly(err);
-      });
-
-      it('should start a new automatic context when last query paramater is null', function() {
-        query.call(connectionObj, 'sql here', function() {}, null);
-
-        assert.equal(stubBaseQuery.args[0][2].name, 'autoContext');
-      });
     });
   });
 

--- a/packages/mysql/test/unit/mysql_p.test.js
+++ b/packages/mysql/test/unit/mysql_p.test.js
@@ -386,4 +386,94 @@ describe('captureMySQL', function() {
       });
     });
   });
+
+  describe('#capturePromisePool', function(){
+    describe('for basic connections', function(){
+      var conn, connectionObj, pool, poolObj, mysql, query, queryObj, sandbox, segment, stubAddNew, stubBaseQuery, subsegment;
+
+      before(function(done) {
+        conn = {
+          config: {
+            user: 'mcmuls',
+            host: 'database.location',
+            port: '8080',
+            database: 'myTestDb'
+          },
+          query: function() {}
+        };
+        pool = {
+          query: function() {},
+          getConnection: function() { return Promise.resolve(conn); }
+        };
+
+        mysql = { createPool: function() { return pool; } };
+        mysql = captureMySQL(mysql);
+        poolObj = mysql.createPool();
+        poolObj.getConnection()
+          .then(function(connection) {
+            connectionObj = connection;
+            return done();
+          });
+      });
+
+      beforeEach(function() {
+        sandbox = sinon.sandbox.create();
+        segment = new Segment('test');
+        subsegment = segment.addNewSubsegment('testSub');
+
+        queryObj = new TestEmitter();
+        queryObj.sql = 'sql statement here';
+        queryObj.values = ['hello', 'there'];
+
+        sandbox = sinon.sandbox.create();
+        stubBaseQuery = sandbox.stub(connectionObj, '__query').returns(queryObj);
+        sandbox.stub(AWSXRay, 'getSegment').returns(segment);
+        stubAddNew = sandbox.stub(segment, 'addNewSubsegment').returns(subsegment);
+        sandbox.stub(AWSXRay, 'isAutomaticMode').returns(true);
+        query = connectionObj.query;
+      });
+
+      afterEach(function() {
+        sandbox.restore();
+      });
+
+      it('should create a new subsegment using database and host', function() {
+        var config = conn.config;
+        query.call(connectionObj, 'sql here');
+
+        stubAddNew.should.have.been.calledWithExactly(config.database + '@' + config.host);
+      });
+
+      it('should add the sql data to the subsegment', function() {
+        var stubAddSql = sandbox.stub(subsegment, 'addSqlData');
+        var stubDataInit = sandbox.stub(SqlData.prototype, 'init');
+        var config = conn.config;
+
+        query.call(connectionObj, 'sql here');
+
+        stubDataInit.should.have.been.calledWithExactly(undefined, undefined, config.user,
+          config.host + ':' + config.port + '/' + config.database, 'statement');
+        stubAddSql.should.have.been.calledWithExactly(sinon.match.instanceOf(SqlData));
+      });
+
+      it('should start a new automatic context and close the subsegment via the callback if supplied', function(done) {
+        var stubClose = sandbox.stub(subsegment, 'close');
+        var session = { run: function(fcn) { fcn(); }};
+        var stubRun = sandbox.stub(session, 'run');
+
+        sandbox.stub(AWSXRay, 'getNamespace').returns(session);
+        query.call(connectionObj, 'sql here', function() {});
+
+        stubBaseQuery.should.have.been.calledWith(sinon.match.string, null, sinon.match.func);
+        assert.equal(stubBaseQuery.args[0][2].name, 'autoContext');
+        stubBaseQuery.args[0][2].call(queryObj);
+
+        setTimeout(function() {
+          stubClose.should.always.have.been.calledWith();
+          stubRun.should.have.been.calledOnce;
+          done();
+        }, 50);
+      });
+    });
+  });
 });

--- a/packages/mysql/test/unit/mysql_p.test.js
+++ b/packages/mysql/test/unit/mysql_p.test.js
@@ -443,10 +443,11 @@ describe('captureMySQL', function() {
   });
 
   describe('#capturePoolCluster', function(){
-    it('should patch getConnection on the poolCluster', function(){
+    it('should patch getConnection and of on the poolCluster', function(){
       var poolCluster = {
         query: function() {},
-        getConnection: function() {}
+        getConnection: function() {},
+        of: function() {}
       };
       var mysql = {
         createPoolCluster: function() { return poolCluster; }
@@ -457,6 +458,30 @@ describe('captureMySQL', function() {
 
       assert.property(patched, '__getConnection');
       assert.equal(patched.getConnection.name, 'patchedGetConnection');
+      assert.property(patched, '__of');
+      assert.equal(patched.of.name, 'patchedOf');
+    });
+
+    it('should patch the pool returned by of', function(){
+      var pool = {
+        query: function() {},
+        getConnection: function() {}
+      };
+      var poolCluster = {
+        query: function() {},
+        getConnection: function() {},
+        of: function() {return pool;}
+      };
+      var mysql = {
+        createPoolCluster: function() { return poolCluster; }
+      };
+
+      var mysqlObj = captureMySQL(mysql);
+      var patched = mysqlObj.createPoolCluster();
+      var patchedPool = patched.of();
+
+      assert.property(patchedPool, '__getConnection');
+      assert.equal(patchedPool.getConnection.name, 'patchedGetConnection');
     });
 
     describe('for basic connections', function(){

--- a/packages/mysql/test/unit/mysql_p.test.js
+++ b/packages/mysql/test/unit/mysql_p.test.js
@@ -28,9 +28,11 @@ describe('captureMySQL', function() {
 
       assert.property(patched, '__createConnection');
       assert.property(patched, '__createPool');
+      assert.property(patched, '__createPoolCluster');
 
       assert.equal(patched.createConnection.name, 'patchedCreateConnection');
       assert.equal(patched.createPool.name, 'patchedCreatePool');
+      assert.equal(patched.createPoolCluster.name, 'patchedCreatePoolCluster');
     });
   });
 
@@ -377,6 +379,112 @@ describe('captureMySQL', function() {
             connectionObj = connection;
             return done();
           });
+      });
+
+      beforeEach(function() {
+        sandbox = sinon.sandbox.create();
+        segment = new Segment('test');
+        subsegment = segment.addNewSubsegment('testSub');
+
+        queryObj = new TestEmitter();
+        queryObj.sql = 'sql statement here';
+        queryObj.values = ['hello', 'there'];
+
+        sandbox = sinon.sandbox.create();
+        stubBaseQuery = sandbox.stub(connectionObj, '__query').returns(queryObj);
+        sandbox.stub(AWSXRay, 'getSegment').returns(segment);
+        stubAddNew = sandbox.stub(segment, 'addNewSubsegment').returns(subsegment);
+        sandbox.stub(AWSXRay, 'isAutomaticMode').returns(true);
+        query = connectionObj.query;
+      });
+
+      afterEach(function() {
+        sandbox.restore();
+      });
+
+      it('should create a new subsegment using database and host', function() {
+        var config = conn.config;
+        query.call(connectionObj, 'sql here');
+
+        stubAddNew.should.have.been.calledWithExactly(config.database + '@' + config.host);
+      });
+
+      it('should add the sql data to the subsegment', function() {
+        var stubAddSql = sandbox.stub(subsegment, 'addSqlData');
+        var stubDataInit = sandbox.stub(SqlData.prototype, 'init');
+        var config = conn.config;
+
+        query.call(connectionObj, 'sql here');
+
+        stubDataInit.should.have.been.calledWithExactly(undefined, undefined, config.user,
+          config.host + ':' + config.port + '/' + config.database, 'statement');
+        stubAddSql.should.have.been.calledWithExactly(sinon.match.instanceOf(SqlData));
+      });
+
+      it('should start a new automatic context and close the subsegment via the callback if supplied', function(done) {
+        var stubClose = sandbox.stub(subsegment, 'close');
+        var session = { run: function(fcn) { fcn(); }};
+        var stubRun = sandbox.stub(session, 'run');
+
+        sandbox.stub(AWSXRay, 'getNamespace').returns(session);
+        query.call(connectionObj, 'sql here', function() {});
+
+        stubBaseQuery.should.have.been.calledWith(sinon.match.string, null, sinon.match.func);
+        assert.equal(stubBaseQuery.args[0][2].name, 'autoContext');
+        stubBaseQuery.args[0][2].call(queryObj);
+
+        setTimeout(function() {
+          stubClose.should.always.have.been.calledWith();
+          stubRun.should.have.been.calledOnce;
+          done();
+        }, 50);
+      });
+    });
+  });
+
+  describe('#capturePoolCluster', function(){
+    it('should patch getConnection on the poolCluster', function(){
+      var poolCluster = {
+        query: function() {},
+        getConnection: function() {}
+      };
+      var mysql = {
+        createPoolCluster: function() { return poolCluster; }
+      };
+
+      var mysqlObj = captureMySQL(mysql);
+      var patched = mysqlObj.createPoolCluster();
+
+      assert.property(patched, '__getConnection');
+      assert.equal(patched.getConnection.name, 'patchedGetConnection');
+    });
+
+    describe('for basic connections', function(){
+      var conn, connectionObj, poolCluster, poolClusterObj, mysql, query, queryObj, sandbox, segment, stubAddNew, stubBaseQuery, subsegment;
+
+      before(function(done) {
+        conn = {
+          config: {
+            user: 'mcmuls',
+            host: 'database.location',
+            port: '8080',
+            database: 'myTestDb'
+          },
+          query: function() {}
+        };
+        poolCluster = {
+          query: function() {},
+          getConnection: function(patternOrCb, selectorOrCb, callback) {
+            if (patternOrCb instanceof Function) return patternOrCb(undefined, conn);
+            else if (selectorOrCb instanceof Function) return selectorOrCb(undefined, conn);
+            else return callback(undefined, conn);
+          }
+        };
+
+        mysql = { createPoolCluster: function() { return poolCluster; } };
+        mysql = captureMySQL(mysql);
+        poolClusterObj = mysql.createPoolCluster();
+        poolClusterObj.getConnection(function (err, connection) {connectionObj = connection; return done();});
       });
 
       beforeEach(function() {


### PR DESCRIPTION
*Issue #, if available:* #87

*Description of changes:*

Adds a simple patchObject call around connections returned from a pools `getConnection`.
Far as I could tell mysql doesn't take any other arguments for this, so it assumes the first argument is the callback.

I'm unsure what mysql2 makes of this, but I assume they promisified it which I didn't yet support. Would be nice to hear from someone who uses mysql2 what changes are still needed to support mysql2. I'll be looking into adding it but would like confirmation on what parameters it takes and what it returns.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
