### PR TITLE
chore: adds Express integration tests

### DIFF
--- a/packages/test_express/.eslintrc.json
+++ b/packages/test_express/.eslintrc.json
@@ -1,0 +1,29 @@
+{
+    "env": {
+        "node": true,
+        "mocha": true
+    },
+    "extends": "eslint:recommended",
+    "rules": {
+        "indent": [
+            "error",
+            2
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "quotes": [
+            "error",
+            "single"
+        ],
+        "semi": [
+            "error",
+            "always"
+        ],
+        "eol-last": [
+            "error",
+            "always"
+        ]
+    }
+}

--- a/packages/test_express/package.json
+++ b/packages/test_express/package.json
@@ -19,7 +19,6 @@
     "aws-xray-sdk-express": "^2.3.1",
     "chai": "^3.5.0",
     "eslint": "^3.10.2",
-    "jmespath": "^0.15.0",
     "mocha": "^3.0.2"
   },
   "scripts": {

--- a/packages/test_express/package.json
+++ b/packages/test_express/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "test-aws-xray-sdk-express",
+  "private": true,
+  "version": "2.3.1",
+  "description": "AWS X-Ray Middleware for Express (Javascript)",
+  "author": "Amazon Web Services",
+  "contributors": [
+    "Sandra McMullen <mcmuls@amazon.com>"
+  ],
+  "main": "lib/index.js",
+  "engines": {
+    "node": ">= 4.x"
+  },
+  "directories": {
+    "test": "test"
+  },
+  "devDependencies": {
+    "aws-xray-sdk-core": "^2.3.1",
+    "aws-xray-sdk-express": "^2.3.1",
+    "chai": "^3.5.0",
+    "eslint": "^3.10.2",
+    "jmespath": "^0.15.0",
+    "mocha": "^3.0.2"
+  },
+  "scripts": {
+    "test": "./node_modules/.bin/mocha --recursive ./test/ -R spec"
+  },
+  "keywords": [
+    "amazon",
+    "api",
+    "aws",
+    "express",
+    "xray",
+    "x-ray",
+    "x ray"
+  ],
+  "license": "Apache-2.0",
+  "repository": "https://github.com/aws/aws-xray-sdk-node/tree/master/packages/express",
+  "dependencies": {
+    "express": "^4.16.4"
+  }
+}

