### PR TITLE
chore: prepares 2.3.4 release

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog for AWS X-Ray Core SDK for JavaScript
-<!--LATEST=2.3.3-->
+<!--LATEST=2.3.4-->
 <!--ENTRYINSERT-->
+## 2.3.4
+* improvement: Updated eslint dev dependency: [PR #145](https://github.com/aws/aws-xray-sdk-node/pull/145)
+* improvement: Updated .eslintrc.json to enable es6 and fixed eslint errors: [PR #146](https://github.com/aws/aws-xray-sdk-node/pull/146)
+* improvement: Updated nock,mocha dependencies to fix lodash version: [PR #153](https://github.com/aws/aws-xray-sdk-node/pull/153)
+
 ## 2.3.3
 * bugfix: adds workaround for missing cls namespace when cls-hooked imported. [#PR126](https://github.com/aws/aws-xray-sdk-node/pull/126)
 * bugfix: no longer creates pending subsegments for AWS presigned url operations. [#PR130](https://github.com/aws/aws-xray-sdk-node/pull/130)

--- a/packages/express/CHANGELOG.md
+++ b/packages/express/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog for AWS X-Ray SDK Express for JavaScript
-<!--LATEST=2.3.3-->
+<!--LATEST=2.3.4-->
 <!--ENTRYINSERT-->
+## 2.3.4
+* improvement: Updated eslint dev dependency: [PR #145](https://github.com/aws/aws-xray-sdk-node/pull/145)
+* improvement: Updated .eslintrc.json to enable es6 and fixed eslint errors: [PR #146](https://github.com/aws/aws-xray-sdk-node/pull/146)
+* improvement: Updated nock,mocha,sinon dependencies to fix lodash version: [PR #153](https://github.com/aws/aws-xray-sdk-node/pull/153)
+
 ## 2.3.3
 * bugfix(express): express middleware closes segments when client request cancelled. [PR#128](https://github.com/aws/aws-xray-sdk-node/pull/128)
 

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -14,7 +14,7 @@
     "test": "test"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^2.3.3"
+    "aws-xray-sdk-core": "^2.3.4"
   },
   "devDependencies": {
     "aws-xray-sdk-core": "^2.3.3",

--- a/packages/full_sdk/CHANGELOG.md
+++ b/packages/full_sdk/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog for AWS X-Ray SDK for JavaScript
-<!--LATEST=2.3.3-->
+<!--LATEST=2.3.4-->
 <!--ENTRYINSERT-->
+## 2.3.4
+* change: Updated .eslintrc.json to enable es6 and fixed eslint errors: [PR #146](https://github.com/aws/aws-xray-sdk-node/pull/146)
+* change: Updated aws-xray-sdk-core to 2.3.4. See aws-xray-sdk-core's CHANGELOG.md for package changes.
+* change: Updated aws-xray-sdk-express to 2.3.4. See aws-xray-sdk-express's CHANGELOG.md for package changes.
+* change: Updated aws-xray-sdk-mysql to 2.3.4.
+  * improvement: Updated eslint dev dependency: [PR #145](https://github.com/aws/aws-xray-sdk-node/pull/145)
+  * improvement: Updated .eslintrc.json to enable es6 and fixed eslint errors: [PR #146](https://github.com/aws/aws-xray-sdk-node/pull/146)
+  * improvement: Updated nock,mocha,sinon dependencies to fix lodash version: [PR #153](https://github.com/aws/aws-xray-sdk-node/pull/153)
+* change: Updated aws-xray-postgres to 2.3.4
+  * improvement: Updated eslint dev dependency: [PR #145](https://github.com/aws/aws-xray-sdk-node/pull/145)
+  * improvement: Updated .eslintrc.json to enable es6 and fixed eslint errors: [PR #146](https://github.com/aws/aws-xray-sdk-node/pull/146)
+  * improvement: Updated nock,mocha,sinon dependencies to fix lodash version: [PR #153](https://github.com/aws/aws-xray-sdk-node/pull/153)
+
 ## 2.3.3
 * change: Updated aws-xray-sdk-core to 2.3.3. See aws-xray-sdk-core's CHANGELOG.md for package changes.
 * change: Updated aws-xray-sdk-express to 2.3.3. See aws-xray-sdk-express's CHANGELOG.md for package changes.

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -14,7 +14,7 @@
     "test": "test"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^2.3.3"
+    "aws-xray-sdk-core": "^2.3.4"
   },
   "devDependencies": {
     "aws-xray-sdk-core": "^2.3.3",

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -14,7 +14,7 @@
     "test": "test"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^2.3.3"
+    "aws-xray-sdk-core": "^2.3.4"
   },
   "devDependencies": {
     "aws-xray-sdk-core": "^2.3.3",

--- a/packages/restify/package.json
+++ b/packages/restify/package.json
@@ -14,7 +14,7 @@
     "test": "test"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^2.3.3"
+    "aws-xray-sdk-core": "^2.3.4"
   },
   "devDependencies": {
     "aws-xray-sdk-core": "^2.3.3",


### PR DESCRIPTION
*Description of changes:*
Stages the version 2.3.4 SDK release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
