### PR TITLE
Resolve critical dependency warning when bundling XRay SDK with webpack

### DIFF
--- a/packages/core/lib/patchers/call_capturer.js
+++ b/packages/core/lib/patchers/call_capturer.js
@@ -38,7 +38,7 @@ CallCapturer.prototype.append = function append(source) {
 
   if (typeof source === 'string') {
     logger.getLogger().info('Appending AWS whitelist with custom file: ' + source);
-    newServices = loadWhitelist(require(source));
+    newServices = loadWhitelist(require(`${source}`));
   } else {
     logger.getLogger().info('Appending AWS whitelist with a custom source.');
     newServices = loadWhitelist(source);


### PR DESCRIPTION
This change resolves the following error that is encountered:

./node_modules/aws-xray-sdk-core/lib/patchers/call_capturer.js 41:32-47
Critical dependency: the request of a dependency is an expression

When running:

webpack version 4.39.2
aws-xray-sdk version 2.3.6

*Issue #103*

*Description of changes:*

Use template literal embedded expression when require `source` in `call_capture.js`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
