### PR TITLE
Updated eslint dev dependecy to v4.18.2 to fix the security vulnerability.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "aws-xray-sdk-core": "^2.0.1",
     "chai": "^3.5.0",
-    "eslint": "^3.10.2",
+    "eslint": "^4.18.2",
     "grunt": "^1.0.3",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-jsdoc": "^2.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "eslint": "^3.10.2",
+    "eslint": "^4.18.2",
     "grunt": "^1.0.3",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-jsdoc": "^2.1.0",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "aws-xray-sdk-core": "^2.3.3",
     "chai": "^3.5.0",
-    "eslint": "^3.10.2",
+    "eslint": "^4.18.2",
     "grunt": "^1.0.3",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-jsdoc": "^2.1.0",

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "aws-xray-sdk-core": "^2.3.3",
     "chai": "^3.5.0",
-    "eslint": "^3.10.2",
+    "eslint": "^4.18.2",
     "grunt": "^1.0.3",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-jsdoc": "^2.1.0",

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "aws-xray-sdk-core": "^2.3.3",
     "chai": "^3.5.0",
-    "eslint": "^3.10.2",
+    "eslint": "^4.18.2",
     "grunt": "^1.0.3",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-jsdoc": "^2.1.0",

--- a/packages/restify/package.json
+++ b/packages/restify/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "aws-xray-sdk-core": "^2.3.3",
     "chai": "^3.5.0",
-    "eslint": "^3.10.2",
+    "eslint": "^4.18.2",
     "mocha": "^3.0.2",
     "sinon": "^1.17.5",
     "sinon-chai": "^2.8.0"

--- a/packages/test_express/package.json
+++ b/packages/test_express/package.json
@@ -19,7 +19,7 @@
     "aws-xray-sdk-express": "^2.3.3",
     "chai": "^3.5.0",
     "cls-hooked": "^4.2.2",
-    "eslint": "^3.10.2",
+    "eslint": "^4.18.2",
     "express": "^4.16.4",
     "mocha": "^3.0.2"
   },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
