### PR TITLE
Get protocol using standard ClientRequest interface

### DIFF
--- a/packages/core/lib/segments/attributes/remote_request_data.js
+++ b/packages/core/lib/segments/attributes/remote_request_data.js
@@ -12,7 +12,7 @@ function RemoteRequestData(req, res, downstreamXRayEnabled) {
 
 RemoteRequestData.prototype.init = function init(req, res, downstreamXRayEnabled) {
   this.request = {
-    url: (req.agent.protocol + '//' + req.getHeader('host') + req.path) || '',
+    url: (req.connection.secure ? 'https:' : 'http:') + '//' + req.getHeader('host') + req.path) || '',
     method: req.method || '',
   };
 


### PR DESCRIPTION
*Description of changes:*

According to node.js documentation nobody promises that ClientRequest will have "agent" attribute. For example, patching @hapi/wreck fails, because ClientRequest does not have attribute "agent". It is safer to use ClientRequest.connection.secure, which is a part of ClientRequest standard API

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
