### PR TITLE
Fixed lambda logging bug

### DIFF
--- a/packages/core/lib/logger.js
+++ b/packages/core/lib/logger.js
@@ -22,7 +22,10 @@ if (process.env.LAMBDA_TASK_ROOT) {
   logger.error = function(string) { console.error(string); };
   logger.info = function(string) { console.info(string); };
   logger.warn = function(string) { console.warn(string); };
-  logger.debug = function(string) { console.debug(string); };
+  
+  if (process.env.AWS_XRAY_DEBUG_MODE) {
+    logger.debug = function(string) { console.debug(string); };
+  }
 }
 /* eslint-enable no-console */
 


### PR DESCRIPTION
*Issue #, if available:*
Addresses bug in #175 

*Description of changes:*
Fixed a bug caused by a previous pull request in which instrumented functions running on Lambda would send all debug messages to CloudWatch logs, even without AWS_XRAY_DEBUG_MODE enabled. This fix will enable debug log level if and only if the user sets the debug mode environment variable.

Tested using sample app.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
