### PR TITLE
Upgrade of Winston library from version 2.4.4 to 3.2.1

### DIFF
--- a/packages/core/lib/logger.js
+++ b/packages/core/lib/logger.js
@@ -1,5 +1,4 @@
 var winston = require('winston');
-var format = require('date-fns/format');
 
 var logger;
 var xrayLogLevel = process.env.AWS_XRAY_LOG_LEVEL;
@@ -9,7 +8,7 @@ if (process.env.AWS_XRAY_DEBUG_MODE) {
 } else if (xrayLogLevel) {
   logger = createWinstonLogger(xrayLogLevel);
 } else {
-  logger = createWinstonLogger('info', true)
+  logger = createWinstonLogger('info', true);
 }
 
 /* eslint-disable no-console */
@@ -25,7 +24,7 @@ function outputFormatter() {
   return winston.format.printf((info) => {
     return `${info.timestamp} [${info.level.toUpperCase()}] ${info.message}`
       + (info.meta && Object.keys(info.meta).length ? '\n\t'+ JSON.stringify(info.meta) : '' );
-  })
+  });
 }
 
 function createWinstonLogger(level, silent) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
     "date-fns": "^1.29.0",
     "pkginfo": "^0.4.0",
     "semver": "^5.3.0",
-    "winston": "^2.4.4"
+    "winston": "^3.2.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,6 @@
     "atomic-batcher": "^1.0.2",
     "aws-sdk": "^2.304.0",
     "continuation-local-storage": "^3.2.0",
-    "date-fns": "^1.29.0",
     "pkginfo": "^0.4.0",
     "semver": "^5.3.0",
     "winston": "^3.2.1"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,8 @@
     "mocha": "^6.2.0",
     "nock": "^10.0.6",
     "sinon": "^4.5.0",
