### PR TITLE
Removal of Winston

### DIFF
--- a/packages/core/lib/logger.js
+++ b/packages/core/lib/logger.js
@@ -1,99 +1,56 @@
-var winston = require('winston');
 var format = require('date-fns/format');
 
-var logger;
-var xrayLogLevel = process.env.AWS_XRAY_LOG_LEVEL;
+var validLogLevelNames = [ 'trace', 'debug', 'info', 'warn', 'error', 'silent'  ];
 
-if (process.env.AWS_XRAY_DEBUG_MODE) {
-  logger = new (winston.Logger)({
-    transports: [
-      new (winston.transports.Console)({
-        formatter: outputFormatter,
-        level: 'debug',
-        timestamp: timestampFormatter
-      })
-    ]
-  });
-} else if (xrayLogLevel) {
-  logger = new (winston.Logger)({
-    transports: [
-      new (winston.transports.Console)({
-        formatter: outputFormatter,
-        level: xrayLogLevel,
-        timestamp: timestampFormatter
-      })
-    ]
-  });
-} else {
-  logger = new (winston.Logger)({});
-}
+// Log level to be used if no other or invalid level is specified.
+var defaultLogLevel = calculateLogLevel('error');
+var currentLogLevel = calculateLogLevel(process.env.AWS_XRAY_DEBUG_MODE ? 'debug' : process.env.AWS_XRAY_LOG_LEVEL);
+
+var logger = {
+  error: createLoggerForLevel('error'),
+  info: createLoggerForLevel('info'),
+  warn: createLoggerForLevel('warn'),
+  debug: createLoggerForLevel('debug'),
+  setLevel: (level) => currentLogLevel = calculateLogLevel(level),
+  getLevel: () => validLogLevelNames[currentLogLevel]
+};
 
 /* eslint-disable no-console */
