### PR TITLE
chore: add node.js 12 to travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
   - "6"
   - "8"
   - "10"
+  - "12"
   - "node"
 
 sudo: false

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 ## Installing
 
 The AWS X-Ray SDK for Node.js is compatible with Node.js version 4 and later.
-The AWS X-Ray SDK for Node.js has been tested with versions 4.x through 11.x of Node.js.
-There may be issues when running on versions of Node.js newer than 11.x.
+The AWS X-Ray SDK for Node.js has been tested with versions 4.x through 12.x of Node.js.
+There may be issues when running on versions of Node.js newer than 12.x.
 
 The SDK is available from NPM. For local development, install the SDK in your project directory with npm.
 


### PR DESCRIPTION
*Description of changes:*
Adds node.js 12 to the travis build matrix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
