### PR TITLE
Lazily create socket in SegmentEmitter (2.x)

### DIFF
--- a/packages/core/lib/segment_emitter.js
+++ b/packages/core/lib/segment_emitter.js
@@ -102,7 +102,6 @@ BatchingTemporarySocket.prototype.send = function (msg, offset, length, port, ad
  */
 
 var SegmentEmitter = {
-  socket: dgram.createSocket('udp4'),
   daemonConfig: require('./daemon_config'),
 
   /**
@@ -119,6 +118,9 @@ var SegmentEmitter = {
    */
 
   send: function send(segment) {
+    if (!this.socket) {
+      this.socket = dgram.createSocket('udp4'); 
+    }
     var client = this.socket;
     var formatted = segment.format();
     var data = PROTOCOL_HEADER + PROTOCOL_DELIMITER + formatted;

--- a/packages/core/lib/segment_emitter.js
+++ b/packages/core/lib/segment_emitter.js
@@ -119,7 +119,11 @@ var SegmentEmitter = {
 
   send: function send(segment) {
     if (!this.socket) {
-      this.socket = dgram.createSocket('udp4'); 
+      if (this.useBatchingTemporarySocket) {
+        this.socket = new BatchingTemporarySocket();
+      } else {
+        this.socket = dgram.createSocket('udp4');
+      }
     }
     var client = this.socket;
     var formatted = segment.format();
@@ -180,7 +184,7 @@ var SegmentEmitter = {
    */
 
   disableReusableSocket: function() {
-    this.socket = new BatchingTemporarySocket();
+    this.useBatchingTemporarySocket = true;
   }
 };
 

--- a/packages/core/test/unit/segment_emitter.test.js
+++ b/packages/core/test/unit/segment_emitter.test.js
@@ -87,8 +87,8 @@ describe('SegmentEmitter', function() {
         SegmentEmitter.disableReusableSocket();
       }
 
-      it('should send the segment using the dgram client', testSegmentSend.bind(undefined, 1, 2, configureHook));
-      it('should share the dgram client between many segments sent at once', testSegmentSend.bind(undefined, 10, 3, configureHook));
+      it('should send the segment using the dgram client', testSegmentSend.bind(undefined, 1, 1, configureHook));
+      it('should share the dgram client between many segments sent at once', testSegmentSend.bind(undefined, 10, 2, configureHook));
     });
   });
 


### PR DESCRIPTION
This addresses issue #142. While that issue points to other open handles, `segment_emitter` is currently opening a UDP handle as soon as it's required in a file.

This initializes the socket only on first send which should prevent the false positive errors mentioned in #142.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
