### PR TITLE
Avoid logging the error message twice and comply to winston v3 signature

### DIFF
--- a/packages/core/lib/middleware/sampling/service_connector.js
+++ b/packages/core/lib/middleware/sampling/service_connector.js
@@ -23,7 +23,7 @@ var ServiceConnector = {
 
     this.client.makeUnauthenticatedRequest('getSamplingRules', null, function(err, data) {
       if(err)
-        logger.getLogger().warn(err, err.stack);
+        logger.getLogger().warn(err.stack);
       else {
         var newRules = assembleRules(data);
         callback(newRules);
@@ -36,7 +36,7 @@ var ServiceConnector = {
 
     this.client.makeUnauthenticatedRequest('getSamplingTargets', params, function(err, data) {
       if(err) {
-        logger.getLogger().warn(err, err.stack);
+        logger.getLogger().warn(err.stack);
       }
       else{
         var targetsMapping = assembleTargets(data);


### PR DESCRIPTION
Injecting a winston v3 logger breaks the way how the log is outputted, given that they
do not handle instances of the Error object anymore and the logger fn signature changed

*Description of changes:*

Only log stack trace, not the error object itself in order to comply with both v2 and v3 of winston. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
