### PR TITLE
Add log level setting

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -80,6 +80,7 @@ below for the different usages.
     with the middleware. See 'dynamic and fixed naming modes'.
     AWS_XRAY_DAEMON_ADDRESS          For setting the daemon address and port.
     AWS_XRAY_CONTEXT_MISSING         For setting the SDK behavior when trace context is missing. Valid values are 'RUNTIME_ERROR' or 'LOG_ERROR'. The SDK's default behavior is 'RUNTIME_ERROR'.
+    AWS_XRAY_LOG_LEVEL               Sets a log level for the SDK built in logger.
 
 ### Daemon configuration
 
@@ -94,7 +95,11 @@ You can change this via the environment variables listed above, or through code.
 ### Logging configuration
 
 Default logging to a file has been removed. To set up file logging, configure a logger
-that responds to debug, info, warn, and error functions.
+that responds to debug, info, warn, and error functions. To suppress logs such as context setup the log level can be
+overridden, e.g. to suppress info logs such as context and daemon config set the following environment variable.  
+
+    AWS_XRAY_LOG_LEVEL='error'
+
 To log information about configuration, be sure you set the logger before other configuration
 options.
 

--- a/packages/core/lib/logger.js
+++ b/packages/core/lib/logger.js
@@ -2,6 +2,7 @@ var winston = require('winston');
 var format = require('date-fns/format');
 
 var logger;
+var xrayLogLevel = process.env.AWS_XRAY_LOG_LEVEL;
 
 if (process.env.AWS_XRAY_DEBUG_MODE) {
   logger = new (winston.Logger)({
@@ -9,6 +10,16 @@ if (process.env.AWS_XRAY_DEBUG_MODE) {
       new (winston.transports.Console)({
         formatter: outputFormatter,
         level: 'debug',
+        timestamp: timestampFormatter
+      })
+    ]
+  });
+} else if (xrayLogLevel) {
+  logger = new (winston.Logger)({
+    transports: [
+      new (winston.transports.Console)({
+        formatter: outputFormatter,
+        level: xrayLogLevel,
         timestamp: timestampFormatter
       })
     ]

--- a/packages/core/test/unit/logger.test.js
+++ b/packages/core/test/unit/logger.test.js
@@ -1,0 +1,39 @@
+var assert = require('chai').assert;
+
+var logger = require('../../lib/logger');
+
+describe('logger', function () {
+  function reloadLogger() {
+    var path = '../../lib/logger';
+    delete require.cache[require.resolve(path)];
+    logger = require(path);
+  }
+
+  describe('defaults', function () {
+    afterEach(function () {
+      delete process.env.AWS_XRAY_DEBUG_MODE;
+      reloadLogger();
+
+    });
+    it('Should have a default logger with no transport and level set to info', function () {
+      assert.deepEqual(logger.getLogger().transports, {});
+      assert.equal(logger.getLogger().level, 'info');
+    });
+    it('Should have a logger with console transport with level set to debug when AWS_XRAY_DEBUG_MODE is set', function () {
+      process.env.AWS_XRAY_DEBUG_MODE = 'set';
+      reloadLogger();
+      assert.equal(logger.getLogger().transports.console.level, 'debug');
+    });
+    it('Should have a logger with console transport with level set to debug when AWS_XRAY_DEBUG_MODE is set even when XRAY_LOG_LEVEL is error', function () {
+      process.env.AWS_XRAY_DEBUG_MODE = 'set';
+      process.env.AWS_XRAY_LOG_LEVEL = 'error';
+      reloadLogger();
+      assert.equal(logger.getLogger().transports.console.level, 'debug');
+    });
+    it('Should have a logger with console transport with level set to error when AWS_XRAY_LOG_LEVEL=error and AWS_XRAY_DEBUG_MODE is not set', function () {
+      process.env.AWS_XRAY_LOG_LEVEL = 'error';
+      reloadLogger();
+      assert.equal(logger.getLogger().transports.console.level, 'error');
+    });
+  });
+});

--- a/packages/core/test/unit/logger.test.js
+++ b/packages/core/test/unit/logger.test.js
@@ -16,6 +16,9 @@ describe('logger', function () {
 
     });
     it('Should have a default logger with no transport and level set to info', function () {
+      process.env.AWS_XRAY_LOG_LEVEL = '';
+      process.env.AWS_XRAY_DEBUG_MODE = '';
+      reloadLogger();
       assert.deepEqual(logger.getLogger().transports, {});
       assert.equal(logger.getLogger().level, 'info');
     });
@@ -32,6 +35,7 @@ describe('logger', function () {
     });
     it('Should have a logger with console transport with level set to error when AWS_XRAY_LOG_LEVEL=error and AWS_XRAY_DEBUG_MODE is not set', function () {
       process.env.AWS_XRAY_LOG_LEVEL = 'error';
+      process.env.AWS_XRAY_DEBUG_MODE = '';
       reloadLogger();
       assert.equal(logger.getLogger().transports.console.level, 'error');
     });


### PR DESCRIPTION
Attempt to fix #163 
In the lambda execution environment having xray info logs adds noise and
potentially cost, this add the ability to set the log level via
environment variable allowing these to be suppressed.