### PR TITLE
Add logger.debug for lambda

### DIFF
--- a/packages/core/lib/logger.js
+++ b/packages/core/lib/logger.js
@@ -22,6 +22,7 @@ if (process.env.LAMBDA_TASK_ROOT) {
   logger.error = function(string) { console.error(string); };
   logger.info = function(string) { console.info(string); };
   logger.warn = function(string) { console.warn(string); };
+  logger.debug = function(string) { console.debug(string); };
 }
 /* eslint-enable no-console */
 


### PR DESCRIPTION

*Description of changes:*
I'm assuming that there are lambda-specific logging overrides due to [this winston issue with the Console transport](https://github.com/winstonjs/winston/issues/1544#issuecomment-472199224). This is also affecting `logger.debug`.

Without this, none of the built-in `logger.debug()` calls are showing up in cloudwatch logs when `AWS_XRAY_DEBUG_MODE=1` is set on a lambda function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
