### PR TITLE
Removed restify from lerna tests

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "lerna": "3.15.0",
   "packages": [
-    "packages/*"
+    "packages/!(restify)"
   ],
   "version": "independent",
   "npmClientArgs": [


### PR DESCRIPTION
*Description of changes:*
This excludes the `restify` beta package from tests run with lerna on the `experimental-hooks` branch. For some reason this package caused `lerna` to hang when running tests, so since the `restify` package doesn't have an experimental release, it doesn't need to be tested so it can be safely excluded.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