-if (process.env.LAMBDA_TASK_ROOT) {
-  logger.error = function(string) { console.error(string); };
-  logger.info = function(string) { console.info(string); };
-  logger.warn = function(string) { console.warn(string); };
-  
-  if (process.env.AWS_XRAY_DEBUG_MODE) {
-    logger.debug = function(string) { console.debug(string); };
-  }
+function createLoggerForLevel(levelName) {
+  var loggerLevel = validLogLevelNames.indexOf(levelName);
+  var consoleMethod = console[levelName] || console.log || (() => {});
+  return (message, meta) => {
+    if (loggerLevel >= currentLogLevel) {
+      consoleMethod(formatLogMessage(levelName, message, meta));
+    }
+  };
 }
 /* eslint-enable no-console */
 
-function timestampFormatter() {
+function calculateLogLevel(levelName) {
+  var normalisedLevelName = (levelName || '').toLowerCase();
+  var index = validLogLevelNames.indexOf(normalisedLevelName);
+
+  // Silently ignore invalid log levels
+  return index >= 0 ? index : defaultLogLevel;
+}
+
+function createTimestamp() {
   return format(new Date(), 'YYYY-MM-DD HH:mm:ss.SSS Z');
 }
 
-function outputFormatter(options) {
-  return options.timestamp() +' [' + options.level.toUpperCase() + '] '+
-    (options.message !== undefined ? options.message : '') +
-    (options.meta && Object.keys(options.meta).length ? '\n\t'+ JSON.stringify(options.meta) : '' );
+function formatLogMessage(level, message, meta) {
+  return createTimestamp() +' [' + level.toUpperCase() + '] ' +
+    (message !== undefined ? message : '') +
+    formatMetaData(meta);
 }
 
-/**
- * Polyfill for Object.keys
- * @see: https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Object/keys
- */
+function formatMetaData(meta) {
+  if (!meta) {
+    return '';
+  }
 
-if (!Object.keys) {
-  Object.keys = (function() {
-    'use strict';
-    var hasOwnProperty = Object.prototype.hasOwnProperty,
-      hasDontEnumBug = !({ toString: null }).propertyIsEnumerable('toString'),
-      dontEnums = [
-        'toString',
-        'toLocaleString',
-        'valueOf',
-        'hasOwnProperty',
-        'isPrototypeOf',
-        'propertyIsEnumerable',
-        'constructor'
-      ],
-      dontEnumsLength = dontEnums.length;
-
-    return function(obj) {
-      if (typeof obj !== 'object' && (typeof obj !== 'function' || obj === null)) {
-        throw new TypeError('Object.keys called on non-object');
-      }
-
-      var result = [], prop, i;
-
-      for (prop in obj) {
-        if (hasOwnProperty.call(obj, prop)) {
-          result.push(prop);
-        }
-      }
-
-      if (hasDontEnumBug) {
-        for (i = 0; i < dontEnumsLength; i++) {
-          if (hasOwnProperty.call(obj, dontEnums[i])) {
-            result.push(dontEnums[i]);
-          }
-        }
-      }
-      return result;
-    };
-  }());
+  return '\n  ' + ((typeof(meta) === 'string') ? meta : JSON.stringify(meta));
 }
 
 var logging = {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,8 +19,7 @@
     "continuation-local-storage": "^3.2.0",
     "date-fns": "^1.29.0",
     "pkginfo": "^0.4.0",
-    "semver": "^5.3.0",
-    "winston": "^2.4.4"
+    "semver": "^5.3.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,8 @@
     "mocha": "^6.2.0",
     "nock": "^10.0.6",
     "sinon": "^4.5.0",
-    "sinon-chai": "^2.8.0"
+    "sinon-chai": "^2.8.0",
+    "upath": "^1.2.0"
   },
   "scripts": {
     "test": "mocha --recursive ./test/ -R spec"

--- a/packages/core/test/unit/aws-xray.test.js
+++ b/packages/core/test/unit/aws-xray.test.js
@@ -2,7 +2,7 @@ var assert = require('chai').assert;
 var chai = require('chai');
 var sinon = require('sinon');
 var sinonChai = require('sinon-chai');
-var upath = require('upath')
+var upath = require('upath');
 
 var segmentUtils = require('../../lib/segments/segment_utils');
 
@@ -31,7 +31,7 @@ describe('AWSXRay', function() {
       // We should always clear the require cache for these two files so this test
       // could run independently.
       Object.keys(require.cache).forEach(function(key) {
-        var normalisedPath = upath.toUnix(key)
+        var normalisedPath = upath.toUnix(key);
         if(normalisedPath.includes('core/lib/index.js') || normalisedPath.includes('core/lib/aws-xray.js')) {
           delete require.cache[key];
         }

--- a/packages/core/test/unit/aws-xray.test.js
+++ b/packages/core/test/unit/aws-xray.test.js
@@ -2,6 +2,7 @@ var assert = require('chai').assert;
 var chai = require('chai');
 var sinon = require('sinon');
 var sinonChai = require('sinon-chai');
+var upath = require('upath')
 
 var segmentUtils = require('../../lib/segments/segment_utils');
 
@@ -29,8 +30,9 @@ describe('AWSXRay', function() {
       // This test requires both index.js and aws-xray.js are first time required.
       // We should always clear the require cache for these two files so this test
       // could run independently.
-      Object.keys(require.cache).forEach(function(key) { 
-        if(key.includes('core/lib/index.js') || key.includes('core/lib/aws-xray.js')) {
+      Object.keys(require.cache).forEach(function(key) {
+        var normalisedPath = upath.toUnix(key)
+        if(normalisedPath.includes('core/lib/index.js') || normalisedPath.includes('core/lib/aws-xray.js')) {
           delete require.cache[key];
         }
       });

--- a/packages/core/test/unit/logger.test.js
+++ b/packages/core/test/unit/logger.test.js
@@ -1,43 +1,207 @@
 var assert = require('chai').assert;
-
-var logger = require('../../lib/logger');
+var expect = require('chai').expect;
+var sinon = require('sinon');
+var logging = require('../../lib/logger');
 
 describe('logger', function () {
   function reloadLogger() {
     var path = '../../lib/logger';
     delete require.cache[require.resolve(path)];
-    logger = require(path);
+    logging = require(path);
   }
 
-  describe('defaults', function () {
+  describe('setting logging levels', function () {
     afterEach(function () {
       delete process.env.AWS_XRAY_DEBUG_MODE;
+      delete process.env.AWS_XRAY_LOG_LEVEL;
       reloadLogger();
 
     });
-    it('Should have a default logger with no transport and level set to info', function () {
+
+    it('Should have a default logger with level set to error', function () {
       process.env.AWS_XRAY_LOG_LEVEL = '';
       process.env.AWS_XRAY_DEBUG_MODE = '';
       reloadLogger();
-      assert.deepEqual(logger.getLogger().transports, {});
-      assert.equal(logger.getLogger().level, 'info');
+      assert.equal(logging.getLogger().getLevel(), 'error');
     });
-    it('Should have a logger with console transport with level set to debug when AWS_XRAY_DEBUG_MODE is set', function () {
+
+    it('Should have a logger with level set to debug when AWS_XRAY_DEBUG_MODE is set', function () {
       process.env.AWS_XRAY_DEBUG_MODE = 'set';
       reloadLogger();
-      assert.equal(logger.getLogger().transports.console.level, 'debug');
+      assert.equal(logging.getLogger().getLevel(), 'debug');
     });
-    it('Should have a logger with console transport with level set to debug when AWS_XRAY_DEBUG_MODE is set even when XRAY_LOG_LEVEL is error', function () {
+
+    it('Should have a loggerwith level set to debug when AWS_XRAY_DEBUG_MODE is set even when XRAY_LOG_LEVEL is error', function () {
       process.env.AWS_XRAY_DEBUG_MODE = 'set';
       process.env.AWS_XRAY_LOG_LEVEL = 'error';
       reloadLogger();
-      assert.equal(logger.getLogger().transports.console.level, 'debug');
+      assert.equal(logging.getLogger().getLevel(), 'debug');
     });
-    it('Should have a logger with console transport with level set to error when AWS_XRAY_LOG_LEVEL=error and AWS_XRAY_DEBUG_MODE is not set', function () {
-      process.env.AWS_XRAY_LOG_LEVEL = 'error';
-      process.env.AWS_XRAY_DEBUG_MODE = '';
+
+    it('Should have a logger with level set to warn when AWS_XRAY_LOG_LEVEL=warn and AWS_XRAY_DEBUG_MODE is not set', function () {
+      process.env.AWS_XRAY_LOG_LEVEL = 'warn';
       reloadLogger();
-      assert.equal(logger.getLogger().transports.console.level, 'error');
+      assert.equal(logging.getLogger().getLevel(), 'warn');
+    });
+
+    it('Should set level to error if invalid level specified in AWS_XRAY_LOG_LEVEL', function() {
+      process.env.AWS_XRAY_LOG_LEVEL = 'somethingnotquiteright';
+      reloadLogger();
+      assert.equal(logging.getLogger().getLevel(), 'error');
+    });
+
+    it('Should set logging level after initialisation', function() {
+      process.env.AWS_XRAY_LOG_LEVEL = 'warn';
+      reloadLogger();
+      
+      assert.equal(logging.getLogger().getLevel(), 'warn');
+      logging.getLogger().setLevel('debug');
+      assert.equal(logging.getLogger().getLevel(), 'debug');
+    });
+
+    it('Should set logging level to error if invalid value is used after initialisation', function() {
+      process.env.AWS_XRAY_LOG_LEVEL = 'warn';
+      reloadLogger();
+      
+      assert.equal(logging.getLogger().getLevel(), 'warn');
+      logging.getLogger().setLevel('debugorsomething');
+      assert.equal(logging.getLogger().getLevel(), 'error');
     });
   });
+
+  /* eslint-disable no-console */
+  describe('console logging methods', function () {
+    var spies = [];
+
+    beforeEach(function() {
+      spies.push(sinon.spy(console, 'error'));
+      spies.push(sinon.spy(console, 'warn'));
+      spies.push(sinon.spy(console, 'info'));
+      spies.push(sinon.spy(console, 'log'));
+
+      if (console.debug) {
+        spies.push(sinon.spy(console, 'debug'));
+      }
+
+      reloadLogger();
+      logging.getLogger().setLevel('debug');
+    });
+
+    afterEach(function () {
+      spies.forEach(spy => spy.restore());
+      spies = [];
+    });
+
+    it('Should send debug logs to console.debug', function () {
+      logging.getLogger().debug('test');
+      
+      if (console.debug) {
+        expect(console.debug).to.be.calledOnce;
+      } else {
+        expect(console.log).to.be.calledOnce;
+      }
+    });
+
+    it('Should send info logs to console.info', function () {
+      logging.getLogger().info('test');
+      expect(console.info).to.be.calledOnce;
+    });
+
+    it('Should send warn logs to console.warn', function () {
+      logging.getLogger().warn('test');
+      expect(console.warn).to.be.calledOnce;
+    });
+
+    it('Should sent error logs to console.error', function () {
+      logging.getLogger().error('test');
+      expect(console.error).to.be.calledOnce;
+    });
+  });
+
+  describe('console logging filters', function () {
+    var spies = [];
+
+    beforeEach(function() {
+      spies.push(sinon.spy(console, 'error'));
+      spies.push(sinon.spy(console, 'warn'));
+      spies.push(sinon.spy(console, 'info'));
+      spies.push(sinon.spy(console, 'log'));
+
+      if (console.debug) {
+        spies.push(sinon.spy(console, 'debug'));
+      }
+
+      reloadLogger();
+    });
+
+    afterEach(function () {
+      spies.forEach(spy => spy.restore());
+      spies = [];
+    });
+
+    it('Should not emit log if log level is silent', function () {
+      var logger = logging.getLogger();
+      logger.setLevel('silent');
+      logger.debug('test');
+      logger.info('test');
+      logger.warn('test');
+      logger.error('test');
+
+      spies.forEach(spy => expect(spy).to.not.be.called);
+    });
+
+    it('Should only emit error logs if level is error', function () {
+      var logger = logging.getLogger();
+      logger.setLevel('error');
+      logger.debug('test');
+      logger.info('test');
+      logger.warn('test');
+      logger.error('test');
+
+      expect(console.error).to.be.calledOnce;
+      spies.filter(spy => spy !== console.error)
+        .forEach(spy => expect(spy).to.not.be.called);
+    });
+
+    it('Should emit error and warn logs if level is warn', function () {
+      var logger = logging.getLogger();
+      logger.setLevel('warn');
+      logger.debug('test');
+      logger.info('test');
+      logger.warn('test');
+      logger.error('test');
+
+      var expected = [ console.error, console.warn ];
+      expected.forEach(spy => expect(spy).to.be.called);
+      spies.filter(spy => !expected.includes(spy))
+        .forEach(spy => expect(spy).to.not.be.called);
+    });
+
+    it('Should emit error, warn, and info logs if level is info', function () {
+      var logger = logging.getLogger();
+      logger.setLevel('info');
+      logger.debug('test');
+      logger.info('test');
+      logger.warn('test');
+      logger.error('test');
+
+      var expected = [ console.error, console.warn, console.info ];
+      expected.forEach(spy => expect(spy).to.be.called);
+      spies.filter(spy => !expected.includes(spy))
+        .forEach(spy => expect(spy).to.not.be.called);
+    });
+
+    it('Should emit all logs if level is debug', function () {
+      var logger = logging.getLogger();
+      logger.setLevel('debug');
+      logger.debug('test');
+      logger.info('test');
+      logger.warn('test');
+      logger.error('test');
+
+      var filterMethod = console.debug ? (spy => spy !== console.log) : (() => true);
+      spies.filter(filterMethod).forEach(spy => expect(spy).to.be.called);
+    });
+  });
+  /* eslint-enable no-console */
 });


### PR DESCRIPTION
Issue #, if available:
#10 #48 #103

Description of changes:
Migration of merge request #190 to the 2.x branch as requested by @willarmiros 

Alternative approach to upgrading the logging to that proposed in #188 - both requests aren't needed, it's one or the other.

Instead of upgrading the Winston library this change creates a simple logger that can be used instead. This change also standardises the logging format for in all environments and ensures that the specified logging level is honoured in lambda environments.

As far as I can tell the meta (or second argument to the logging functions) is only used in two places, both of which log out err.stack. As previously implemented this was converted into a JSON string which made it hard to read. The logger was changed so that strings (such as the stack trace) are printed out without being stringified.

Additionally the ability to change the log level was added whereas previously this could only be done via environmental variables before the module is loaded.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.