--- a/packages/test_express/test/express.js
+++ b/packages/test_express/test/express.js
@@ -1,0 +1,133 @@
+var dgram = require('dgram');
+var xray = require('aws-xray-sdk-core');
+xray.capturePromise();
+var jmespath = require('jmespath');
+
+var createAppWithRoute = require('./helpers').createAppWithRoute;
+var createDaemon = require('./helpers').createDaemon;
+var messageCounter = require('./helpers').messageCounter;
+var parseMessage = require('./helpers').parseMessage;
+var triggerEndpoint = require('./helpers').triggerEndpoint;
+
+var chai = require('chai');
+var assert = chai.assert;
+chai.should();
+
+describe('Express', () => {
+  /**
+   * @type {dgram.Socket}
+   */
+  var daemon;
+
+  before(() => {
+    // force all requests to be sampled
+    xray.middleware.disableCentralizedSampling();
+    xray.middleware.setSamplingRules({
+      "version": 2,
+      "rules": [],
+      "default": {
+        "fixed_target": 0,
+        "rate": 1
+      }
+    });
+  });
+
+  beforeEach((done) => {
+    daemon = createDaemon();
+    daemon.bind(() => {
+      var address = daemon.address().address + ':' + daemon.address().port;
+      xray.setDaemonAddress(address);
+      done()
+    });
+  });
+
+  afterEach((done) => {
+    daemon.close(done);
+  });
+
+  it('should generate fix-named segments', (done) => {
+    // resolve promise once expected number of messages received by daemon
+    var daemonMessagesResolved = new Promise((resolve) => {
+      daemon.on('message', messageCounter(1, (resolve)));
+    });
+
+    var route = '/';
+    var name = 'test';
+    var expressApp = createAppWithRoute({
+      name: name,
+      route: route,
+      handler: function(req, res) {
+        res.status(200).end();
+      }
+    });
+
+    var server = expressApp.listen(0, () => {
+      var url = 'http://127.0.0.1:' + server.address().port + route;
+
+      // wait for the express response, and the daemon to receive messages
+      Promise.all([triggerEndpoint(url), daemonMessagesResolved])
+      .then((data) => {
+        var result = data[0];
+        var messages = data[1];
+
+        assert.equal(result.status, 200);
+        assert.equal(messages.length, 1);
+        
+        // verify the Segment is valid
+        var segment = parseMessage(messages[0]);
+        assert.equal(jmespath.search(segment, 'name'), name);
+        assert.equal(jmespath.search(segment, 'http.request.method'), 'GET');
+        assert.equal(jmespath.search(segment, 'http.response.status'), result.status);
+        assert.equal(jmespath.search(segment, 'type(trace_id)'), 'string');
+        done();
+      }).catch(done);
+    });
+  });
+
+  it('should generate dynamic-named segments', (done) => {
+    // resolve promise once expected number of messages received by daemon
+    var daemonMessagesResolved = new Promise((resolve) => {
+      daemon.on('message', messageCounter(1, resolve));
+    });
+
+    var route = '/';
+    var name = 'test';
+    var dynamicPattern = '*';
+    var dynamicName;
+
+    var expressApp = createAppWithRoute({
+      dynamicPattern: dynamicPattern,
+      name: name,
+      route: route,
+      handler: function(req, res) {
+        dynamicName = req.headers.host;
+        res.status(200).end();
+      }
+    });
+
+    var server = expressApp.listen(0, () => {
+      var url = 'http://127.0.0.1:' + server.address().port + route;
+
+      // wait for the express response, and the daemon to receive messages
+      Promise.all([triggerEndpoint(url), daemonMessagesResolved])
+      .then((data) => {
+        var result = data[0];
+        var messages = data[1];
+
+        assert.equal(result.status, 200);
+        assert.equal(messages.length, 1);
+        assert.isString(dynamicName);
+        assert.isAtLeast(dynamicName.length, 1);
+        
+        // verify the Segment is valid
+        var segment = parseMessage(messages[0]);
+        assert.equal(jmespath.search(segment, 'name'), dynamicName);
+        assert.equal(jmespath.search(segment, 'http.request.method'), 'GET');
+        assert.equal(jmespath.search(segment, 'http.response.status'), result.status);
+        assert.equal(jmespath.search(segment, 'type(trace_id)'), 'string');
+
+        done();
+      }).catch(done);
+    });
+  });
+});

--- a/packages/test_express/test/express.js
+++ b/packages/test_express/test/express.js
@@ -1,13 +1,13 @@
 var dgram = require('dgram');
 var xray = require('aws-xray-sdk-core');
 xray.capturePromise();
-var jmespath = require('jmespath');
 
 var createAppWithRoute = require('./helpers').createAppWithRoute;
 var createDaemon = require('./helpers').createDaemon;
 var messageCounter = require('./helpers').messageCounter;
 var parseMessage = require('./helpers').parseMessage;
 var triggerEndpoint = require('./helpers').triggerEndpoint;
+var validateExpressSegment = require('./helpers').validateExpressSegment;
 
 var chai = require('chai');
 var assert = chai.assert;
@@ -42,6 +42,10 @@ describe('Express', () => {
   });
 
   afterEach((done) => {
+    // disable dynamic naming in case it was enabled by a test
+    xray.middleware.dynamicNaming = false;
+    xray.middleware.hostPattern = null;
+
     daemon.close(done);
   });
 
@@ -75,10 +79,11 @@ describe('Express', () => {
         
         // verify the Segment is valid
         var segment = parseMessage(messages[0]);
-        assert.equal(jmespath.search(segment, 'name'), name);
-        assert.equal(jmespath.search(segment, 'http.request.method'), 'GET');
-        assert.equal(jmespath.search(segment, 'http.response.status'), result.status);
-        assert.equal(jmespath.search(segment, 'type(trace_id)'), 'string');
+        validateExpressSegment(segment, {
+          name: name,
+          responseStatus: result.status,
+          url: url
+        });
         done();
       }).catch(done);
     });