-    "sinon-chai": "^2.8.0"
+    "sinon-chai": "^2.8.0",
+    "upath": "^1.2.0"
   },
   "scripts": {
     "test": "mocha --recursive ./test/ -R spec"

--- a/packages/core/test/unit/aws-xray.test.js
+++ b/packages/core/test/unit/aws-xray.test.js
@@ -2,6 +2,7 @@ var assert = require('chai').assert;
 var chai = require('chai');
 var sinon = require('sinon');
 var sinonChai = require('sinon-chai');
+var upath = require('upath')
 
 var segmentUtils = require('../../lib/segments/segment_utils');
 
@@ -29,8 +30,9 @@ describe('AWSXRay', function() {
       // This test requires both index.js and aws-xray.js are first time required.
       // We should always clear the require cache for these two files so this test
       // could run independently.
-      Object.keys(require.cache).forEach(function(key) { 
-        if(key.includes('core/lib/index.js') || key.includes('core/lib/aws-xray.js')) {
+      Object.keys(require.cache).forEach(function(key) {
+        var normalisedPath = upath.toUnix(key)
+        if(normalisedPath.includes('core/lib/index.js') || normalisedPath.includes('core/lib/aws-xray.js')) {
           delete require.cache[key];
         }
       });

--- a/packages/core/test/unit/logger.test.js
+++ b/packages/core/test/unit/logger.test.js
@@ -1,4 +1,5 @@
 var assert = require('chai').assert;
+var winston = require('winston');
 
 var logger = require('../../lib/logger');
 
@@ -15,29 +16,45 @@ describe('logger', function () {
       reloadLogger();
 
     });
-    it('Should have a default logger with no transport and level set to info', function () {
+    it('Should have a default logger with silent transport and level set to info', function () {
       process.env.AWS_XRAY_LOG_LEVEL = '';
       process.env.AWS_XRAY_DEBUG_MODE = '';
       reloadLogger();
-      assert.deepEqual(logger.getLogger().transports, {});
       assert.equal(logger.getLogger().level, 'info');
+
+      var transports = logger.getLogger().transports
+      assert.equal(transports.length, 1);
+      assert.equal(transports[0].silent, true);
+      assert.equal(transports[0].constructor, winston.transports.Console);
     });
     it('Should have a logger with console transport with level set to debug when AWS_XRAY_DEBUG_MODE is set', function () {
       process.env.AWS_XRAY_DEBUG_MODE = 'set';
       reloadLogger();
-      assert.equal(logger.getLogger().transports.console.level, 'debug');
+      assert.equal(logger.getLogger().level, 'debug');
+
+      var transports = logger.getLogger().transports
+      assert.equal(transports.length, 1);
+      assert.equal(transports[0].constructor, winston.transports.Console);
     });
     it('Should have a logger with console transport with level set to debug when AWS_XRAY_DEBUG_MODE is set even when XRAY_LOG_LEVEL is error', function () {
       process.env.AWS_XRAY_DEBUG_MODE = 'set';
       process.env.AWS_XRAY_LOG_LEVEL = 'error';
       reloadLogger();
-      assert.equal(logger.getLogger().transports.console.level, 'debug');
+      assert.equal(logger.getLogger().level, 'debug');
+
+      var transports = logger.getLogger().transports
+      assert.equal(transports.length, 1);
+      assert.equal(transports[0].constructor, winston.transports.Console);
     });
     it('Should have a logger with console transport with level set to error when AWS_XRAY_LOG_LEVEL=error and AWS_XRAY_DEBUG_MODE is not set', function () {
       process.env.AWS_XRAY_LOG_LEVEL = 'error';
       process.env.AWS_XRAY_DEBUG_MODE = '';
       reloadLogger();
-      assert.equal(logger.getLogger().transports.console.level, 'error');
+      assert.equal(logger.getLogger().level, 'error');
+
+      var transports = logger.getLogger().transports
+      assert.equal(transports.length, 1);
+      assert.equal(transports[0].constructor, winston.transports.Console);
     });
   });
 });

--- a/packages/core/test/unit/logger.test.js
+++ b/packages/core/test/unit/logger.test.js
@@ -22,7 +22,7 @@ describe('logger', function () {
       reloadLogger();
       assert.equal(logger.getLogger().level, 'info');
 
-      var transports = logger.getLogger().transports
+      var transports = logger.getLogger().transports;
       assert.equal(transports.length, 1);
       assert.equal(transports[0].silent, true);
       assert.equal(transports[0].constructor, winston.transports.Console);
@@ -32,7 +32,7 @@ describe('logger', function () {
       reloadLogger();
       assert.equal(logger.getLogger().level, 'debug');
 
-      var transports = logger.getLogger().transports
+      var transports = logger.getLogger().transports;
       assert.equal(transports.length, 1);
       assert.equal(transports[0].constructor, winston.transports.Console);
     });
@@ -42,7 +42,7 @@ describe('logger', function () {
       reloadLogger();
       assert.equal(logger.getLogger().level, 'debug');
 
-      var transports = logger.getLogger().transports
+      var transports = logger.getLogger().transports;
       assert.equal(transports.length, 1);
       assert.equal(transports[0].constructor, winston.transports.Console);
     });
@@ -52,7 +52,7 @@ describe('logger', function () {
       reloadLogger();
       assert.equal(logger.getLogger().level, 'error');
 
-      var transports = logger.getLogger().transports
+      var transports = logger.getLogger().transports;
       assert.equal(transports.length, 1);
       assert.equal(transports[0].constructor, winston.transports.Console);
     });


### PR DESCRIPTION
*Issue #, if available:*
#10 #48 #103 

*Description of changes:*
Upgrade of Winston library from version 2.4.4 to 3.2.1

I tried to keep the changes to a minimum and hence configured the new version to get the behaviour as close as possible to that of the previous version. As part of this change the date-fns package was removed.

There are additional changes/issues that might be worth considering. First, I can't see anything adding meta information to the logs so it might be better to remove the metadata formatter.

Second, it looks like the logging for lambda is treated differently (see lines 31 to 38 of logger.js) and I'm not sure why. In particular it would seem that this code removes any filtering on log level.

Third, as mentioned in one of the issues, using winston might be overkill for what we want to achieve. Maybe it would just be better to have a standard logger that writes everything to the console and then let users to override if they want? 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
