### PR TITLE
Removal of Winston

### DIFF
--- a/packages/core/.eslintrc.json
+++ b/packages/core/.eslintrc.json
@@ -10,6 +10,7 @@
             "error",
             2
         ],
+        "no-console": "off",
         "linebreak-style": [
             "error",
             "unix"

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -121,7 +121,11 @@ AWSXRay.setLogger(logger);
 ```
 
 If you use your own logged you are responsible for determining the log level as the AWS_XRAY_DEBUG_MODE and
-AWS_XRAY_LOG_LEVEL only apply to the default logger. 
+AWS_XRAY_LOG_LEVEL only apply to the default logger.
+
+Note that in most circumstances the provided logger will prefix each log line with a timestamp and the
+level of the message as shown in the example below. However this will not be the case when using this SDK
+from within an AWS Lambda. In that scenaro the timestamp and level are added by the lambda runtime instead.
 
 ### Sampling configuration
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -75,12 +75,12 @@ below for the different usages.
 
 **Environment variables always override values set in code.**
 
-    AWS_XRAY_DEBUG_MODE              Enables logging to console output. Logging to a file is no longer built in. See 'configure logging' below.
+    AWS_XRAY_DEBUG_MODE              Enables logging of dbug messages to console output. Logging to a file is no longer built in. See 'configure logging' below.
     AWS_XRAY_TRACING_NAME            For overriding the default segment name to use
     with the middleware. See 'dynamic and fixed naming modes'.
     AWS_XRAY_DAEMON_ADDRESS          For setting the daemon address and port.
     AWS_XRAY_CONTEXT_MISSING         For setting the SDK behavior when trace context is missing. Valid values are 'RUNTIME_ERROR' or 'LOG_ERROR'. The SDK's default behavior is 'RUNTIME_ERROR'.
-    AWS_XRAY_LOG_LEVEL               Sets a log level for the SDK built in logger.
+    AWS_XRAY_LOG_LEVEL               Sets a log level for the SDK built in logger. This value is ignored if AWS_XRAY_DEBUG_MODE is set.
 
 ### Daemon configuration
 
@@ -94,16 +94,34 @@ You can change this via the environment variables listed above, or through code.
 
 ### Logging configuration
 
-Default logging to a file has been removed. To set up file logging, configure a logger
-that responds to debug, info, warn, and error functions. To suppress logs such as context setup the log level can be
-overridden, e.g. to suppress info logs such as context and daemon config set the following environment variable.  
+By default the SDK will log error messages to the console using the standard methods on the console object. The log
+level of the built in logger can be set bu using either the AWS_XRAY_DEBUG_MODE or AWS_XRAY_LOG_LEVEL environment
+variables.
 
-    AWS_XRAY_LOG_LEVEL='error'
+If AWS_XRAY_DEBUG_MODE is set to a truthy value, e.g. true, then the log level will be set to debug. If
+AWS_XRAY_DEBUG_MODE is not set then AWS_XRAY_LOG_LEVEL will be used to determine the log level. This variable can
+be set to either debug, info, warn, error or silent. Be warned if the log level is set to silent then NO log
+messages will be produced. The default log level is error and this will be used if neither environment variable
+is set or if an invalid level is specified.
 
-To log information about configuration, be sure you set the logger before other configuration
-options.
+If you wish to provide a different format or destination for the logs then you can provide the SDK with you own
+implementation of the logger interface as shown below. Any object that implements this interface can be used.
+This means that many logging libraries, e.g. Winston, could be used and passed to the SDK directly.
 
-    AWSXRay.setLogger(logger);
+```js
+// Create your own logger or instantiate one using a library.
+var logger = {
+  error: (message, meta) => { /* logging code */ },
+  warn: (message, meta) => { /* logging code */ },
+  info: (message, meta) => { /* logging code */ },
+  debug: (message, meta) => { /* logging code */ }
+}
+
+AWSXRay.setLogger(logger);
+```
+
+If you use your own logged you are responsible for determining the log level as the AWS_XRAY_DEBUG_MODE and
+AWS_XRAY_LOG_LEVEL only apply to the default logger. 
 
 ### Sampling configuration
 

--- a/packages/core/lib/logger.js
+++ b/packages/core/lib/logger.js
@@ -15,9 +15,10 @@ var logger = {
 /* eslint-disable no-console */
 function createLoggerForLevel(level) {
   var loggerLevel = validLogLevels.indexOf(level);
+  var consoleMethod = console[level] || console.log || (() => {})
   return (message, meta) => {
     if (loggerLevel >= logLevel) {
-      console[level](formatLogMessage(level, message, meta));
+      consoleMethod(formatLogMessage(level, message, meta));
     }
   };
 }

--- a/packages/core/lib/logger.js
+++ b/packages/core/lib/logger.js
@@ -15,7 +15,7 @@ var logger = {
 /* eslint-disable no-console */
 function createLoggerForLevel(level) {
   var loggerLevel = validLogLevels.indexOf(level);
-  var consoleMethod = console[level] || console.log || (() => {})
+  var consoleMethod = console[level] || console.log || (() => {});
   return (message, meta) => {
     if (loggerLevel >= logLevel) {
       consoleMethod(formatLogMessage(level, message, meta));

--- a/packages/core/lib/logger.js
+++ b/packages/core/lib/logger.js
@@ -11,7 +11,6 @@ var logger = {
   debug: createLoggerForLevel('debug'),
 };
 
-/* eslint-disable no-console */
 function createLoggerForLevel(level) {
   var loggerLevel = validLogLevels.indexOf(level);
   var consoleMethod = console[level] || console.log || (() => {});
@@ -22,7 +21,6 @@ function createLoggerForLevel(level) {
     return () => {};
   }
 }
-/* eslint-enable no-console */
 
 function calculateLogLevel(level) {
   if (level) {

--- a/packages/core/lib/logger.js
+++ b/packages/core/lib/logger.js
@@ -16,7 +16,11 @@ function createLoggerForLevel(level) {
   var consoleMethod = console[level] || console.log || (() => {});
 
   if (loggerLevel >= logLevel) {
-    return (message, meta) => consoleMethod(formatLogMessage(level, message, meta));
+    return (message, meta) => {
+      if(message || meta) {
+        consoleMethod(formatLogMessage(level, message, meta));
+      }
+    };
   } else {
     return () => {};
   }

--- a/packages/core/lib/logger.js
+++ b/packages/core/lib/logger.js
@@ -37,10 +37,25 @@ function createTimestamp() {
   return format(new Date(), 'YYYY-MM-DD HH:mm:ss.SSS Z');
 }
 
+function isLambdaFunction() {
+  return process.env.LAMBDA_TASK_ROOT !== undefined;
+}
+
 function formatLogMessage(level, message, meta) {
-  return createTimestamp() +' [' + level.toUpperCase() + '] ' +
-    (message ? message : '') +
-    formatMetaData(meta);
+  var messageParts = [];
+
+  if (!isLambdaFunction()) {
+    messageParts.push(createTimestamp());
+    messageParts.push(`[${level.toUpperCase()}]`);
+  }
+
+  if (message) {
+    messageParts.push(message);
+  }
+
+  var logString = messageParts.join(' ');
+  var metaDataString = formatMetaData(meta);
+  return [logString, metaDataString].filter(str => str.length > 0).join('\n  ');
 }
 
 function formatMetaData(meta) {
@@ -48,7 +63,7 @@ function formatMetaData(meta) {
     return '';
   }
 
-  return '\n  ' + ((typeof(meta) === 'string') ? meta : JSON.stringify(meta));
+  return ((typeof(meta) === 'string') ? meta : JSON.stringify(meta));
 }
 
 var logging = {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,8 +19,7 @@
     "continuation-local-storage": "^3.2.0",
     "date-fns": "^1.29.0",
     "pkginfo": "^0.4.0",
-    "semver": "^5.3.0",
-    "winston": "^2.4.4"
+    "semver": "^5.3.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,8 @@
     "mocha": "^6.2.0",
     "nock": "^10.0.6",
     "sinon": "^4.5.0",
-    "sinon-chai": "^2.8.0"
+    "sinon-chai": "^2.8.0",
+    "upath": "^1.2.0"
   },
   "scripts": {
     "test": "mocha --recursive ./test/ -R spec"

--- a/packages/core/test.js
+++ b/packages/core/test.js
@@ -1,6 +1,0 @@
-var logger = require('./lib/logger')
-
-delete console['debug']
-delete console['log']
-logger.getLogger().setLevel('debug')
-logger.getLogger().debug('hello')

--- a/packages/core/test.js
+++ b/packages/core/test.js
@@ -1,0 +1,6 @@
+var logger = require('./lib/logger')
+
+delete console['debug']
+delete console['log']
+logger.getLogger().setLevel('debug')
+logger.getLogger().debug('hello')

--- a/packages/core/test/unit/aws-xray.test.js
+++ b/packages/core/test/unit/aws-xray.test.js
@@ -2,7 +2,7 @@ var assert = require('chai').assert;
 var chai = require('chai');
 var sinon = require('sinon');
 var sinonChai = require('sinon-chai');
-var upath = require('upath')
+var upath = require('upath');
 
 var segmentUtils = require('../../lib/segments/segment_utils');
 
@@ -31,7 +31,7 @@ describe('AWSXRay', function() {
       // We should always clear the require cache for these two files so this test
       // could run independently.
       Object.keys(require.cache).forEach(function(key) {
-        var normalisedPath = upath.toUnix(key)
+        var normalisedPath = upath.toUnix(key);
         if(normalisedPath.includes('core/lib/index.js') || normalisedPath.includes('core/lib/aws-xray.js')) {
           delete require.cache[key];
         }

--- a/packages/core/test/unit/aws-xray.test.js
+++ b/packages/core/test/unit/aws-xray.test.js
@@ -2,6 +2,7 @@ var assert = require('chai').assert;
 var chai = require('chai');
 var sinon = require('sinon');
 var sinonChai = require('sinon-chai');
+var upath = require('upath')
 
 var segmentUtils = require('../../lib/segments/segment_utils');
 
@@ -29,8 +30,9 @@ describe('AWSXRay', function() {
       // This test requires both index.js and aws-xray.js are first time required.
       // We should always clear the require cache for these two files so this test
       // could run independently.
-      Object.keys(require.cache).forEach(function(key) { 
-        if(key.includes('core/lib/index.js') || key.includes('core/lib/aws-xray.js')) {
+      Object.keys(require.cache).forEach(function(key) {
+        var normalisedPath = upath.toUnix(key)
+        if(normalisedPath.includes('core/lib/index.js') || normalisedPath.includes('core/lib/aws-xray.js')) {
           delete require.cache[key];
         }
       });

--- a/packages/core/test/unit/logger.test.js
+++ b/packages/core/test/unit/logger.test.js
@@ -71,7 +71,7 @@ describe('logger', function () {
 
   describe('console logging levels', function () {
     beforeEach(function() {
-      sinon.spy(console, 'error"');
+      sinon.spy(console, 'error');
       sinon.spy(console, 'warn');
       sinon.spy(console, 'info');
       sinon.spy(console, 'debug');
@@ -87,22 +87,22 @@ describe('logger', function () {
       console.debug.restore();
     });
 
-    it('Should have a default logger with level set to error', function () {
+    it('Should send debug logs to console.debug', function () {
       logger.getLogger().debug('test');
       expect(console.debug).to.be.calledOnce;
     });
 
-    it('Should have a default logger with level set to error', function () {
+    it('Should send info logs to console.info', function () {
       logger.getLogger().info('test');
       expect(console.info).to.be.calledOnce;
     });
 
-    it('Should have a default logger with level set to error', function () {
+    it('Should send warn logs to console.warn', function () {
       logger.getLogger().warn('test');
       expect(console.warn).to.be.calledOnce;
     });
 
-    it('Should have a default logger with level set to error', function () {
+    it('Should sent error logs to console.error', function () {
       logger.getLogger().error('test');
       expect(console.error).to.be.calledOnce;
     });

--- a/packages/core/test/unit/logger.test.js
+++ b/packages/core/test/unit/logger.test.js
@@ -74,7 +74,11 @@ describe('logger', function () {
       sinon.spy(console, 'error');
       sinon.spy(console, 'warn');
       sinon.spy(console, 'info');
-      sinon.spy(console, 'debug');
+      sinon.spy(console, 'log');
+
+      if (console.debug) {
+        sinon.spy(console, 'debug');
+      }
 
       reloadLogger();
       logger.getLogger().setLevel('debug');
@@ -84,12 +88,21 @@ describe('logger', function () {
       console.error.restore();
       console.warn.restore();
       console.info.restore();
-      console.debug.restore();
+      console.log.restore();
+
+      if (console.debug) {
+        console.debug.restore();
+      }
     });
 
     it('Should send debug logs to console.debug', function () {
       logger.getLogger().debug('test');
-      expect(console.debug).to.be.calledOnce;
+      
+      if (console.debug) {
+        expect(console.debug).to.be.calledOnce;
+      } else {
+        expect(console.log).to.be.calledOnce;
+      }
     });
 
     it('Should send info logs to console.info', function () {

--- a/packages/core/test/unit/logger.test.js
+++ b/packages/core/test/unit/logger.test.js
@@ -170,9 +170,18 @@ describe('logger', function () {
       expect(groups[5].trim()).to.equal(expectedMessage);
     });
 
+    it('should not output if message and meta falsey', () => {
+      var logger = logging.getLogger();
+      logger.error();
+      logger.error(null);
+      logger.error('', null);
+
+      spies.forEach(spy => expect(spy).not.to.be.called);
+    });
+
     it('should convert falsey value to empty string', () => {
       var logger = logging.getLogger();
-      logger.error(null);
+      logger.error(null, {});
 
       var message = console.error.args[0][0];
       var groups = message.match(logMessageRegex);

--- a/packages/core/test/unit/logger.test.js
+++ b/packages/core/test/unit/logger.test.js
@@ -1,5 +1,6 @@
 var assert = require('chai').assert;
-
+var expect = require('chai').expect;
+var sinon = require('sinon');
 var logger = require('../../lib/logger');
 
 describe('logger', function () {
@@ -9,35 +10,99 @@ describe('logger', function () {
     logger = require(path);
   }
 
-  describe('defaults', function () {
+  describe('setting logging levels', function () {
     afterEach(function () {
       delete process.env.AWS_XRAY_DEBUG_MODE;
+      delete process.env.AWS_XRAY_LOG_LEVEL;
       reloadLogger();
 
     });
-    it('Should have a default logger with no transport and level set to info', function () {
+
+    it('Should have a default logger with level set to error', function () {
       process.env.AWS_XRAY_LOG_LEVEL = '';
       process.env.AWS_XRAY_DEBUG_MODE = '';
       reloadLogger();
-      assert.deepEqual(logger.getLogger().transports, {});
-      assert.equal(logger.getLogger().level, 'info');
+      assert.equal(logger.getLogger().getLevel(), 'error');
     });
-    it('Should have a logger with console transport with level set to debug when AWS_XRAY_DEBUG_MODE is set', function () {
+
+    it('Should have a logger with level set to debug when AWS_XRAY_DEBUG_MODE is set', function () {
       process.env.AWS_XRAY_DEBUG_MODE = 'set';
       reloadLogger();
-      assert.equal(logger.getLogger().transports.console.level, 'debug');
+      assert.equal(logger.getLogger().getLevel(), 'debug');
     });
-    it('Should have a logger with console transport with level set to debug when AWS_XRAY_DEBUG_MODE is set even when XRAY_LOG_LEVEL is error', function () {
+
+    it('Should have a loggerwith level set to debug when AWS_XRAY_DEBUG_MODE is set even when XRAY_LOG_LEVEL is error', function () {
       process.env.AWS_XRAY_DEBUG_MODE = 'set';
       process.env.AWS_XRAY_LOG_LEVEL = 'error';
       reloadLogger();
-      assert.equal(logger.getLogger().transports.console.level, 'debug');
+      assert.equal(logger.getLogger().getLevel(), 'debug');
     });
-    it('Should have a logger with console transport with level set to error when AWS_XRAY_LOG_LEVEL=error and AWS_XRAY_DEBUG_MODE is not set', function () {
-      process.env.AWS_XRAY_LOG_LEVEL = 'error';
-      process.env.AWS_XRAY_DEBUG_MODE = '';
+
+    it('Should have a logger with level set to warn when AWS_XRAY_LOG_LEVEL=warn and AWS_XRAY_DEBUG_MODE is not set', function () {
+      process.env.AWS_XRAY_LOG_LEVEL = 'warn';
       reloadLogger();
-      assert.equal(logger.getLogger().transports.console.level, 'error');
+      assert.equal(logger.getLogger().getLevel(), 'warn');
+    });
+
+    it('Should set level to error if invalid level specified in AWS_XRAY_LOG_LEVEL', function() {
+      process.env.AWS_XRAY_LOG_LEVEL = 'somethingnotquiteright';
+      reloadLogger();
+      assert.equal(logger.getLogger().getLevel(), 'error');
+    })
+
+    it('Should set logging level after initialisation', function() {
+      process.env.AWS_XRAY_LOG_LEVEL = 'warn';
+      reloadLogger();
+      
+      assert.equal(logger.getLogger().getLevel(), 'warn');
+      logger.getLogger().setLevel('debug')
+      assert.equal(logger.getLogger().getLevel(), 'debug');
+    })
+
+    it('Should set logging level to error if invalid value is used after initialisation', function() {
+      process.env.AWS_XRAY_LOG_LEVEL = 'warn';
+      reloadLogger();
+      
+      assert.equal(logger.getLogger().getLevel(), 'warn');
+      logger.getLogger().setLevel('debugorsomething')
+      assert.equal(logger.getLogger().getLevel(), 'error');
+    })
+  });
+
+  describe('console logging levels', function () {
+    beforeEach(function() {
+      sinon.spy(console, "error");
+      sinon.spy(console, "warn");
+      sinon.spy(console, "info");
+      sinon.spy(console, "debug");
+      logger.getLogger().setLevel('debug');
+    })
+
+    afterEach(function () {
+      console.error.restore();
+      console.warn.restore();
+      console.info.restore();
+      console.debug.restore();
+    });
+
+    it('Should have a default logger with level set to error', function () {
+      logger.getLogger().debug('test');
+      expect(console.debug).to.be.calledOnce;
+    });
+
+    it('Should have a default logger with level set to error', function () {
+      logger.getLogger().info('test');
+      expect(console.info).to.be.calledOnce;
+    });
+
+    it('Should have a default logger with level set to error', function () {
+      logger.getLogger().warn('test');
+      expect(console.warn).to.be.calledOnce;
+    });
+
+    it('Should have a default logger with level set to error', function () {
+      logger.getLogger().error('test');
+      expect(console.error).to.be.calledOnce;
     });
   });
 });

--- a/packages/core/test/unit/logger.test.js
+++ b/packages/core/test/unit/logger.test.js
@@ -48,35 +48,37 @@ describe('logger', function () {
       process.env.AWS_XRAY_LOG_LEVEL = 'somethingnotquiteright';
       reloadLogger();
       assert.equal(logger.getLogger().getLevel(), 'error');
-    })
+    });
 
     it('Should set logging level after initialisation', function() {
       process.env.AWS_XRAY_LOG_LEVEL = 'warn';
       reloadLogger();
       
       assert.equal(logger.getLogger().getLevel(), 'warn');
-      logger.getLogger().setLevel('debug')
+      logger.getLogger().setLevel('debug');
       assert.equal(logger.getLogger().getLevel(), 'debug');
-    })
+    });
 
     it('Should set logging level to error if invalid value is used after initialisation', function() {
       process.env.AWS_XRAY_LOG_LEVEL = 'warn';
       reloadLogger();
       
       assert.equal(logger.getLogger().getLevel(), 'warn');
-      logger.getLogger().setLevel('debugorsomething')
+      logger.getLogger().setLevel('debugorsomething');
       assert.equal(logger.getLogger().getLevel(), 'error');
-    })
+    });
   });
 
   describe('console logging levels', function () {
     beforeEach(function() {
-      sinon.spy(console, "error");
-      sinon.spy(console, "warn");
-      sinon.spy(console, "info");
-      sinon.spy(console, "debug");
+      sinon.spy(console, 'error"');
+      sinon.spy(console, 'warn');
+      sinon.spy(console, 'info');
+      sinon.spy(console, 'debug');
+
+      reloadLogger();
       logger.getLogger().setLevel('debug');
-    })
+    });
 
     afterEach(function () {
       console.error.restore();


### PR DESCRIPTION
Issue #, if available:
#10 #48 #103 

Description of changes:
Alternative approach to upgrading the logging to that proposed in #188 - both requests aren't needed, it's one or the other.

Instead of upgrading the Winston library this change creates a simple logger that can be used instead. This change also standardises the logging format for in all environments and ensures that the specified logging level is honoured in lambda environments.

As far as I can tell the meta (or second argument to the logging functions) is only used in two places, both of which log out err.stack. As previously implemented this was converted into a JSON string which made it hard to read. The logger was changed so that strings (such as the stack trace) are printed out without being stringified.

Additionally the ability to change the log level was added whereas previously this could only be done via environmental variables before the module is loaded.

Some additional error checking may be required before merging this request and I'm making this initial submission to show the alternative mentioned in #188 is feasible.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
