### PR TITLE
fix: replace instanceof Promise checks with thennable checks

### DIFF
--- a/packages/mysql/lib/mysql_p.js
+++ b/packages/mysql/lib/mysql_p.js
@@ -36,7 +36,7 @@ function patchCreateConnection(mysql) {
 
   mysql['createConnection'] = function patchedCreateConnection() {
     var connection = mysql[baseFcn].apply(connection, arguments);
-    if (connection instanceof Promise) {
+    if (connection.then instanceof Function) {
       connection = connection.then((result) => {
         patchObject(result.connection);
         return result;
@@ -54,7 +54,7 @@ function patchCreatePool(mysql) {
 
   mysql['createPool'] = function patchedCreatePool() {
     var pool = mysql[baseFcn].apply(pool, arguments);
-    if (pool instanceof Promise) {
+    if (pool.then instanceof Function) {
       pool = pool.then((result) => {
         patchObject(result.pool);
         return result;


### PR DESCRIPTION
*Issue #, if available:* No issue, came up in https://github.com/aws/aws-xray-sdk-node/pull/98#discussion_r276745026.

*Description of changes:* Replaces 2 `instanceof Promise` checks to instead check if .then is a function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

If preferred I can merge this into the feat/support-pool-get-connection branch.

Wasn't too sure on a way to add tests for this, so refrained on adding them for now. Let me know if you have any ideas.