### PR TITLE
bugfix(core): prevents xray calls made for centralized sampling from being traced

### DIFF
--- a/packages/core/lib/patchers/aws_p.js
+++ b/packages/core/lib/patchers/aws_p.js
@@ -10,6 +10,7 @@ var contextUtils = require('../context_utils');
 var Utils = require('../utils');
 
 var logger = require('../logger');
+var ServiceConnector = require('../middleware/sampling/service_connector');
 
 var minVersion = '2.7.15';
 
@@ -57,6 +58,11 @@ var captureAWSClient = function captureAWSClient(service) {
 };
 
 function captureAWSRequest(req) {
+  // short-circuit if the client is the sampling poller
+  if (req.service === ServiceConnector.client) {
+    return req;
+  }
+
   var parent = contextUtils.resolveSegment(contextUtils.resolveManualSegmentParams(req.params));
 
   if (!parent) {

--- a/packages/core/test/functional/service_connector_patching.test.js
+++ b/packages/core/test/functional/service_connector_patching.test.js
@@ -1,0 +1,76 @@
+var expect = require('chai').expect;
+var sinon = require('sinon');
+var XRay = require('aws-sdk/clients/xray');
+var AWS = require('aws-sdk/global');
+var AWSXRay = require('../../lib/index');
+var ServiceConnector = require('../../lib/middleware/sampling/service_connector');
+
+function generateXrayClient() {
+  var client = new XRay({
+    region: 'mock-region',
+    credentials: {
+      accessKeyId: 'akid',
+      secretAccessKey: 'secret',
+      sessionToken: 'session'
+    },
+    endpoint: 'http://localhost:3000'
+  });
+
+  // remove events that require network calls
+  client.makeUnauthenticatedRequest = function(operation, params, cb) {
+    var request = this.makeRequest(operation, params).toUnauthenticated();
+    request.removeAllListeners('send');
+    request.removeListener('validateResponse', AWS.EventListeners.Core.VALIDATE_RESPONSE);
+    request.removeListener('validate', AWS.EventListeners.Core.VALIDATE_PARAMETERS);
+    request.removeAllListeners('extractData');
+    request.on('validateResponse', function() {
+      request.emit('success', request);
+    });
+    return request.send(cb);
+  }
+  
+  return client;
+}
+
+describe('X-Ray AWS', function() {
+  var sandbox;
+  var client;
+  before(function() {
+    client = ServiceConnector.client;
+    ServiceConnector.client = generateXrayClient();
+  });
+
+  after(function() {
+    ServiceConnector.client = client;
+  });
+
+  beforeEach(function() {
+    sandbox = sinon.sandbox.create();
+  });
+  
+  afterEach(function() {
+    sandbox.restore();
+    // reset customizations
+    XRay.prototype.customizeRequests(null);
+  });
+
+  describe('client patching', function() {
+    it('should not affect the centralized sampling x-ray client', function(done) {
+      AWSXRay.captureAWSClient(XRay.prototype);
+      ServiceConnector.client.makeUnauthenticatedRequest('getSamplingTargets', {}, function(err, data) {
+        expect(err).to.be.a('null');
+        done();
+      });
+    });
+
+    it('should affect non x-ray sdk clients', function() {
+      AWSXRay.captureAWSClient(XRay.prototype);
+      // expect to get a context missing error if the client is instrumented
+      expect(function() {
+        generateXrayClient().makeUnauthenticatedRequest('getSamplingTargets', {}, function(err, data) {})
+          .to.throw(Error, 'Failed to get the current sub/segment from the context.');
+      });
+      
+    });
+  });
+});


### PR DESCRIPTION
*Issue #, if available:*
Fixes #100 

*Description of changes:*
The X-Ray SDK now checks if the AWS SDK client it is instrumenting is the one used internally to poll the x-ray daemon. This prevents traces being generated (and resulting in missing context errors) for x-ray calls made by this SDK.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
