### PR TITLE
Dont reference node_modules

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,7 @@
     "sinon-chai": "^2.8.0"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha --recursive ./test/ -R spec"
+    "test": "mocha --recursive ./test/ -R spec"
   },
   "keywords": [
     "amazon",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -29,7 +29,7 @@
     "sinon-chai": "^2.8.0"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha --recursive ./test/ -R spec"
+    "test": "mocha --recursive ./test/ -R spec"
   },
   "keywords": [
     "amazon",

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -29,7 +29,7 @@
     "sinon-chai": "^2.8.0"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha --recursive ./test/ -R spec"
+    "test": "mocha --recursive ./test/ -R spec"
   },
   "keywords": [
     "amazon",

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -29,7 +29,7 @@
     "sinon-chai": "^2.8.0"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha --recursive ./test/ -R spec"
+    "test": "mocha --recursive ./test/ -R spec"
   },
   "keywords": [
     "amazon",

--- a/packages/restify/package.json
+++ b/packages/restify/package.json
@@ -25,7 +25,7 @@
     "sinon-chai": "^2.8.0"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha --recursive ./test/ -R spec"
+    "test": "mocha --recursive ./test/ -R spec"
   },
   "keywords": [
     "amazon",

--- a/packages/test_express/package.json
+++ b/packages/test_express/package.json
@@ -24,7 +24,7 @@
     "mocha": "^3.5.3"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha --recursive ./test/ -R spec"
+    "test": "mocha --recursive ./test/ -R spec"
   },
   "keywords": [
     "amazon",


### PR DESCRIPTION
This change follows best practices of not directly referencing node_modules subdirectory

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