@@ -121,13 +126,510 @@ describe('Express', () => {
         
         // verify the Segment is valid
         var segment = parseMessage(messages[0]);
-        assert.equal(jmespath.search(segment, 'name'), dynamicName);
-        assert.equal(jmespath.search(segment, 'http.request.method'), 'GET');
-        assert.equal(jmespath.search(segment, 'http.response.status'), result.status);
-        assert.equal(jmespath.search(segment, 'type(trace_id)'), 'string');
+        validateExpressSegment(segment, {
+          name: dynamicName,
+          responseStatus: result.status,
+          url: url
+        });
 
         done();
       }).catch(done);
+    });
+  });
+
+  describe('automatic mode', () => {
+    before(() => {
+      xray.enableAutomaticMode();
+    });
+
+    it('supports segment retrieval', (done) => {
+      // resolve promise once expected number of messages received by daemon
+      var daemonMessagesResolved = new Promise((resolve) => {
+        daemon.on('message', messageCounter(1, resolve));
+      });
+  
+      var route = '/';
+      var name = 'test';
+      var expressSegment;
+
+      var expressApp = createAppWithRoute({
+        name: name,
+        route: route,
+        handler: function(req, res) {
+          expressSegment = xray.getSegment();
+          res.status(200).end();
+        }
+      });
+  
+      var server = expressApp.listen(0, () => {
+        var url = 'http://127.0.0.1:' + server.address().port + route;
+  
+        // wait for the express response, and the daemon to receive messages
+        Promise.all([triggerEndpoint(url), daemonMessagesResolved])
+        .then((data) => {
+          var result = data[0];
+          var messages = data[1];
+  
+          assert.equal(result.status, 200);
+          assert.equal(messages.length, 1);
+          
+          // verify the Segment is valid
+          var segment = parseMessage(messages[0]);
+          validateExpressSegment(segment, {
+            name: name,
+            responseStatus: result.status,
+            url: url
+          });
+  
+          // verify segment retrieved from express handler
+          assert.isDefined(expressSegment);
+          assert.equal(expressSegment.id, segment.id);
+
+          done();
+        }).catch(done);
+      });
+    });
+
+    it('supports segment annotations', (done) => {
+      // resolve promise once expected number of messages received by daemon
+      var daemonMessagesResolved = new Promise((resolve) => {
+        daemon.on('message', messageCounter(1, resolve));
+      });
+  
+      var route = '/';
+      var name = 'test';
+      var expressSegment;
+
+      var expressApp = createAppWithRoute({
+        name: name,
+        route: route,
+        handler: function(req, res) {
+          expressSegment = xray.getSegment();
+          expressSegment.addAnnotation('foo', 'bar');
+          res.status(200).end();
+        }
+      });
+  
+      var server = expressApp.listen(0, () => {
+        var url = 'http://127.0.0.1:' + server.address().port + route;
+  
+        // wait for the express response, and the daemon to receive messages
+        Promise.all([triggerEndpoint(url), daemonMessagesResolved])
+        .then((data) => {
+          var result = data[0];
+          var messages = data[1];
+  
+          assert.equal(result.status, 200);
+          assert.equal(messages.length, 1);
+          
+          // verify the Segment is valid
+          var segment = parseMessage(messages[0]);
+          validateExpressSegment(segment, {
+            name: name,
+            responseStatus: result.status,
+            url: url
+          });
+  
+          // verify segment retrieved from express handler
+          assert.isDefined(expressSegment);
+          assert.equal(expressSegment.id, segment.id);
+          assert.deepEqual(segment.annotations, {foo: 'bar'});
+          done();
+        }).catch(done);
+      });
+    });
+
+    it('supports segment metadata', (done) => {
+      // resolve promise once expected number of messages received by daemon
+      var daemonMessagesResolved = new Promise((resolve) => {
+        daemon.on('message', messageCounter(1, resolve));
+      });
+  
+      var route = '/';
+      var name = 'test';
+      var expressSegment;
+
+      var expressApp = createAppWithRoute({
+        name: name,
+        route: route,
+        handler: function(req, res) {
+          expressSegment = xray.getSegment();
+          expressSegment.addMetadata('foo', 'bar');
+          res.status(200).end();
+        }
+      });
+  
+      var server = expressApp.listen(0, () => {
+        var url = 'http://127.0.0.1:' + server.address().port + route;
+  
+        // wait for the express response, and the daemon to receive messages
+        Promise.all([triggerEndpoint(url), daemonMessagesResolved])
+        .then((data) => {
+          var result = data[0];
+          var messages = data[1];
+  
+          assert.equal(result.status, 200);
+          assert.equal(messages.length, 1);
+          
+          // verify the Segment is valid
+          var segment = parseMessage(messages[0]);
+          validateExpressSegment(segment, {
+            name: name,
+            responseStatus: result.status,
+            url: url
+          });
+  
+          // verify segment retrieved from express handler
+          assert.isDefined(expressSegment);
+          assert.equal(expressSegment.id, segment.id);
+          assert.deepEqual(segment.metadata, {default: {foo: 'bar'}});
+          done();
+        }).catch(done);
+      });
+    });
+
+    it('supports captureFunc', (done) => {
+      // resolve promise once expected number of messages received by daemon
+      var daemonMessagesResolved = new Promise((resolve) => {
+        daemon.on('message', messageCounter(1, resolve));
+      });
+  
+      var route = '/';
+      var name = 'test';
+      var subsegmentName = 'descendant';
+
+      var expressApp = createAppWithRoute({
+        name: name,
+        route: route,
+        handler: function(req, res) {
+          xray.captureFunc(subsegmentName, () => {/* just generate a subsegment */});
+          res.status(200).end();
+        }
+      });
+  
+      var server = expressApp.listen(0, () => {
+        var url = 'http://127.0.0.1:' + server.address().port + route;
+  
+        // wait for the express response, and the daemon to receive messages
+        Promise.all([triggerEndpoint(url), daemonMessagesResolved])
+        .then((data) => {
+          var result = data[0];
+          var messages = data[1];
+  
+          assert.equal(result.status, 200);
+          assert.equal(messages.length, 1);
+          
+          // verify the Segment is valid
+          var segment = parseMessage(messages[0]);
+          validateExpressSegment(segment, {
+            name: name,
+            responseStatus: result.status,
+            url: url
+          });
+  
+          assert.equal(segment.subsegments.length, 1);
+          assert.equal(segment.subsegments[0].name, subsegmentName);
+          done();
+        }).catch(done);
+      });
+    });
+
+    it('supports captureAsyncFunc', (done) => {
+      // resolve promise once expected number of messages received by daemon
+      var daemonMessagesResolved = new Promise((resolve) => {
+        daemon.on('message', messageCounter(1, resolve));
+      });
+  
+      var route = '/';
+      var name = 'test';
+      var subsegmentName = 'descendant';
+
+      var expressApp = createAppWithRoute({
+        name: name,
+        route: route,
+        handler: function(req, res) {
+          xray.captureAsyncFunc(subsegmentName, (subsegment) => {
+            setTimeout(() => {
+              subsegment.close();
+              res.status(200).end();
+            }, 0);
+          });
+        }
+      });
+  
+      var server = expressApp.listen(0, () => {
+        var url = 'http://127.0.0.1:' + server.address().port + route;
+  
+        // wait for the express response, and the daemon to receive messages
+        Promise.all([triggerEndpoint(url), daemonMessagesResolved])
+        .then((data) => {
+          var result = data[0];
+          var messages = data[1];
+  
+          assert.equal(result.status, 200);
+          assert.equal(messages.length, 1);
+          
+          // verify the Segment is valid
+          var segment = parseMessage(messages[0]);
+          validateExpressSegment(segment, {
+            name: name,
+            responseStatus: result.status,
+            url: url
+          });
+  
+          assert.equal(segment.subsegments.length, 1);
+          assert.equal(segment.subsegments[0].name, subsegmentName);
+          done();
+        }).catch(done);
+      });
+    });
+  });
+
+  describe('manual mode', () => {
+    before(() => {
+      xray.enableManualMode();
+    });
+
+    it('supports segment retrieval', (done) => {
+      // resolve promise once expected number of messages received by daemon
+      var daemonMessagesResolved = new Promise((resolve) => {
+        daemon.on('message', messageCounter(1, resolve));
+      });
+  
+      var route = '/';
+      var name = 'test';
+      var expressSegment;
+
+      var expressApp = createAppWithRoute({
+        name: name,
+        route: route,
+        handler: function(req, res) {
+          expressSegment = req.segment;
+          res.status(200).end();
+        }
+      });
+  
+      var server = expressApp.listen(0, () => {
+        var url = 'http://127.0.0.1:' + server.address().port + route;
+  
+        // wait for the express response, and the daemon to receive messages
+        Promise.all([triggerEndpoint(url), daemonMessagesResolved])
+        .then((data) => {
+          var result = data[0];
+          var messages = data[1];
+  
+          assert.equal(result.status, 200);
+          assert.equal(messages.length, 1);
+          
+          // verify the Segment is valid
+          var segment = parseMessage(messages[0]);
+          validateExpressSegment(segment, {
+            name: name,
+            responseStatus: result.status,
+            url: url
+          });
+  
+          // verify segment retrieved from express handler
+          assert.isDefined(expressSegment);
+          assert.equal(expressSegment.id, segment.id);
+
+          done();
+        }).catch(done);
+      });
+    });
+
+    it('supports segment annotations', (done) => {
+      // resolve promise once expected number of messages received by daemon
+      var daemonMessagesResolved = new Promise((resolve) => {
+        daemon.on('message', messageCounter(1, resolve));
+      });
+  
+      var route = '/';
+      var name = 'test';
+      var expressSegment;
+
+      var expressApp = createAppWithRoute({
+        name: name,
+        route: route,
+        handler: function(req, res) {
+          expressSegment = req.segment;
+          expressSegment.addAnnotation('foo', 'bar');
+          res.status(200).end();
+        }
+      });
+  
+      var server = expressApp.listen(0, () => {
+        var url = 'http://127.0.0.1:' + server.address().port + route;
+  
+        // wait for the express response, and the daemon to receive messages
+        Promise.all([triggerEndpoint(url), daemonMessagesResolved])
+        .then((data) => {
+          var result = data[0];
+          var messages = data[1];
+  
+          assert.equal(result.status, 200);
+          assert.equal(messages.length, 1);
+          
+          // verify the Segment is valid
+          var segment = parseMessage(messages[0]);
+          validateExpressSegment(segment, {
+            name: name,
+            responseStatus: result.status,
+            url: url
+          });
+  
+          // verify segment retrieved from express handler
+          assert.isDefined(expressSegment);
+          assert.equal(expressSegment.id, segment.id);
+          assert.deepEqual(segment.annotations, {foo: 'bar'});
+          done();
+        }).catch(done);
+      });
+    });
+
+    it('supports segment metadata', (done) => {
+      // resolve promise once expected number of messages received by daemon
+      var daemonMessagesResolved = new Promise((resolve) => {
+        daemon.on('message', messageCounter(1, resolve));
+      });
+  
+      var route = '/';
+      var name = 'test';
+      var expressSegment;
+
+      var expressApp = createAppWithRoute({
+        name: name,
+        route: route,
+        handler: function(req, res) {
+          expressSegment = req.segment;
+          expressSegment.addMetadata('foo', 'bar');
+          res.status(200).end();
+        }
+      });
+  
+      var server = expressApp.listen(0, () => {
+        var url = 'http://127.0.0.1:' + server.address().port + route;
+  
+        // wait for the express response, and the daemon to receive messages
+        Promise.all([triggerEndpoint(url), daemonMessagesResolved])
+        .then((data) => {
+          var result = data[0];
+          var messages = data[1];
+  
+          assert.equal(result.status, 200);
+          assert.equal(messages.length, 1);
+          
+          // verify the Segment is valid
+          var segment = parseMessage(messages[0]);
+          validateExpressSegment(segment, {
+            name: name,
+            responseStatus: result.status,
+            url: url
+          });
+  
+          // verify segment retrieved from express handler
+          assert.isDefined(expressSegment);
+          assert.equal(expressSegment.id, segment.id);
+          assert.deepEqual(segment.metadata, {default: {foo: 'bar'}});
+          done();
+        }).catch(done);
+      });
+    });
+
+    it('supports captureFunc', (done) => {
+      // resolve promise once expected number of messages received by daemon
+      var daemonMessagesResolved = new Promise((resolve) => {
+        daemon.on('message', messageCounter(1, resolve));
+      });
+  
+      var route = '/';
+      var name = 'test';
+      var subsegmentName = 'descendant';
+
+      var expressApp = createAppWithRoute({
+        name: name,
+        route: route,
+        handler: function(req, res) {
+          xray.captureFunc(subsegmentName, () => {/* just generate a subsegment */}, req.segment);
+          res.status(200).end();
+        }
+      });
+  
+      var server = expressApp.listen(0, () => {
+        var url = 'http://127.0.0.1:' + server.address().port + route;
+  
+        // wait for the express response, and the daemon to receive messages
+        Promise.all([triggerEndpoint(url), daemonMessagesResolved])
+        .then((data) => {
+          var result = data[0];
+          var messages = data[1];
+  
+          assert.equal(result.status, 200);
+          assert.equal(messages.length, 1);
+          
+          // verify the Segment is valid
+          var segment = parseMessage(messages[0]);
+          validateExpressSegment(segment, {
+            name: name,
+            responseStatus: result.status,
+            url: url
+          });
+  
+          assert.equal(segment.subsegments.length, 1);
+          assert.equal(segment.subsegments[0].name, subsegmentName);
+          done();
+        }).catch(done);
+      });
+    });
+
+    it('supports captureAsyncFunc', (done) => {
+      // resolve promise once expected number of messages received by daemon
+      var daemonMessagesResolved = new Promise((resolve) => {
+        daemon.on('message', messageCounter(1, resolve));
+      });
+  
+      var route = '/';
+      var name = 'test';
+      var subsegmentName = 'descendant';
+
+      var expressApp = createAppWithRoute({
+        name: name,
+        route: route,
+        handler: function(req, res) {
+          xray.captureAsyncFunc(subsegmentName, (subsegment) => {
+            setTimeout(() => {
+              subsegment.close();
+              res.status(200).end();
+            }, 0);
+          }, req.segment);
+        }
+      });
+  
+      var server = expressApp.listen(0, () => {
+        var url = 'http://127.0.0.1:' + server.address().port + route;
+  
+        // wait for the express response, and the daemon to receive messages
+        Promise.all([triggerEndpoint(url), daemonMessagesResolved])
+        .then((data) => {
+          var result = data[0];
+          var messages = data[1];
+  
+          assert.equal(result.status, 200);
+          assert.equal(messages.length, 1);
+          
+          // verify the Segment is valid
+          var segment = parseMessage(messages[0]);
+          validateExpressSegment(segment, {
+            name: name,
+            responseStatus: result.status,
+            url: url
+          });
+  
+          assert.equal(segment.subsegments.length, 1);
+          assert.equal(segment.subsegments[0].name, subsegmentName);
+          done();
+        }).catch(done);
+      });
     });
   });
 });

