### PR TITLE
Added setUser() operation

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -337,6 +337,14 @@ This will solve the issue where the subsegments within a Promise chain are attac
 
     subsegment.addMetadata(key, value);
     subsegment.addMetadata(key, value, 'greeting');   //custom namespace
+    
+### Set user
+
+Note that this operation will not work in Lambda functions, because the segment object is immutable. `setUser()` can only be applied to segments, not subsegments. 
+
+    var user = 'john123';
+    
+    AWSXRay.getSegment().setUser(user);
 
 ### Create new subsegment
 

--- a/packages/core/lib/segments/segment.js
+++ b/packages/core/lib/segments/segment.js
@@ -89,7 +89,7 @@ Segment.prototype.addAnnotation = function addAnnotation(key, value) {
  */
 Segment.prototype.setUser = function (user) {
   if (typeof user !== 'string') {
-    logger.getLogger().error('Set user:' + user + 'failed. User IDs must be of type string.');
+    logger.getLogger().error('Set user: ' + user + ' failed. User IDs must be of type string.');
   }
   this.user = user;
 }

--- a/packages/core/lib/segments/segment.js
+++ b/packages/core/lib/segments/segment.js
@@ -83,6 +83,18 @@ Segment.prototype.addAnnotation = function addAnnotation(key, value) {
 };
 
 /**
+ * Adds a User ID that can be queried from the X-Ray console. User ID
+ * must be a string.
+ * @param {string} user - The ID of the user corresponding to this segment
+ */
+Segment.prototype.setUser = function (user) {
+  if (typeof user !== 'string') {
+    logger.getLogger().error('Set user:' + user + 'failed. User IDs must be of type string.');
+  }
+  this.user = user;
+}
+
+/**
  * Adds a key-value pair to the metadata.default attribute when no namespace is given.
  * Metadata is not queryable, but is recorded.
  * @param {string} key - The name of the key to add.


### PR DESCRIPTION
*Description of changes:*
Adds `segment.setUser()` operation to maintain feature parity with other SDKs, as pointed out in #107. 

Tested with a sample app, the user attribute appeared in traces and was queryable with the "user" keyword on X-Ray console.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
