### PR TITLE
chore: sets aws-xray-sdk-core as a dev dependency for restify

### DIFF
--- a/packages/restify/package.json
+++ b/packages/restify/package.json
@@ -17,6 +17,7 @@
     "aws-xray-sdk-core": "^2.3.0"
   },
   "devDependencies": {
+    "aws-xray-sdk-core": "^2.3.0",
     "chai": "^3.5.0",
     "eslint": "^3.10.2",
     "mocha": "^3.0.2",


### PR DESCRIPTION
*Description of changes:*
Previously, aws-xray-sdk-restify depended on the version of `aws-xray-sdk-core` that was installed by the root `package.json`, which would cause a different version of the core SDK to be used than what is specified in `peerDependencies` in some cases. Adding the dependency to `devDependencies` as well forces tests to be run against the version we expect.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
