### PR TITLE
fix: keep Query instances passed to connection.query intact

### DIFF
--- a/packages/mysql/lib/mysql_p.js
+++ b/packages/mysql/lib/mysql_p.js
@@ -143,6 +143,7 @@ function resolveArguments(argsObj) {
       args.sql = argsObj[0].sql;
       args.values = argsObj[0].values;
       args.callback = argsObj[1];
+      if (!argsObj[1] && argsObj[0].on instanceof Function) args.sql = argsObj[0];
     } else {
       args.sql = argsObj[0];
       args.values = typeof argsObj[1] !== 'function' ? argsObj[1] : null;


### PR DESCRIPTION
*Issue #, if available:* #136

*Description of changes:*

Preserves the first argument of resolveArguments when it is an Object and no callback(2nd argument) has been provided. This because in the case described in https://github.com/aws/aws-xray-sdk-node/issues/136#issuecomment-490763147 it's relying on the eventEmitter that's in the Mysql.Query instance provided in the first argument.

Since resolveArguments part where the first argument is an object part was added in #62, I would like to ask @jafl whether he remembers what case (presumably in mysql2) this was added, so we can check whether that would still pass as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.