### PR TITLE
fix: no longer error when checking .then on variables

### DIFF
--- a/packages/mysql/lib/mysql_p.js
+++ b/packages/mysql/lib/mysql_p.js
@@ -37,7 +37,7 @@ function patchCreateConnection(mysql) {
 
   mysql['createConnection'] = function patchedCreateConnection() {
     var connection = mysql[baseFcn].apply(connection, arguments);
-    if (connection != null && connection.then instanceof Function) {
+    if (connection && connection.then instanceof Function) {
       connection = connection.then((result) => {
         patchObject(result.connection);
         return result;
@@ -55,7 +55,7 @@ function patchCreatePool(mysql) {
 
   mysql['createPool'] = function patchedCreatePool() {
     var pool = mysql[baseFcn].apply(pool, arguments);
-    if (pool != null && pool.then instanceof Function) {
+    if (pool && pool.then instanceof Function) {
       pool = pool.then((result) => {
         patchObject(result.pool);
         return result;
@@ -108,7 +108,7 @@ function patchGetConnection(pool) {
     }
 
     var result = pool[baseFcn].apply(pool, args);
-    if (result != null && result.then instanceof Function) return result.then(patchObject);
+    if (result && result.then instanceof Function) return result.then(patchObject);
     else return result;
   }
 }

--- a/packages/mysql/lib/mysql_p.js
+++ b/packages/mysql/lib/mysql_p.js
@@ -37,7 +37,7 @@ function patchCreateConnection(mysql) {
 
   mysql['createConnection'] = function patchedCreateConnection() {
     var connection = mysql[baseFcn].apply(connection, arguments);
-    if (connection.then instanceof Function) {
+    if (connection != null && connection.then instanceof Function) {
       connection = connection.then((result) => {
         patchObject(result.connection);
         return result;
@@ -55,7 +55,7 @@ function patchCreatePool(mysql) {
 
   mysql['createPool'] = function patchedCreatePool() {
     var pool = mysql[baseFcn].apply(pool, arguments);
-    if (pool.then instanceof Function) {
+    if (pool != null && pool.then instanceof Function) {
       pool = pool.then((result) => {
         patchObject(result.pool);
         return result;
@@ -108,7 +108,7 @@ function patchGetConnection(pool) {
     }
 
     var result = pool[baseFcn].apply(pool, args);
-    if (result.then instanceof Function) return result.then(patchObject);
+    if (result != null && result.then instanceof Function) return result.then(patchObject);
     else return result;
   }
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-xray-sdk-node/pull/114#issuecomment-485554819

*Description of changes:*

Prevents errors from occurring on the case that a variable is null or undefined and being checked on whether it's a promise through accessing the .then property.
I think properties are only inaccessible on null and undefined, so as 
far as I know this should fully catch this case. Let me know if there's 
more.

Sorry for the double if you already fixed it, noticed https://github.com/aws/aws-xray-sdk-node/pull/114#issuecomment-485555958 after I already made these changes so I thought I might as well open a PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
