### PR TITLE
Reduce aws-sdk version down to the version packaged with Lambda 8.10

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "atomic-batcher": "^1.0.2",
-    "aws-sdk": "^2.304.0",
+    "aws-sdk": "^2.290.0",
     "continuation-local-storage": "^3.2.0",
     "date-fns": "^1.29.0",
     "lodash": "^4.17.11",


### PR DESCRIPTION
When people deploy to AWS Lambda, they often exclude uploading the aws-sdk package since the Lambda runtime already includes a copy. I've been doing this for a while now and the AWS X-Ray package works fine. The only minor problem is that npm can complain when trying for force all packages to use the Lambda aws-sdk version using "resolutions" in package.json because the x-ray library claims to need a higher version.

I don't believe this package needs the higher version it claims to, and so reducing the package version will make it clear that this library is compatible with Lambda Node 8.10's builtin runtime.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
