### PR TITLE
bugfix(express): express middleware closes segments when client request cancelled

### DIFF
--- a/packages/express/lib/express_mw.js
+++ b/packages/express/lib/express_mw.js
@@ -43,7 +43,7 @@ var expressMW = {
       AWSXRay.getLogger().debug('Starting express segment: { url: ' + req.url + ', name: ' + segment.name + ', trace_id: ' +
         segment.trace_id + ', id: ' + segment.id + ', sampled: ' + !segment.notTraced + ' }');
 
-      res.on('finish', function () {
+      var endSegment = function () {
         if (this.statusCode === 429)
           segment.addThrottleFlag();
         if (AWSXRay.utils.getCauseTypeFromHttpStatus(this.statusCode))
@@ -54,7 +54,10 @@ var expressMW = {
 
         AWSXRay.getLogger().debug('Closed express segment successfully: { url: ' + req.url + ', name: ' + segment.name + ', trace_id: ' +
           segment.trace_id + ', id: ' + segment.id + ', sampled: ' + !segment.notTraced + ' }');
-      });
+      };
+
+      res.on('finish', endSegment);
+      res.on('close', endSegment);
 
       if (AWSXRay.isAutomaticMode()) {
         var ns = AWSXRay.getNamespace();

--- a/packages/express/test/unit/express_mw.test.js
+++ b/packages/express/test/unit/express_mw.test.js
@@ -115,11 +115,12 @@ describe('Express middleware', function() {
         addReqDataSpy.should.have.been.calledWithExactly(sinon.match.instanceOf(IncomingRequestData));
       });
 
-      it('should add a finish event to the response', function() {
+      it('should add a finish and close event to the response', function() {
         open(req, res);
 
-        onEventStub.should.have.been.calledOnce;
+        onEventStub.should.have.been.calledTwice;
         onEventStub.should.have.been.calledWithExactly('finish', sinon.match.typeOf('function'));
+        onEventStub.should.have.been.calledWithExactly('close', sinon.match.typeOf('function'));
       });
     });
 

--- a/packages/test_express/test/express.js
+++ b/packages/test_express/test/express.js
@@ -10,7 +10,9 @@ var parseMessage = require('./helpers').parseMessage;
 var sleep = require('./helpers').sleep;
 var sleepDedupe = require('./helpers').sleepDedupe;
 var triggerEndpoint = require('./helpers').triggerEndpoint;
+var triggerEndpointWithTimeout = require('./helpers').triggerEndpointWithTimeout;
 var validateExpressSegment = require('./helpers').validateExpressSegment;
+var ShakyStream = require('./shaky_stream').ShakyStream;
 
 var chai = require('chai');
 var assert = chai.assert;
@@ -382,6 +384,58 @@ describe('Express', () => {
   
           assert.equal(segment.subsegments.length, 1);
           assert.equal(segment.subsegments[0].name, subsegmentName);
+          done();
+        }).catch(done);
+      });
+    });
+
+    it('supports aborted client-side requests', (done) => {
+      // resolve promise once expected number of messages received by daemon
+      var daemonMessagesResolved = new Promise((resolve) => {
+        daemon.on('message', messageCounter(1, resolve));
+      });
+  
+      var route = '/';
+      var name = 'test';
+      var expressSegment;
+
+      var expressApp = createAppWithRoute({
+        name: name,
+        route: route,
+        handler: function(req, res) {
+          expressSegment = xray.getSegment();
+          var slowStream = new ShakyStream({
+            pauseFor: 4000
+          });
+          res.status(200);
+          slowStream.pipe(res);
+        }
+      });
+  
+      var server = expressApp.listen(0, () => {
+        var url = 'http://127.0.0.1:' + server.address().port + route;
+  
+        // wait for the express response, and the daemon to receive messages
+        Promise.all([triggerEndpointWithTimeout(url, 100), daemonMessagesResolved])
+        .then((data) => {
+          var result = data[0];
+          var messages = data[1];
+  
+          assert.equal(result.status, 200);
+          assert.equal(messages.length, 1);
+          
+          // verify the Segment is valid
+          var segment = parseMessage(messages[0]);
+          validateExpressSegment(segment, {
+            name: name,
+            responseStatus: result.status,
+            url: url
+          });
+  
+          // verify segment retrieved from express handler
+          assert.isDefined(expressSegment);
+          assert.equal(expressSegment.id, segment.id);
+
           done();
         }).catch(done);
       });

--- a/packages/test_express/test/helpers.js
+++ b/packages/test_express/test/helpers.js
@@ -101,22 +101,23 @@ function triggerEndpoint(url, waitFor) {
  */
 function triggerEndpointWithTimeout(url, timeoutAfter) {
     return new Promise((resolve, reject) => {
+        var result = {};
         var request = http.get(url, (response) => {
+            result.status = response.statusCode;
             var chunks = [];
             response.on('data', (chunk) => {
                 chunks.push(chunk);
             });
 
             response.on('end', () => {
-                resolve({
-                    body: Buffer.concat(chunks).toString(),
-                    status: response.statusCode
-                });
+                result.body = Buffer.concat(chunks).toString();
+                resolve(result);
             });
         }).on('error', reject);
         request.setTimeout(timeoutAfter || 0, function () {
             // response.end should be triggered
             this.socket.end();
+            resolve(result);
         });
     });
 }

--- a/packages/test_express/test/helpers.js
+++ b/packages/test_express/test/helpers.js
@@ -96,6 +96,32 @@ function triggerEndpoint(url, waitFor) {
 }
 
 /**
+ * @param {string} url 
+ * @param {number} timeoutAfter Amount of time in ms to wait before aborting request
+ */
+function triggerEndpointWithTimeout(url, timeoutAfter) {
+    return new Promise((resolve, reject) => {
+        var request = http.get(url, (response) => {
+            var chunks = [];
+            response.on('data', (chunk) => {
+                chunks.push(chunk);
+            });
+
+            response.on('end', () => {
+                resolve({
+                    body: Buffer.concat(chunks).toString(),
+                    status: response.statusCode
+                });
+            });
+        }).on('error', reject);
+        request.setTimeout(timeoutAfter || 0, function () {
+            // response.end should be triggered
+            this.socket.end();
+        });
+    });
+}
+
+/**
  * 
  * @param {*} segment 
  * @param {object} expectedFields
@@ -123,5 +149,6 @@ module.exports = {
     sleep: sleep,
     sleepDedupe: sleepDedupe,
     triggerEndpoint: triggerEndpoint,
+    triggerEndpointWithTimeout: triggerEndpointWithTimeout,
     validateExpressSegment: validateExpressSegment
 };

--- a/packages/test_express/test/shaky_stream.js
+++ b/packages/test_express/test/shaky_stream.js
@@ -1,0 +1,46 @@
+var stream = require('stream');
+var util = require('util');
+
+var Readable = stream.Readable;
+
+var timeoutFn = typeof setTimeoutOrig === 'function' ? setTimeoutOrig : setTimeout;
+
+/**
+ * ShakyStream will send data in 2 parts, pausing between parts.
+ * @param {object} options
+ * @param {number} options.pauseFor Length of time in ms to pause stream when reading.
+ */
+function ShakyStream(options) {
+    if (!(this instanceof ShakyStream)) {
+        return new ShakyStream(options);
+    }
+    if (!options.highWaterMark) {
+        options.highWaterMark = 1024 * 16;
+    }
+    this._shakyTime = options.pauseFor;
+    this._didStart = false;
+    this._isPaused = false;
+
+    Readable.call(this, options);
+}
+
+util.inherits(ShakyStream, Readable);
+
+ShakyStream.prototype._read = function _read(_) {
+    if (!this._didStart) {
+        this._didStart = true;
+        this.push(Buffer.from('{"Count":1,"Items":[{"id":{"S":"2016-12-11"},"dateUTC":{"N":"1481494545591"},'));
+    }
+    if (this._didStart && this._isPaused) {
+        return;
+    } else if (this._didStart) {
+        this._isPaused = true;
+        var self = this;
+        timeoutFn(function() {
+            self.push(Buffer.from('"javascript":{"M":{"foo":{"S":"bar"},"baz":{"S":"buz"}}}}],"ScannedCount":1}'));
+            self.push(null);
+        }, this._shakyTime);
+    }
+};
+
+module.exports = {ShakyStream: ShakyStream};


### PR DESCRIPTION
*Issue #, if available:*
#104 

*Description of changes:*
Updates express middleware to end segments on a ServerResponse `close` event, in addition to `finish` event. In node.js 10.x and lower, `close` is emitted if the client's connection is closed prior to the response `end` method being called. In node.js 11.x and higher, `close` is always called.

Alternatively we could listen to the request's `aborted` event, but this method allows us to use the same `endSegment` function for the aborted and completed scenarios, so I preferred this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
