### PR TITLE
refactor: remove lodash from runtime dependencies

### DIFF
--- a/packages/core/lib/patchers/http_p.js
+++ b/packages/core/lib/patchers/http_p.js
@@ -6,7 +6,6 @@
  * This module patches the HTTP and HTTPS node built-in libraries and returns a copy of the module with tracing enabled.
  */
 
-var omit = require('lodash/omit');
 var url = require('url');
 
 var contextUtils = require('../context_utils');
@@ -112,7 +111,10 @@ function enableCapture(module, downstreamXRayEnabled) {
       }
     };
 
-    var req = baseFunc(omit(options, 'Segment'), function(res) {
+    var optionsCopy = Object.assign({}, options);
+    if ('Segment' in optionsCopy) delete optionsCopy.Segment;
+
+    var req = baseFunc(optionsCopy, function(res) {
       res.on('end', function() {
         if (res.statusCode === 429)
           subsegment.addThrottleFlag();

--- a/packages/core/lib/segments/attributes/captured_exception.js
+++ b/packages/core/lib/segments/attributes/captured_exception.js
@@ -1,6 +1,3 @@
-var each = require('lodash/each');
-var isEmpty = require('lodash/isEmpty');
-
 /**
  * Represents a captured exception.
  * @constructor
@@ -25,12 +22,12 @@ CapturedException.prototype.init = function init(err, remote) {
     stack.shift();
 
     var self = this;
-    each(stack, function(stackline) {
+    stack.forEach(function(stackline) {
       var line = stackline.trim().replace(/\(|\)/g, '');
       line = line.substring(line.indexOf(' ') + 1);
 
       var label = line.lastIndexOf(' ') >= 0 ? line.slice(0, line.lastIndexOf(' ')) : null;
-      var path = isEmpty(label) ? line : line.slice(line.lastIndexOf(' ') + 1);
+      var path = Array.isArray(label) && !label.length ? line : line.slice(line.lastIndexOf(' ') + 1);
       path = path.split(':');
 
       var entry = {

--- a/packages/core/lib/segments/attributes/subsegment.js
+++ b/packages/core/lib/segments/attributes/subsegment.js
@@ -116,7 +116,7 @@ Subsegment.prototype.addPrecursorId = function(id) {
  */
 
 Subsegment.prototype.addAnnotation = function(key, value) {
-  if (!['boolean', 'number', 'string'].includes(typeof value)) {
+  if (!(typeof value === 'boolean' || typeof value === 'string' || (typeof value === 'number' && isFinite(value)))) {
     throw new Error('Failed to add annotation key: ' + key + ' value: ' + value + ' to subsegment ' +
       this.name + '. Value must be of type string, number or boolean.');
   } else if (typeof key !== 'string') {

--- a/packages/core/lib/segments/attributes/subsegment.js
+++ b/packages/core/lib/segments/attributes/subsegment.js
@@ -1,11 +1,3 @@
-var omit = require('lodash/omit');
-var isEmpty = require('lodash/isEmpty');
-var isBoolean = require('lodash/isBoolean');
-var isFinite = require('lodash/isFinite');
-var isString = require('lodash/isString');
-var isUndefined = require('lodash/isUndefined');
-var isObject = require('lodash/isObject');
-
 var crypto = require('crypto');
 
 var CapturedException = require('./captured_exception');
@@ -59,13 +51,13 @@ Subsegment.prototype.addSubsegment = function(subsegment) {
       '".  Not a subsegment.');
   }
 
-  if (isUndefined(this.subsegments))
+  if (this.subsegments === undefined)
     this.subsegments = [];
 
   subsegment.segment = this.segment;
   subsegment.parent = this;
 
-  if (isUndefined(subsegment.end_time)) {
+  if (subsegment.end_time === undefined) {
     this.incrementCounter(subsegment.counter);
   }
 
@@ -82,7 +74,7 @@ Subsegment.prototype.removeSubsegment = function removeSubsegment(subsegment) {
       '".  Not a subsegment.');
   }
 
-  if (!isUndefined(this.subsegments)) {
+  if (this.subsegments === undefined) {
     var index = this.subsegments.indexOf(subsegment);
 
     if (index >= 0)
@@ -106,11 +98,11 @@ Subsegment.prototype.addAttribute = function addAttribute(name, data) {
  */
 
 Subsegment.prototype.addPrecursorId = function(id) {
-  if (!isString(id))
+  if (typeof id !== 'string')
     logger.getLogger().error('Failed to add id:' + id + ' to subsegment ' + this.name +
       '.  Precursor Ids must be of type string.');
 
-  if (isUndefined(this.precursor_ids))
+  if (this.precursor_ids === undefined)
     this.precursor_ids = [];
 
   this.precursor_ids.push(id);
@@ -124,15 +116,15 @@ Subsegment.prototype.addPrecursorId = function(id) {
  */
 
 Subsegment.prototype.addAnnotation = function(key, value) {
-  if (!(isBoolean(value) || isString(value) || isFinite(value))) {
+  if (!['boolean', 'number', 'string'].includes(typeof value)) {
     throw new Error('Failed to add annotation key: ' + key + ' value: ' + value + ' to subsegment ' +
       this.name + '. Value must be of type string, number or boolean.');
-  } else if (!isString(key)) {
+  } else if (typeof key !== 'string') {
     throw new Error('Failed to add annotation key: ' + key + ' value: ' + value + ' to subsegment ' +
       this.name + '. Key must be of type string.');
   }
 
-  if (isUndefined(this.annotations))
+  if (this.annotations === undefined)
     this.annotations = {};
 
   this.annotations[key] = value;
@@ -147,10 +139,10 @@ Subsegment.prototype.addAnnotation = function(key, value) {
  */
 
 Subsegment.prototype.addMetadata = function(key, value, namespace) {
-  if (!isString(key)) {
+  if (typeof key !== 'string') {
     throw new Error('Failed to add annotation key: ' + key + ' value: ' + value + ' to subsegment ' +
       this.name + '. Key must be of type string.');
-  } else if (namespace && !isString(namespace)) {
+  } else if (namespace && typeof namespace !== 'string') {
     throw new Error('Failed to add annotation key: ' + key + ' value: ' + value + 'namespace: ' + namespace + ' to subsegment ' +
       this.name + '. Namespace must be of type string.');
   }
@@ -182,7 +174,7 @@ Subsegment.prototype.addSqlData = function addSqlData(sqlData) {
  */
 
 Subsegment.prototype.addError = function addError(err, remote) {
-  if (!isObject(err) && typeof(err) !== 'string') {
+  if (err == null || typeof err !== 'object' && typeof(err) !== 'string') {
     throw new Error('Failed to add error:' + err + ' to subsegment "' + this.name +
       '".  Not an object or string literal.');
   }
@@ -207,7 +199,7 @@ Subsegment.prototype.addError = function addError(err, remote) {
     //error, cannot propagate exception if not added to segment
   }
 
-  if (isUndefined(this.cause)) {
+  if (this.cause === undefined) {
     this.cause = {
       working_directory: process.cwd(),
       exceptions: []
@@ -379,12 +371,16 @@ Subsegment.prototype.toString = function toString() {
 };
 
 Subsegment.prototype.toJSON = function toJSON() {
-  var ignore = ['segment', 'parent', 'counter'];
+  var thisCopy = Object.assign({}, this);
 
-  if (isEmpty(this.subsegments))
-    ignore.push('subsegments');
+  if ('segment' in thisCopy) delete thisCopy.segment;
+  if ('parent' in thisCopy) delete thisCopy.parent;
+  if ('counter' in thisCopy) delete thisCopy.counter;
 
-  return omit(this, ignore);
+  if (Array.isArray(this.subsegments) && !this.subsegments.length && 'subsegments' in thisCopy)
+    delete thisCopy.subsegments;
+
+  return thisCopy;
 };
 
 module.exports = Subsegment;

--- a/packages/core/lib/segments/attributes/subsegment.js
+++ b/packages/core/lib/segments/attributes/subsegment.js
@@ -377,8 +377,9 @@ Subsegment.prototype.toJSON = function toJSON() {
   if ('parent' in thisCopy) delete thisCopy.parent;
   if ('counter' in thisCopy) delete thisCopy.counter;
 
-  if (Array.isArray(this.subsegments) && !this.subsegments.length && 'subsegments' in thisCopy)
+  if (Array.isArray(this.subsegments) && !this.subsegments.length && 'subsegments' in thisCopy) {
     delete thisCopy.subsegments;
+  }
 
   return thisCopy;
 };

--- a/packages/core/lib/segments/segment.js
+++ b/packages/core/lib/segments/segment.js
@@ -354,8 +354,9 @@ Segment.prototype.format = function format() {
   if ('notTraced' in thisCopy) delete thisCopy.notTraced;
   if ('exception' in thisCopy) delete thisCopy.exception;
 
-  if (Array.isArray(this.subsegments) && !this.subsegments.length && 'subsegments' in thisCopy)
+  if (Array.isArray(this.subsegments) && !this.subsegments.length && 'subsegments' in thisCopy) {
     delete thisCopy.subsegments;
+  }
 
   return JSON.stringify(thisCopy);
 };

--- a/packages/core/lib/segments/segment_utils.js
+++ b/packages/core/lib/segments/segment_utils.js
@@ -1,5 +1,3 @@
-var isFinite = require('lodash/isFinite');
-
 var logger = require('../logger');
 
 var DEFAULT_STREAMING_THRESHOLD = 100;

--- a/packages/core/lib/utils.js
+++ b/packages/core/lib/utils.js
@@ -2,11 +2,6 @@
  * @module utils
  */
 
-var each = require('lodash/each');
-var isNull = require('lodash/isNull');
-var isString = require('lodash/isString');
-var isUndefined = require('lodash/isUndefined');
-
 var logger = require('./logger');
 
 var utils = {
@@ -20,9 +15,9 @@ var utils = {
 
   getCauseTypeFromHttpStatus: function getCauseTypeFromHttpStatus(status) {
     var stat = status.toString();
-    if (!isNull(stat.match(/^[4][0-9]{2}$/)))
+    if (stat.match(/^[4][0-9]{2}$/) !== null)
       return 'error';
-    else if (!isNull(stat.match(/^[5][0-9]{2}$/)))
+    else if (stat.match(/^[5][0-9]{2}$/) !== null)
       return 'fault';
   },
 
@@ -38,7 +33,7 @@ var utils = {
    */
 
   wildcardMatch: function wildcardMatch(pattern, text) {
-    if (isUndefined(pattern) || isUndefined(text))
+    if (pattern === undefined || text === undefined)
       return false;
 
     if (pattern.length === 1 && pattern.charAt(0) === '*')
@@ -164,10 +159,10 @@ var utils = {
   processTraceData: function processTraceData(traceData) {
     var amznTraceData = {};
 
-    if (!(isString(traceData) && traceData))
+    if (!(typeof traceData === 'string' && traceData))
       return amznTraceData;
 
-    each(traceData.split(';'), function(header) {
+    traceData.split(';').forEach(function(header) {
       if (!header)
         return;
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,6 @@
     "aws-sdk": "^2.304.0",
     "continuation-local-storage": "^3.2.0",
     "date-fns": "^1.29.0",
-    "lodash": "^4.17.11",
     "pkginfo": "^0.4.0",
     "semver": "^5.3.0",
     "winston": "^2.4.4"

--- a/packages/core/test/unit/sampling/local_reservoir.test.js
+++ b/packages/core/test/unit/sampling/local_reservoir.test.js
@@ -1,7 +1,6 @@
 var assert = require('chai').assert;
 var expect = require('chai').expect;
 var sinon = require('sinon');
-var times = require('lodash/times');
 
 var LocalReservoir = require('../../../lib/middleware/sampling/local_reservoir');
 
@@ -43,9 +42,9 @@ describe('LocalReservoir', function() {
     });
 
     it('should return true up to the fixed target set.', function() {
-      times(fixedTarget, function() {
+      for (var i = 0; i < fixedTarget; i++) {
         assert.isTrue(localReservoir.isSampled());
-      });
+      }
 
       assert.isFalse(localReservoir.isSampled());
     });


### PR DESCRIPTION
*Issue #, if available:* #84

*Description of changes:*

Removes use of lodash functions making lodash no longer required on runtime.
May have a slight regression in performance on the replacement of omit. 
Would prefer using destructuring but that's not supported below node v6.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
