### PR TITLE
Segment Emitter, remove unsafe Buffer method

### DIFF
--- a/packages/core/lib/segment_emitter.js
+++ b/packages/core/lib/segment_emitter.js
@@ -122,7 +122,7 @@ var SegmentEmitter = {
     var client = this.socket;
     var formatted = segment.format();
     var data = PROTOCOL_HEADER + PROTOCOL_DELIMITER + formatted;
-    var message = new Buffer(data);
+    var message = Buffer.from(data);
 
     var short = '{"trace_id:"' + segment.trace_id + '","id":"' + segment.id + '"}';
     var type = segment.type === 'subsegment' ? 'Subsegment' : 'Segment';


### PR DESCRIPTION
No Issue

the Segment_emitter used the deprecated `New Buffer(data)` constructor which caused warnings on newer Node runtimes, and is noise in CloudWatch Logs.

> [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

One buffer is used, and this has been replaced by the newer `Buffer.from(data)` construct.

This solution will not work for node version prior to 6: it's a simple replacement rather than a more complicated backwards compatible solution [Detailed here](https://nodejs.org/fa/docs/guides/buffer-constructor-deprecation/#variant-3).

Given that AWS only supports 8.10 or 10.x, I submit this anyway, and you can take a decision is compatibility is of concern.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.