--- a/packages/test_express/test/helpers.js
+++ b/packages/test_express/test/helpers.js
@@ -37,6 +37,14 @@ function messageCounter(expectedCount, callback) {
   }
 }
 
+function parseMessage(message) {
+  message = message.toString();
+  var parts = message.split('\n');
+  assert.equal(parts.length, 2, 'Daemon message should contain a protocol and a segment document.');
+  // parse the Segment document
+  return JSON.parse(parts[1]);
+}
+
 /**
  * @param {string} url 
  */
@@ -58,12 +66,23 @@ function triggerEndpoint(url) {
   });
 }
 
-function parseMessage(message) {
-  message = message.toString();
-  var parts = message.split('\n');
-  assert.equal(parts.length, 2, 'Daemon message should contain a protocol and a segment document.');
-  // parse the Segment document
-  return JSON.parse(parts[1]);
+/**
+ * 
+ * @param {*} segment 
+ * @param {object} expectedFields
+ * @param {string} expectedFields.name Segment name
+ * @param {number} expectedFields.responseStatus Express response status code
+ * @param {string} expectedFields.url Express route url
+ */
+function validateExpressSegment(segment, expectedFields) {
+  assert.equal(segment.name, expectedFields.name);
+  assert.isNumber(segment.end_time);
+  assert.isNumber(segment.start_time);
+  assert.equal(segment.http.request.method, 'GET');
+  assert.isString(segment.http.request.client_ip);
+  assert.equal(segment.http.request.url, expectedFields.url);
+  assert.equal(segment.http.response.status, expectedFields.responseStatus);
+  assert.isString(segment.trace_id);
 }
 
 module.exports = {
@@ -71,5 +90,6 @@ module.exports = {
   createDaemon: createDaemon,
   messageCounter: messageCounter,
   parseMessage: parseMessage,
-  triggerEndpoint: triggerEndpoint
+  triggerEndpoint: triggerEndpoint,
+  validateExpressSegment: validateExpressSegment
 };

--- a/packages/test_express/test/helpers.js
+++ b/packages/test_express/test/helpers.js
@@ -1,0 +1,75 @@
+var dgram = require('dgram');
+var xray = require('aws-xray-sdk-core');
+var xrayExpress = require('aws-xray-sdk-express');
+var express = require('express');
+var http = require('http');
+var assert = require('chai').assert;
+
+/**
+ * @param {object} options 
+ * @param {string} options.dynamicPattern
+ * @param {Function} options.handler
+ * @param {string} options.name
+ * @param {string} options.route
+ */
+function createAppWithRoute(options) {
+  var app = express();
+  if (options.dynamicPattern) {
+    xray.middleware.enableDynamicNaming(options.dynamicPattern);
+  }
+  app.use(xrayExpress.openSegment(options.name));
+  app.use(options.route, options.handler);
+  app.use(xrayExpress.closeSegment());
+  return app;
+}
+
+function createDaemon() {
+  return dgram.createSocket('udp4');
+}
+
+function messageCounter(expectedCount, callback) {
+  var messages = [];
+  return (message) => {
+    messages.push(message);
+    if (messages.length == expectedCount) {
+      return callback(messages);
+    } 
+  }
+}
+
+/**
+ * @param {string} url 
+ */
+function triggerEndpoint(url) {
+  return new Promise((resolve, reject) => {
+    http.get(url, (response) => {
+      var chunks = [];
+      response.on('data', (chunk) => {
+        chunks.push(chunk);
+      });
+
+      response.on('end', () => {
+        resolve({
+          body: Buffer.concat(chunks).toString(),
+          status: response.statusCode
+        });
+      });
+    }).on('error', reject);
+  });
+}
+
+function parseMessage(message) {
+  message = message.toString();
+  var parts = message.split('\n');
+  assert.equal(parts.length, 2, 'Daemon message should contain a protocol and a segment document.');
+  // parse the Segment document
+  return JSON.parse(parts[1]);
+}
+
+module.exports = {
+  createAppWithRoute: createAppWithRoute,
+  createDaemon: createDaemon,
+  messageCounter: messageCounter,
+  parseMessage: parseMessage,
+  triggerEndpoint: triggerEndpoint
+};


### PR DESCRIPTION
*Description of changes:*
Adds integration tests that can run as part of travis builds. This will help catch more issues that the unit tests miss due to mocking/stubbing classes.

Currently adds the `test_express` package. This package is marked as `private` so lerna will ignore it when publishing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
