### PR TITLE
make aws-sdk a dev dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,12 +15,14 @@
   },
   "dependencies": {
     "atomic-batcher": "^1.0.2",
-    "aws-sdk": "^2.304.0",
     "continuation-local-storage": "^3.2.0",
     "date-fns": "^1.29.0",
     "pkginfo": "^0.4.0",
     "semver": "^5.3.0",
     "winston": "^2.4.4"
+  },
+  "peerDependencies": {
+    "aws-sdk": "^2.304.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
*Issue #, if available:*
#186 
installs the complete aws-sdk, which increase the size of zipped packages by 7mb

*Description of changes:*
in core package made aws-sdk a devDependency

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
