### PR TITLE
Add TypeScript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "mocha": "^6.2.0",
     "nock": "^10.0.6",
     "sinon": "^4.5.0",
-    "sinon-chai": "^2.8.0"
+    "sinon-chai": "^2.8.0",
+    "tsd": "^0.10.0"
   },
   "engines": {
     "node": ">= 4.x",

--- a/packages/core/lib/aws-xray.d.ts
+++ b/packages/core/lib/aws-xray.d.ts
@@ -1,0 +1,71 @@
+import * as ec2Plugin from './segments/plugins/ec2_plugin';
+import * as ecsPlugin from './segments/plugins/ecs_plugin';
+import * as elasticBeanstalkPlugin from './segments/plugins/elastic_beanstalk_plugin';
+import * as segmentUtils from './segments/segment_utils';
+import * as utils from './utils';
+import * as middleware from './middleware/mw_utils';
+import Segment = require('./segments/segment');
+import Subsegment = require('./segments/attributes/subsegment');
+import sqlData = require('./database/sql_data');
+
+export namespace plugins {
+  const EC2Plugin: typeof ec2Plugin;
+  const ECSPlugin: typeof ecsPlugin;
+  const ElasticBeanstalkPlugin: typeof elasticBeanstalkPlugin;
+
+  type EC2Plugin = typeof ec2Plugin;
+  type ECSPlugin = typeof ecsPlugin;
+  type ElasticBeanstalkPlugin = typeof elasticBeanstalkPlugin;
+
+  type EC2Metadata = ec2Plugin.EC2Metadata;
+  type ECSMetadata = ecsPlugin.ECSMetadata;
+  type ElasticBeanstalkMetadata = elasticBeanstalkPlugin.ElasticBeanstalkMetadata;
+
+  type Plugin = EC2Plugin | ECSPlugin | ElasticBeanstalkPlugin;
+}
+
+export function config(plugins: plugins.Plugin[]): void;
+
+export { appendAWSWhitelist, setAWSWhitelist } from './segments/attributes/aws';
+
+export { setStreamingThreshold } from './segments/segment_utils';
+
+export { setLogger, getLogger, Logger } from './logger';
+
+export { setDaemonAddress } from './daemon_config'
+
+export { captureAsyncFunc, captureCallbackFunc, captureFunc } from './capture'
+
+export { captureAWS, captureAWSClient } from './patchers/aws_p';
+
+export { captureHTTPs, captureHTTPsGlobal } from './patchers/http_p';
+
+export { capturePromise } from './patchers/promise_p';
+
+export { utils }
+
+export namespace database {
+  const SqlData: typeof sqlData;
+  type SqlData = sqlData;
+}
+
+export { middleware }
+
+export {
+  getNamespace,
+  resolveSegment,
+  getSegment,
+  setSegment,
+  isAutomaticMode,
+  enableAutomaticMode,
+  enableManualMode,
+  setContextMissingStrategy
+} from './context_utils';
+
+export {
+  Segment,
+  Subsegment,
+  segmentUtils as SegmentUtils
+}
+
+export type SegmentLike = Segment | Subsegment;

--- a/packages/core/lib/capture.d.ts
+++ b/packages/core/lib/capture.d.ts
@@ -1,0 +1,16 @@
+import Segment = require('./segments/segment');
+import Subsegment = require('./segments/attributes/subsegment');
+
+export function captureFunc<T>(name: string, fcn: (subsegment?: Subsegment) => T, parent?: Segment | Subsegment): T;
+
+export function captureAsyncFunc<T>(
+  name: string,
+  fcn: (subsegment?: Subsegment) => T,
+  parent?: Segment | Subsegment
+): T;
+
+export function captureCallbackFunc<S extends any[], T>(
+  name: string,
+  fcn: (...args: S) => T,
+  parent?: Segment | Subsegment
+): (...args: S) => T;

--- a/packages/core/lib/context_utils.d.ts
+++ b/packages/core/lib/context_utils.d.ts
@@ -1,0 +1,21 @@
+import { Namespace } from 'continuation-local-storage';
+import Segment = require('./segments/segment');
+import Subsegment = require('./segments/attributes/subsegment');
+
+export function getNamespace(): Namespace;
+
+export function resolveSegment(segment: Segment | Subsegment): Segment | Subsegment | undefined;
+
+export function getSegment(): Segment | Subsegment | undefined;
+
+export function setSegment(segment: Segment | Subsegment): void;
+
+export function isAutomaticMode(): boolean;
+
+export function enableAutomaticMode(): void;
+
+export function enableManualMode(): void;
+
+export type ContextMissingStrategy = 'LOG_ERROR' | 'RUNTIME_ERROR' | ((msg: string) => void);
+
+export function setContextMissingStrategy(strategy: ContextMissingStrategy): void;

--- a/packages/core/lib/daemon_config.d.ts
+++ b/packages/core/lib/daemon_config.d.ts
@@ -1,0 +1,1 @@
+export function setDaemonAddress(address: string): void;

--- a/packages/core/lib/database/sql_data.d.ts
+++ b/packages/core/lib/database/sql_data.d.ts
@@ -1,0 +1,11 @@
+declare class SqlData {
+  database_version?: string;
+  driver_version?: string;
+  preparation?: string;
+  url?: string;
+  user?: string;
+
+  constructor(databaseVer?: string, driverVer?: string, user?: string, url?: string, queryType?: string);
+}
+
+export = SqlData;

--- a/packages/core/lib/index.d.ts
+++ b/packages/core/lib/index.d.ts
@@ -1,0 +1,1 @@
+export * from './aws-xray';

--- a/packages/core/lib/logger.d.ts
+++ b/packages/core/lib/logger.d.ts
@@ -1,0 +1,10 @@
+export interface Logger {
+  debug(...args: any[]): any;
+  info(...args: any[]): any;
+  warn(...args: any[]): any;
+  error(...args: any[]): any;
+}
+
+export function setLogger(logObj: Logger): void;
+
+export function getLogger(): Logger;

--- a/packages/core/lib/middleware/incoming_request_data.d.ts
+++ b/packages/core/lib/middleware/incoming_request_data.d.ts
@@ -1,0 +1,11 @@
+import * as http from 'http';
+
+declare class IncomingRequestData {
+  request: { [key: string]: any };
+
+  constructor(req: http.IncomingMessage);
+
+  close(res: http.ServerResponse): void;
+}
+
+export = IncomingRequestData;

--- a/packages/core/lib/middleware/mw_utils.d.ts
+++ b/packages/core/lib/middleware/mw_utils.d.ts
@@ -1,0 +1,60 @@
+import * as http from 'http';
+import Segment = require('../segments/segment');
+import IncomingRequestData = require('./incoming_request_data');
+
+export const defaultName: string | undefined;
+
+export const dynamicNaming: boolean;
+
+export const hostPattern: string | null;
+
+export function enableDynamicNaming(hostPattern?: string): void;
+
+export function processHeaders(req?: Partial<Pick<http.IncomingMessage, 'headers'>>): { [key: string]: string };
+
+export function resolveName(hostHeader?: string): string;
+
+export function resolveSampling(
+  amznTraceHeader: { [key: string]: string },
+  segment: Segment,
+  res: http.ServerResponse
+): void;
+
+export function setDefaultName(name: string): void;
+
+export function disableCentralizedSampling(): void;
+
+export interface BaseRuleConfig {
+  http_method: string;
+  url_path: string;
+  fixed_target: number;
+  rate: number;
+  description?: string;
+}
+
+export interface RuleConfigV1 extends BaseRuleConfig {
+  service_name: string;
+}
+
+export interface RuleConfigV2 extends BaseRuleConfig {
+  host: string;
+}
+
+export type RuleConfig = RuleConfigV1 | RuleConfigV2;
+
+export interface DefaultRuleConfig {
+  fixed_target: number;
+  rate: number;
+}
+
+export interface RulesConfig {
+  version: number;
+  default: DefaultRuleConfig;
+  rules?: RuleConfig[];
+}
+
+export function setSamplingRules(source: string | RulesConfig): void;
+
+export {
+  IncomingRequestData
+}

--- a/packages/core/lib/patchers/aws_p.d.ts
+++ b/packages/core/lib/patchers/aws_p.d.ts
@@ -1,0 +1,38 @@
+import * as AWS from 'aws-sdk';
+import Segment = require('../segments/segment');
+import Subsegment = require('../segments/attributes/subsegment');
+
+export type Callback<D> = (err: AWS.AWSError | undefined, data: D) => void;
+
+export interface AWSRequestMethod<P, D> {
+  (params: P, callback?: Callback<D>): AWS.Request<D, AWS.AWSError>;
+  (callback?: Callback<D>): AWS.Request<D, AWS.AWSError>;
+}
+
+export type PatchedAWSRequestMethod<P, D> = AWSRequestMethod<P & { XRaySegment?: Segment | Subsegment }, D>;
+
+export type PatchedAWSClient<T extends AWS.Service> = {
+  [K in keyof T]: T[K] extends AWSRequestMethod<infer P, infer D>
+  ? PatchedAWSRequestMethod<P, D>
+  : T[K]
+};
+
+export interface AWSClientConstructor<P, T extends typeof AWS.Service> {
+  new(params?: P): InstanceType<T>;
+}
+
+export interface PatchedAWSClientConstructor<P, T extends typeof AWS.Service> {
+  new(params?: P): PatchedAWSClient<InstanceType<T>>;
+}
+
+export type PatchedAWS<T = typeof AWS> = {
+  [K in keyof T]: T[K] extends typeof AWS.Service
+  ? (T[K] extends AWSClientConstructor<infer P, T[K]>
+    ? PatchedAWSClientConstructor<P, T[K]>
+    : T[K])
+  : T[K];
+};
+
+export function captureAWS(awssdk: typeof AWS): PatchedAWS;
+
+export function captureAWSClient<T extends AWS.Service>(service: T): PatchedAWSClient<T>;

--- a/packages/core/lib/patchers/http_p.d.ts
+++ b/packages/core/lib/patchers/http_p.d.ts
@@ -1,0 +1,6 @@
+import * as http from 'http';
+import * as https from 'https';
+
+export function captureHTTPs<T extends typeof http | typeof https>(mod: T, downstreamXRayEnabled: boolean): T;
+
+export function captureHTTPsGlobal(mod: typeof https | typeof http, downstreamXRayEnabled: boolean): void;

--- a/packages/core/lib/patchers/promise_p.d.ts
+++ b/packages/core/lib/patchers/promise_p.d.ts
@@ -1,0 +1,4 @@
+export const capturePromise: {
+  (): void;
+  patchThirdPartyPromise(Promise: any): void;
+};

--- a/packages/core/lib/segments/attributes/aws.d.ts
+++ b/packages/core/lib/segments/attributes/aws.d.ts
@@ -1,0 +1,15 @@
+import * as AWS from 'aws-sdk';
+
+declare class Aws {
+  constructor(res: AWS.Response<any, any>, serviceName: string);
+
+  addData(data: any): void;
+}
+
+declare namespace Aws {
+  function setAWSWhitelist(source: string | object): void;
+
+  function appendAWSWhitelist(source: string | object): void;
+}
+
+export = Aws;

--- a/packages/core/lib/segments/attributes/subsegment.d.ts
+++ b/packages/core/lib/segments/attributes/subsegment.d.ts
@@ -1,0 +1,56 @@
+import * as http from 'http';
+
+declare class Subsegment {
+  id: string;
+  name: string;
+  start_time: number;
+  in_progress?: boolean;
+
+  constructor(name: string);
+
+  addNewSubsegment(name: string): Subsegment;
+
+  addSubsegment(subsegment: Subsegment): void;
+
+  removeSubsegment(subsegment: Subsegment): void;
+
+  addAttribute(name: string, data: any): void;
+
+  addPrecursorId(id: string): void;
+
+  addAnnotation(key: string, value: boolean | string | number): void;
+
+  addMetadata(key: string, value: any, namespace?: string): void;
+
+  addSqlData(sqlData: any): void;
+
+  addError(err: Error | string, remote?: boolean): void;
+
+  addRemoteRequestData(req: http.ClientRequest, res: http.IncomingMessage, downstreamXRayEnabled: boolean): void;
+
+  addFaultFlag(): void;
+
+  addErrorFlag(): void;
+
+  addThrottleFlag(): void;
+
+  close(err?: Error | string | null, remote?: boolean): void;
+
+  incrementCounter(additional?: number): void;
+
+  decrementCounter(): void;
+
+  isClosed(): boolean;
+
+  flush(): void;
+
+  streamSubsegments(): true | undefined;
+
+  format(): string;
+
+  toString(): string;
+
+  toJSON(): { [key: string]: any };
+}
+
+export = Subsegment;

--- a/packages/core/lib/segments/plugins/ec2_plugin.d.ts
+++ b/packages/core/lib/segments/plugins/ec2_plugin.d.ts
@@ -1,0 +1,10 @@
+export interface EC2Metadata {
+  ec2: {
+    instance_id: string;
+    availability_zone: string;
+  };
+}
+
+export function getData(callback: (metadata?: EC2Metadata) => void): void;
+
+export const originName: string;

--- a/packages/core/lib/segments/plugins/ecs_plugin.d.ts
+++ b/packages/core/lib/segments/plugins/ecs_plugin.d.ts
@@ -1,0 +1,9 @@
+export interface ECSMetadata {
+  ecs: {
+    container: string;
+  };
+}
+
+export function getData(callback: (metadata?: ECSMetadata) => void): void;
+
+export const originName: string;

--- a/packages/core/lib/segments/plugins/elastic_beanstalk_plugin.d.ts
+++ b/packages/core/lib/segments/plugins/elastic_beanstalk_plugin.d.ts
@@ -1,0 +1,11 @@
+export interface ElasticBeanstalkMetadata {
+  elastic_beanstalk: {
+    environment: string;
+    version_label: string;
+    deployment_id: number;
+  };
+}
+
+export function getData(callback: (metadata?: ElasticBeanstalkMetadata) => void): void;
+
+export const originName: string;

--- a/packages/core/lib/segments/segment.d.ts
+++ b/packages/core/lib/segments/segment.d.ts
@@ -1,0 +1,60 @@
+import Subsegment = require('./attributes/subsegment');
+import IncomingRequestData = require('../middleware/incoming_request_data');
+
+declare class Segment {
+  id: string;
+  name: string;
+  start_time: number;
+  in_progress?: boolean;
+  trace_id: string;
+  parent_id?: string;
+  origin?: string;
+
+  constructor(name: string, rootId?: string | null, parentId?: string | null);
+
+  addIncomingRequestData(data: IncomingRequestData): void;
+
+  addAnnotation(key: string, value: boolean | string | number): void;
+
+  setUser(user: string): void;
+
+  addMetadata(key: string, value: any, namespace?: string): void;
+
+  setSDKData(data: object): void;
+
+  setMatchedSamplingRule(ruleName: string): void;
+
+  setServiceData(data: any): void;
+
+  addPluginData(data: object): void;
+
+  addNewSubsegment(name: string): Subsegment;
+
+  addSubsegment(subsegment: Subsegment): void;
+
+  removeSubsegment(subsegment: Subsegment): void;
+
+  addError(err: Error | string, remote?: boolean): void;
+
+  addFaultFlag(): void;
+
+  addErrorFlag(): void;
+
+  addThrottleFlag(): void;
+
+  isClosed(): boolean;
+
+  incrementCounter(additional?: number): void;
+
+  decrementCounter(): void;
+
+  close(err?: Error | string | null, remote?: boolean): void;
+
+  flush(): void;
+
+  format(): string;
+
+  toString(): string;
+}
+
+export = Segment;

--- a/packages/core/lib/segments/segment_utils.d.ts
+++ b/packages/core/lib/segments/segment_utils.d.ts
@@ -1,0 +1,15 @@
+export const streamingThreshold: number;
+
+export function getCurrentTime(): number;
+
+export function setOrigin(origin: string): void;
+
+export function setPluginData(pluginData: object): void;
+
+export function setSDKData(sdkData: object): void;
+
+export function setServiceData(serviceData: any): void;
+
+export function setStreamingThreshold(threshold: number): void;
+
+export function getStreamingThreshold(): number;

--- a/packages/core/lib/utils.d.ts
+++ b/packages/core/lib/utils.d.ts
@@ -1,0 +1,19 @@
+import Segment = require('./segments/segment');
+
+export function getCauseTypeFromHttpStatus(status: number | string): 'error' | 'fault' | undefined;
+
+export function wildcardMatch(pattern: string, text: string): boolean;
+
+export namespace LambdaUtils {
+  function validTraceData(xAmznTraceId?: string): boolean;
+
+  function populateTraceData(segment: Segment, xAmznTraceId: string): boolean;
+}
+
+export function processTraceData(traceData?: string): { [key: string]: string };
+
+export function objectWithoutProperties<T extends object, K extends keyof T>(
+  obj: T,
+  keys: K[],
+  preservePrototype?: boolean
+): Omit<T, K>;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,7 @@
     "Sandra McMullen <mcmuls@amazon.com>"
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "engines": {
     "node": ">= 4.x"
   },
@@ -14,6 +15,7 @@
     "test": "test"
   },
   "dependencies": {
+    "@types/continuation-local-storage": "*",
     "atomic-batcher": "^1.0.2",
     "aws-sdk": "^2.304.0",
     "continuation-local-storage": "^3.2.0",
@@ -31,10 +33,12 @@
     "mocha": "^6.2.0",
     "nock": "^10.0.6",
     "sinon": "^4.5.0",
-    "sinon-chai": "^2.8.0"
+    "sinon-chai": "^2.8.0",
+    "tsd": "^0.10.0"
   },
   "scripts": {
-    "test": "mocha --recursive ./test/ -R spec"
+    "test": "mocha --recursive ./test/ -R spec && tsd",
+    "test-d": "tsd"
   },
   "keywords": [
     "amazon",

--- a/packages/core/test-d/index.test-d.ts
+++ b/packages/core/test-d/index.test-d.ts
@@ -1,0 +1,227 @@
+import * as AWS from 'aws-sdk';
+import { AWSError } from 'aws-sdk';
+import { PromiseResult } from 'aws-sdk/lib/request';
+import * as http from 'http';
+import * as https from 'https';
+import { Socket } from 'net';
+import { expectType, expectError } from 'tsd';
+import * as url from 'url';
+import * as AWSXRay from '../lib';
+
+expectType<void>(AWSXRay.plugins.EC2Plugin.getData((metadata?: AWSXRay.plugins.EC2Metadata) => { }));
+expectType<void>(AWSXRay.plugins.ECSPlugin.getData((metadata?: AWSXRay.plugins.ECSMetadata) => { }));
+expectType<void>(
+  AWSXRay.plugins.ElasticBeanstalkPlugin.getData((metadata?: AWSXRay.plugins.ElasticBeanstalkMetadata) => { })
+);
+
+expectType<void>(AWSXRay.config([AWSXRay.plugins.EC2Plugin, AWSXRay.plugins.ECSPlugin]));
+expectType<void>(AWSXRay.config([AWSXRay.plugins.ElasticBeanstalkPlugin]));
+
+expectType<void>(AWSXRay.setAWSWhitelist('/path/here'));
+expectType<void>(AWSXRay.setAWSWhitelist({}));
+expectError(AWSXRay.setAWSWhitelist());
+expectError(AWSXRay.setAWSWhitelist(null));
+expectError(AWSXRay.setAWSWhitelist(0));
+
+expectType<void>(AWSXRay.appendAWSWhitelist('/path/here'));
+expectType<void>(AWSXRay.appendAWSWhitelist({}));
+expectError(AWSXRay.appendAWSWhitelist());
+expectError(AWSXRay.appendAWSWhitelist(null));
+expectError(AWSXRay.appendAWSWhitelist(0));
+
+expectType<void>(AWSXRay.setStreamingThreshold(10));
+
+expectType<void>(AWSXRay.setLogger(console));
+AWSXRay.getLogger().debug('debug');
+AWSXRay.getLogger().info({ foo: 'bar' }, 'info');
+AWSXRay.getLogger().warn('warn', 123);
+AWSXRay.getLogger().error('error');
+
+expectType<void>(AWSXRay.setDaemonAddress('192.168.0.23:8080'));
+
+const traceId = '1-57fbe041-2c7ad569f5d6ff149137be86';
+const segment = new AWSXRay.Segment('test', traceId);
+
+expectType<string>(AWSXRay.captureFunc('tracedFcn', () => 'OK', segment));
+expectType<void>(AWSXRay.captureFunc('tracedFcn', () => { return; }));
+expectType<never>(AWSXRay.captureFunc('tracedFcn', () => { throw new Error(); }));
+let subseg: AWSXRay.Subsegment | undefined;
+expectType<void>(AWSXRay.captureFunc('tracedFcn', (sub) => { subseg = sub; }, segment));
+
+async function fcn(seg?: AWSXRay.Subsegment) {
+  if (seg) {
+    seg.close();
+  }
+  return 'OK';
+}
+expectType<Promise<string>>(AWSXRay.captureAsyncFunc('tracedFcn', fcn, segment));
+expectType<Promise<string>>(AWSXRay.captureAsyncFunc('tracedFcn', fcn));
+
+function tracedFcn(callback: (param0: any, param1: any) => any) {
+  callback('hello', 'there');
+}
+function callback(param0: any, param1: any) {
+  console.log({ param0, param1 });
+}
+tracedFcn(AWSXRay.captureCallbackFunc('callback', callback));
+tracedFcn(AWSXRay.captureCallbackFunc('callback', callback, segment));
+
+const aws = AWSXRay.captureAWS(AWS);
+const sqs = new aws.SQS();
+const queues = sqs.listQueues({
+  QueueNamePrefix: 'test',
+  XRaySegment: segment
+});
+expectType<AWS.Request<AWS.SQS.ListQueuesResult, AWSError>>(queues);
+
+const s3 = AWSXRay.captureAWSClient(new AWS.S3());
+async function main() {
+  const objects = await s3.listObjectsV2({
+    Bucket: 'test',
+    XRaySegment: segment
+  }).promise();
+
+  expectType<PromiseResult<AWS.S3.ListObjectsV2Output, AWSError>>(objects);
+}
+
+expectType<typeof http>(AWSXRay.captureHTTPs(http, true));
+expectType<typeof https>(AWSXRay.captureHTTPs(https, true));
+
+expectType<void>(AWSXRay.captureHTTPsGlobal(http, true));
+expectType<void>(AWSXRay.captureHTTPsGlobal(https, true));
+
+expectType<void>(AWSXRay.capturePromise());
+expectType<void>(AWSXRay.capturePromise.patchThirdPartyPromise(Promise));
+
+expectType<'error' | 'fault' | undefined>(AWSXRay.utils.getCauseTypeFromHttpStatus(200));
+expectType<boolean>(AWSXRay.utils.wildcardMatch('*', 'foo'));
+expectType<boolean>(AWSXRay.utils.LambdaUtils.validTraceData('moop'));
+expectType<boolean>(AWSXRay.utils.LambdaUtils.validTraceData());
+expectType<boolean>(AWSXRay.utils.LambdaUtils.populateTraceData(segment, 'moop'));
+expectType<{ [key: string]: string }>(AWSXRay.utils.processTraceData());
+expectType<{ [key: string]: string }>(AWSXRay.utils.processTraceData('Root=1-58ed6027-14afb2e09172c337713486c0;'));
+const urlWithoutQuery: Omit<url.UrlWithStringQuery, 'query'> = AWSXRay.utils.objectWithoutProperties(
+  url.parse('url'), ['query'],
+  true
+);
+expectType<string | undefined>(urlWithoutQuery.path);
+expectError(urlWithoutQuery.query);
+
+new AWSXRay.database.SqlData('databaseVer', 'driverVer', 'user', 'url', 'queryType');
+const sqlData: AWSXRay.database.SqlData = new AWSXRay.database.SqlData();
+expectType<string | undefined>(sqlData.database_version);
+expectType<string | undefined>(sqlData.driver_version);
+expectType<string | undefined>(sqlData.preparation);
+expectType<string | undefined>(sqlData.url);
+expectType<string | undefined>(sqlData.user);
+
+expectType<void>(AWSXRay.middleware.enableDynamicNaming());
+expectType<void>(AWSXRay.middleware.enableDynamicNaming('ww.*-moop.com'));
+expectType<boolean>(AWSXRay.middleware.dynamicNaming);
+expectType<string | null>(AWSXRay.middleware.hostPattern);
+expectType<{ [key: string]: string }>(AWSXRay.middleware.processHeaders());
+expectType<{ [key: string]: string }>(AWSXRay.middleware.processHeaders({}));
+expectType<{ [key: string]: string }>(AWSXRay.middleware.processHeaders({ headers: {} }));
+expectType<{ [key: string]: string }>(
+  AWSXRay.middleware.processHeaders({ headers: { 'x-amzn-trace-id': 'Root=' + traceId } })
+);
+expectType<void>(AWSXRay.middleware.setDefaultName('defaultName'));
+expectType<string>(AWSXRay.middleware.resolveName('www.myhost.com'));
+expectType<string>(AWSXRay.middleware.resolveName());
+expectType<void>(AWSXRay.middleware.disableCentralizedSampling());
+expectType<void>(AWSXRay.middleware.setSamplingRules('/path/here'));
+const rulesConfig: AWSXRay.middleware.RulesConfig = {
+  version: 2,
+  rules: [
+    {
+      description: 'Player moves.',
+      host: '*',
+      http_method: '*',
+      url_path: '/api/move/*',
+      fixed_target: 0,
+      rate: 1
+    }
+  ],
+  default: {
+    fixed_target: 0,
+    rate: 0
+  }
+};
+expectType<void>(AWSXRay.middleware.setSamplingRules(rulesConfig));
+
+expectType<string>(AWSXRay.getNamespace().name);
+expectType<AWSXRay.Segment | AWSXRay.Subsegment | undefined>(AWSXRay.resolveSegment(segment));
+expectType<AWSXRay.Segment | AWSXRay.Subsegment | undefined>(AWSXRay.getSegment());
+expectType<void>(AWSXRay.setSegment(segment));
+expectType<boolean>(AWSXRay.isAutomaticMode());
+expectType<void>(AWSXRay.enableAutomaticMode());
+expectType<void>(AWSXRay.enableManualMode());
+expectType<void>(AWSXRay.setContextMissingStrategy('LOG_ERROR'));
+expectType<void>(AWSXRay.setContextMissingStrategy('RUNTIME_ERROR'));
+expectType<void>(AWSXRay.setContextMissingStrategy(function() { }));
+expectError(AWSXRay.setContextMissingStrategy('moop'));
+expectError(AWSXRay.setContextMissingStrategy({}));
+
+const rootId = '1-57fbe041-2c7ad569f5d6ff149137be86';
+const parentId = 'f9c6e4f0b5116501';
+new AWSXRay.Segment('foo', rootId);
+new AWSXRay.Segment('foo', null, parentId);
+new AWSXRay.Segment('foo');
+expectType<void>(segment.setUser('user'));
+expectType<void>(segment.setSDKData({ sdk_version: '1.0.0-beta' }));
+expectType<void>(segment.setMatchedSamplingRule('rule'));
+expectType<void>(segment.setServiceData({ version: '2.3.0', package: 'sample-app' }));
+expectType<void>(segment.addPluginData({ elastic_beanstalk: { environment: 'my_environment_name' } }));
+const incomingMessage = new http.IncomingMessage(new Socket());
+expectType<void>(segment.addIncomingRequestData(new AWSXRay.middleware.IncomingRequestData(incomingMessage)));
+
+function testSegmentLike(segmentLike: AWSXRay.Segment | AWSXRay.Subsegment) {
+  expectType<void>(segmentLike.addAnnotation('key', true));
+  expectType<void>(segmentLike.addAnnotation('key', 'value'));
+  expectType<void>(segmentLike.addAnnotation('key', 123));
+  expectType<void>(segmentLike.addMetadata('key', [1, 2, 3]));
+  expectType<void>(segmentLike.addMetadata('key', 123));
+  expectType<void>(segmentLike.addMetadata('key', 'value'));
+  expectType<void>(segmentLike.addMetadata('key', [1, 2, 3], 'hello'));
+  expectType<AWSXRay.Subsegment>(segmentLike.addNewSubsegment('newSubsegment'));
+  expectError(segmentLike.addSubsegment({}));
+  expectError(segmentLike.addSubsegment({ key: 'x' }));
+  expectType<void>(segmentLike.addSubsegment(new AWSXRay.Subsegment('new')));
+  expectType<void>(segmentLike.removeSubsegment(new AWSXRay.Subsegment('old')));
+  expectType<void>(segmentLike.addError(new Error('error')));
+  expectType<void>(segmentLike.addError('error'));
+  expectType<void>(segmentLike.addError('error', true));
+  expectError(segmentLike.addError(3));
+  expectType<void>(segmentLike.addFaultFlag());
+  expectType<void>(segmentLike.addErrorFlag());
+  expectType<void>(segmentLike.addThrottleFlag());
+  expectType<boolean>(segmentLike.isClosed());
+  expectType<void>(segmentLike.incrementCounter());
+  expectType<void>(segmentLike.incrementCounter(3));
+  expectType<void>(segmentLike.decrementCounter());
+  expectType<void>(segmentLike.close());
+  expectType<void>(segmentLike.close(new Error('error')));
+  expectType<void>(segmentLike.close('error', true));
+  expectType<void>(segmentLike.close(null, false));
+  expectType<void>(segmentLike.flush());
+  expectType<string>(segmentLike.format());
+  expectType<string>(segmentLike.toString());
+}
+
+const subsegment = new AWSXRay.Subsegment('foo');
+expectType<void>(subsegment.addAttribute('name', 'value'));
+expectType<void>(subsegment.addPrecursorId('id'));
+expectType<void>(subsegment.addSqlData({}));
+const clientRequest = new http.ClientRequest('http://localhost');
+expectType<void>(subsegment.addRemoteRequestData(clientRequest, incomingMessage, true));
+expectType<true | undefined>(subsegment.streamSubsegments());
+expectType<{ [key: string]: any }>(subsegment.toJSON());
+
+expectType<number>(AWSXRay.SegmentUtils.streamingThreshold);
+expectType<number>(AWSXRay.SegmentUtils.getCurrentTime());
+expectType<void>(AWSXRay.SegmentUtils.setOrigin('hello'));
+expectType<void>(AWSXRay.SegmentUtils.setPluginData({ data: 'hello' }));
+expectType<void>(AWSXRay.SegmentUtils.setSDKData({ sdk_version: '1.0.0-beta' }));
+expectType<void>(AWSXRay.SegmentUtils.setServiceData({ version: '2.3.0', package: 'sample-app' }));
+expectType<number>(AWSXRay.SegmentUtils.getStreamingThreshold());
+expectType<void>(AWSXRay.SegmentUtils.setStreamingThreshold(0));

--- a/packages/express/lib/express_mw.d.ts
+++ b/packages/express/lib/express_mw.d.ts
@@ -1,0 +1,5 @@
+import { ErrorRequestHandler, RequestHandler, Request } from 'express';
+
+export function openSegment(defaultName: string): RequestHandler;
+
+export function closeSegment(): ErrorRequestHandler;

--- a/packages/express/lib/index.d.ts
+++ b/packages/express/lib/index.d.ts
@@ -1,0 +1,11 @@
+import * as AWSXRay from 'aws-xray-sdk-core'
+
+declare global {
+  namespace Express {
+    interface Request {
+      segment?: AWSXRay.Segment;
+    }
+  }
+}
+
+export * from './express_mw';

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -7,11 +7,15 @@
     "Sandra McMullen <mcmuls@amazon.com>"
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "engines": {
     "node": ">= 4.x"
   },
   "directories": {
     "test": "test"
+  },
+  "dependencies": {
+    "@types/express": "*"
   },
   "peerDependencies": {
     "aws-xray-sdk-core": "^2.4.0"
@@ -26,10 +30,12 @@
     "mocha": "^6.2.0",
     "nock": "^10.0.6",
     "sinon": "^4.5.0",
-    "sinon-chai": "^2.8.0"
+    "sinon-chai": "^2.8.0",
+    "tsd": "^0.10.0"
   },
   "scripts": {
-    "test": "mocha --recursive ./test/ -R spec"
+    "test": "mocha --recursive ./test/ -R spec && tsd",
+    "test-d": "tsd"
   },
   "keywords": [
     "amazon",

--- a/packages/express/test-d/index.test-d.ts
+++ b/packages/express/test-d/index.test-d.ts
@@ -1,0 +1,15 @@
+import * as AWSXRay from 'aws-xray-sdk-core';
+import * as express from 'express';
+import { expectType } from 'tsd';
+import * as xrayExpress from '../lib';
+
+const app = express();
+
+app.use(xrayExpress.openSegment('defaultName'));
+
+app.get('/', function(req, res) {
+  expectType<AWSXRay.Segment | undefined>(req.segment);
+  res.render('index');
+});
+
+app.use(xrayExpress.closeSegment());

--- a/packages/full_sdk/lib/index.d.ts
+++ b/packages/full_sdk/lib/index.d.ts
@@ -1,0 +1,11 @@
+import * as express from 'aws-xray-sdk-express';
+import captureMySQL = require('aws-xray-sdk-mysql');
+import capturePostgres = require('aws-xray-sdk-postgres');
+
+export * from 'aws-xray-sdk-core';
+
+export {
+  express,
+  captureMySQL,
+  capturePostgres
+}

--- a/packages/full_sdk/package.json
+++ b/packages/full_sdk/package.json
@@ -7,6 +7,7 @@
     "Sandra McMullen <mcmuls@amazon.com>"
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "engines": {
     "node": ">= 4.x"
   },
@@ -16,6 +17,13 @@
     "aws-xray-sdk-mysql": "^2.4.0",
     "aws-xray-sdk-postgres": "^2.4.0",
     "pkginfo": "^0.4.0"
+  },
+  "devDependencies": {
+    "tsd": "^0.10.0"
+  },
+  "scripts": {
+    "test": "tsd",
+    "test-d": "tsd"
   },
   "keywords": [
     "amazon",

--- a/packages/full_sdk/test-d/index.test-d.ts
+++ b/packages/full_sdk/test-d/index.test-d.ts
@@ -1,0 +1,9 @@
+import * as express from 'aws-xray-sdk-express';
+import captureMySQL = require('aws-xray-sdk-mysql');
+import capturePostgres = require('aws-xray-sdk-postgres');
+import { expectType } from 'tsd';
+import * as AWSXRay from '../lib';
+
+expectType<typeof express>(AWSXRay.express);
+expectType<typeof captureMySQL>(AWSXRay.captureMySQL);
+expectType<typeof capturePostgres>(AWSXRay.capturePostgres);

--- a/packages/mysql/lib/index.d.ts
+++ b/packages/mysql/lib/index.d.ts
@@ -1,0 +1,2 @@
+import captureMySQL = require('./mysql_p');
+export = captureMySQL;

--- a/packages/mysql/lib/mysql_p.d.ts
+++ b/packages/mysql/lib/mysql_p.d.ts
@@ -1,0 +1,77 @@
+import * as AWSXRay from 'aws-xray-sdk-core';
+import * as MySQL from 'mysql';
+
+declare function captureMySQL(mysql: typeof MySQL): captureMySQL.PatchedMySQL;
+
+declare namespace captureMySQL {
+  interface PatchedQueryFunction {
+    (query: MySQL.Query, segment?: AWSXRay.SegmentLike): MySQL.Query;
+    (options: string | MySQL.QueryOptions, callback?: MySQL.queryCallback, segment?: AWSXRay.SegmentLike): MySQL.Query;
+    (options: string, values: any, callback?: MySQL.queryCallback, segment?: AWSXRay.SegmentLike): MySQL.Query;
+  }
+
+  type PatchedConnection<T = MySQL.Connection> = {
+    [K in keyof T]: K extends 'query'
+    ? PatchedQueryFunction
+    : T[K];
+  };
+
+  type PatchedPoolConnection = PatchedConnection<MySQL.PoolConnection>;
+
+  type PatchedPoolConnectionCallback = (err: MySQL.MysqlError, connection: PatchedPoolConnection) => void;
+
+  interface PatchedPoolGetConnectionFunction {
+    (callback: PatchedPoolConnectionCallback): void;
+  }
+
+  type PatchedPool<T = MySQL.Pool> = {
+    [K in keyof T]: K extends 'query'
+    ? PatchedQueryFunction
+    : K extends 'getConnection'
+    ? PatchedPoolGetConnectionFunction
+    : T[K];
+  };
+
+  interface PatchedPoolClusterOfFunction {
+    (pattern: string, selector?: string): PatchedPool;
+    (pattern: undefined | null | false, selector: string): PatchedPool;
+  }
+
+  interface PatchedPoolClusterGetConnectionFunction {
+    (callback: PatchedPoolConnectionCallback): void;
+    (pattern: string, callback: PatchedPoolConnectionCallback): void;
+    (pattern: string, selector: string, callback: PatchedPoolConnectionCallback): void;
+  }
+
+  type PatchedPoolCluster<T = MySQL.PoolCluster> = {
+    [K in keyof T]: K extends 'of'
+    ? PatchedPoolClusterOfFunction
+    : K extends 'getConnection'
+    ? PatchedPoolClusterGetConnectionFunction
+    : T[K]
+  };
+
+  interface PatchedCreateConnectionFunction {
+    (connectionUri: string | MySQL.ConnectionConfig): PatchedConnection;
+  }
+
+  interface PatchedCreatePoolFunction {
+    (config: MySQL.PoolConfig | string): PatchedPool;
+  }
+
+  interface PatchedCreatePoolClusterFunction {
+    (config?: MySQL.PoolClusterConfig): PatchedPoolCluster;
+  }
+
+  type PatchedMySQL<T = typeof MySQL> = {
+    [K in keyof T]: K extends 'createConnection'
+    ? PatchedCreateConnectionFunction
+    : K extends 'createPool'
+    ? PatchedCreatePoolFunction
+    : K extends 'createPoolCluster'
+    ? PatchedCreatePoolClusterFunction
+    : T[K];
+  };
+}
+
+export = captureMySQL;

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -7,11 +7,15 @@
     "Sandra McMullen <mcmuls@amazon.com>"
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "engines": {
     "node": ">= 4.x"
   },
   "directories": {
     "test": "test"
+  },
+  "dependencies": {
+    "@types/mysql": "*"
   },
   "peerDependencies": {
     "aws-xray-sdk-core": "^2.4.0"
@@ -26,10 +30,12 @@
     "mocha": "^6.2.0",
     "nock": "^10.0.6",
     "sinon": "^4.5.0",
-    "sinon-chai": "^2.8.0"
+    "sinon-chai": "^2.8.0",
+    "tsd": "^0.10.0"
   },
   "scripts": {
-    "test": "mocha --recursive ./test/ -R spec"
+    "test": "mocha --recursive ./test/ -R spec && tsd",
+    "test-d": "tsd"
   },
   "keywords": [
     "amazon",

--- a/packages/mysql/test-d/index.test-d.ts
+++ b/packages/mysql/test-d/index.test-d.ts
@@ -1,0 +1,35 @@
+import * as AWSXRay from 'aws-xray-sdk-core';
+import * as MySQL from 'mysql';
+import { expectType } from 'tsd';
+import captureMySQL = require('../lib');
+
+const segment = AWSXRay.getSegment();
+
+const mysql = captureMySQL(MySQL);
+
+const config = {};
+
+const connection: captureMySQL.PatchedConnection = mysql.createConnection(config);
+const pool: captureMySQL.PatchedPool = mysql.createPool(config);
+const poolCluster: captureMySQL.PatchedPoolCluster = mysql.createPoolCluster(config);
+
+const queryCallback: MySQL.queryCallback = function(err: MySQL.MysqlError | null, rows: any) {
+}
+
+const getConnectionCallback = function(err: MySQL.MysqlError, conn: captureMySQL.PatchedConnection) {
+}
+
+expectType<MySQL.Query>(connection.query('SELECT * FROM cats', queryCallback));
+expectType<MySQL.Query>(connection.query('SELECT * FROM cats', queryCallback, segment));
+
+expectType<MySQL.Query>(pool.query('SELECT * FROM cats', queryCallback));
+expectType<MySQL.Query>(pool.query('SELECT * FROM cats', queryCallback, segment));
+expectType<void>(pool.getConnection(getConnectionCallback));
+
+expectType<void>(poolCluster.getConnection(getConnectionCallback));
+expectType<void>(poolCluster.getConnection('pattern', getConnectionCallback));
+expectType<void>(poolCluster.getConnection('pattern', 'selector', getConnectionCallback));
+
+expectType<captureMySQL.PatchedPool>(poolCluster.of('pattern'));
+expectType<captureMySQL.PatchedPool>(poolCluster.of('pattern', 'selector'));
+expectType<captureMySQL.PatchedPool>(poolCluster.of(null, 'selector'));

--- a/packages/postgres/lib/index.d.ts
+++ b/packages/postgres/lib/index.d.ts
@@ -1,0 +1,2 @@
+import capturePostgres = require('./postgres_p');
+export = capturePostgres;

--- a/packages/postgres/lib/postgres_p.d.ts
+++ b/packages/postgres/lib/postgres_p.d.ts
@@ -1,0 +1,112 @@
+import * as AWSXRay from 'aws-xray-sdk-core';
+import * as PG from 'pg';
+
+declare function capturePostgres(pg: typeof PG): capturePostgres.PatchedPostgres;
+
+declare namespace capturePostgres {
+  interface CaptureQueryMethod {
+    <T extends PG.Submittable>(queryStream: T, segment?: AWSXRay.SegmentLike): T;
+
+    <R extends any[] = any[], I extends any[] = any[]>(
+      queryConfig: PG.QueryArrayConfig<I>,
+      values?: I,
+      segment?: AWSXRay.SegmentLike
+    ): Promise<PG.QueryArrayResult<R>>;
+
+    <R extends PG.QueryResultRow = any, I extends any[] = any[]>(
+      queryConfig: PG.QueryConfig<I>,
+      segment?: AWSXRay.SegmentLike
+    ): Promise<PG.QueryResult<R>>;
+
+    <R extends PG.QueryResultRow = any, I extends any[] = any[]>(
+      queryTextOrConfig: string | PG.QueryConfig<I>,
+      values?: I,
+      segment?: AWSXRay.SegmentLike
+    ): Promise<PG.QueryResult<R>>;
+
+    <R extends any[] = any[], I extends any[] = any[]>(
+      queryConfig: PG.QueryArrayConfig<I>,
+      callback: (err: Error, result: PG.QueryArrayResult<R>) => void,
+      segment?: AWSXRay.SegmentLike
+    ): void;
+
+    <R extends PG.QueryResultRow = any, I extends any[] = any[]>(
+      queryTextOrConfig: string | PG.QueryConfig<I>,
+      callback: (err: Error, result: PG.QueryResult<R>) => void,
+      segment?: AWSXRay.SegmentLike
+    ): void;
+
+    <R extends PG.QueryResultRow = any, I extends any[] = any[]>(
+      queryText: string,
+      values: any[],
+      callback: (err: Error, result: PG.QueryResult<R>) => void,
+      segment?: AWSXRay.SegmentLike
+    ): void;
+  }
+
+  type PatchedClientBase<T extends PG.ClientBase> = {
+    [K in keyof T]: K extends 'query'
+    ? CaptureQueryMethod
+    : T[K];
+  };
+
+  interface PatchedClientBaseConstructor<T extends PG.ClientBase> {
+    new(config?: string | PG.ClientConfig): PatchedClientBase<T>;
+  }
+
+  type PatchedClient = PatchedClientBase<PG.Client>;
+  type PatchedClientConstructor = PatchedClientBaseConstructor<PG.Client>;
+
+  type PatchedPoolClient = PatchedClientBase<PG.PoolClient>;
+  type PatchedPoolClientConstructor = PatchedClientBaseConstructor<PG.PoolClient>;
+
+  interface PatchedPoolConnectMethod {
+    (): Promise<PatchedPoolClient>;
+    (callback: (err: Error, client: PatchedPoolClient, done: (release?: any) => void) => void): void;
+  }
+
+  interface PatchedPoolOnMethod {
+    (event: "error", listener: (err: Error, client: PatchedPoolClient) => void): PatchedPool;
+    (event: "connect" | "acquire" | "remove", listener: (client: PatchedPoolClient) => void): PatchedPool;
+  }
+
+  type PatchedPool<T = PG.Pool> = {
+    [K in keyof T]: K extends 'connect'
+    ? PatchedPoolConnectMethod
+    : K extends 'on'
+    ? PatchedPoolOnMethod
+    : T[K];
+  };
+
+  interface PatchedPoolConstructor {
+    new(config?: PG.PoolConfig): PatchedPool;
+  }
+
+  interface PatchedEventsOnMethod {
+    (event: "error", listener: (err: Error, client: PatchedClient) => void): PatchedEvents;
+  }
+
+  type PatchedEvents<T = PG.Events> = {
+    [K in keyof T]: K extends 'on'
+    ? PatchedEventsOnMethod
+    : T[K];
+  };
+
+  interface PatchedEventsConstructor {
+    new(): PatchedEvents;
+  }
+
+  type PatchedPostgres<T = typeof PG> = {
+    [K in keyof T]: K extends 'Client'
+    ? PatchedClientConstructor
+    : K extends 'PoolClient'
+    ? PatchedPoolClientConstructor
+    : K extends 'Pool'
+    ? PatchedPoolConstructor
+    : K extends 'Events'
+    ? PatchedEventsConstructor
+    : T[K];
+  };
+}
+
+export = capturePostgres;

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -7,11 +7,15 @@
     "Sandra McMullen <mcmuls@amazon.com>"
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "engines": {
     "node": ">= 4.x"
   },
   "directories": {
     "test": "test"
+  },
+  "dependencies": {
+    "@types/pg": "*"
   },
   "peerDependencies": {
     "aws-xray-sdk-core": "^2.4.0"
@@ -26,10 +30,12 @@
     "mocha": "^6.2.0",
     "nock": "^10.0.6",
     "sinon": "^4.5.0",
-    "sinon-chai": "^2.8.0"
+    "sinon-chai": "^2.8.0",
+    "tsd": "^0.10.0"
   },
   "scripts": {
-    "test": "mocha --recursive ./test/ -R spec"
+    "test": "mocha --recursive ./test/ -R spec && tsd",
+    "test-d": "tsd"
   },
   "keywords": [
     "amazon",

--- a/packages/postgres/test-d/index.test-d.ts
+++ b/packages/postgres/test-d/index.test-d.ts
@@ -1,0 +1,70 @@
+import * as AWSXRay from 'aws-xray-sdk-core';
+import * as PG from 'pg';
+import { expectType } from 'tsd';
+import capturePostgres = require('../lib');
+
+const segment = AWSXRay.getSegment();
+
+const pg = capturePostgres(PG);
+
+const client: capturePostgres.PatchedClient = new pg.Client();
+
+client.connect((err: Error) => { });
+
+const pool = new pg.Pool();
+
+pool.connect().then((client: capturePostgres.PatchedPoolClient) => { });
+pool.connect((err: Error, client: capturePostgres.PatchedPoolClient, done: (release?: any) => void) => { });
+
+pool.on('error', (err: Error, client: capturePostgres.PatchedPoolClient) => { })
+  .on('connect', (client: capturePostgres.PatchedPoolClient) => { })
+  .on('acquire', (client: capturePostgres.PatchedPoolClient) => { })
+  .on('remove', (client: capturePostgres.PatchedPoolClient) => { });
+
+function testQuery(client: capturePostgres.PatchedClient | capturePostgres.PatchedPoolClient): void {
+  const queryCallback = (err: Error, result: PG.QueryResult) => void {
+  }
+
+  const queryArrayCallback = (err: Error, result: PG.QueryArrayResult) => void {
+  }
+
+  const queryStream = new PG.Query();
+  expectType<PG.Query>(client.query(queryStream));
+  expectType<PG.Query>(client.query(queryStream, segment));
+
+  const queryArrayConfig: PG.QueryArrayConfig = {
+    name: 'get-name',
+    text: 'SELECT $1::text',
+    values: ['brianc'],
+    rowMode: 'array',
+  };
+  expectType<Promise<PG.QueryArrayResult>>(client.query(queryArrayConfig));
+  expectType<Promise<PG.QueryArrayResult>>(client.query(queryArrayConfig, ['brianc']));
+  expectType<Promise<PG.QueryArrayResult>>(client.query(queryArrayConfig, ['brianc'], segment));
+
+  expectType<void>(client.query(queryArrayConfig, queryArrayCallback));
+  expectType<void>(client.query(queryArrayConfig, queryArrayCallback));
+  expectType<void>(client.query(queryArrayConfig, queryArrayCallback, segment));
+
+  const queryConfig: PG.QueryConfig = {
+    name: 'moop',
+    text: 'SELECT $1::text as name',
+    values: ['brianc']
+  };
+  expectType<Promise<PG.QueryResult>>(client.query(queryConfig));
+  expectType<Promise<PG.QueryResult>>(client.query(queryConfig, ['brianc']));
+  expectType<Promise<PG.QueryResult>>(client.query(queryConfig, ['brianc'], segment));
+
+  expectType<void>(client.query(queryConfig, queryCallback));
+  expectType<void>(client.query(queryConfig, queryCallback));
+  expectType<void>(client.query(queryConfig, queryCallback, segment));
+
+  const queryText = 'select $1::text as name';
+  expectType<Promise<PG.QueryResult>>(client.query(queryText));
+  expectType<Promise<PG.QueryResult>>(client.query(queryText, ['brianc']));
+  expectType<Promise<PG.QueryResult>>(client.query(queryText, ['brianc'], segment));
+
+  expectType<void>(client.query(queryText, queryCallback));
+  expectType<void>(client.query(queryText, ['brianc'], queryCallback));
+  expectType<void>(client.query(queryText, ['brianc'], queryCallback, segment));
+}

--- a/packages/restify/lib/index.d.ts
+++ b/packages/restify/lib/index.d.ts
@@ -1,0 +1,10 @@
+import * as AWSXRay from 'aws-xray-sdk-core';
+import { Request } from 'restify';
+
+declare module 'restify' {
+  interface Request {
+    segment?: AWSXRay.Segment;
+  }
+}
+
+export * from './restify_mw';

--- a/packages/restify/lib/restify_mw.d.ts
+++ b/packages/restify/lib/restify_mw.d.ts
@@ -1,0 +1,3 @@
+import * as restify from 'restify';
+
+export function enable(server: restify.Server, defaultName: string): void;

--- a/packages/restify/package.json
+++ b/packages/restify/package.json
@@ -7,11 +7,15 @@
     "Sandra McMullen <mcmuls@amazon.com>"
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "engines": {
     "node": ">= 4.3"
   },
   "directories": {
     "test": "test"
+  },
+  "dependencies": {
+    "@types/restify": "*"
   },
   "peerDependencies": {
     "aws-xray-sdk-core": "^2.4.0"
@@ -22,10 +26,12 @@
     "eslint": "^4.19.1",
     "mocha": "^6.2.0",
     "sinon": "^4.5.0",
-    "sinon-chai": "^2.8.0"
+    "sinon-chai": "^2.8.0",
+    "tsd": "^0.10.0"
   },
   "scripts": {
-    "test": "mocha --recursive ./test/ -R spec"
+    "test": "mocha --recursive ./test/ -R spec && tsd",
+    "test-d": "tsd"
   },
   "keywords": [
     "amazon",

--- a/packages/restify/test-d/index.test-d.ts
+++ b/packages/restify/test-d/index.test-d.ts
@@ -1,0 +1,13 @@
+import * as AWSXRay from 'aws-xray-sdk-core';
+import * as restify from 'restify';
+import { expectType } from 'tsd';
+import * as AWSXRayRestify from '../lib';
+
+const server = restify.createServer();
+
+AWSXRayRestify.enable(server, 'defaultName');
+
+server.get('/', function(req, res) {
+  expectType<AWSXRay.Segment | undefined>(req.segment);
+  res.send('hello');
+});


### PR DESCRIPTION
*Issue #, if available:* #14 

*Description of changes:*

This PR makes a complete first pass at adding TypeScript definitions for aws-xray-sdk. It leverages some of the work done in a previous PR that seems to be abandoned (#109, thank you to that author!)

I realize it's a pretty big PR, so I will be happy to do anything I can that might make it easier to review, and of course to iterate on it in response to any feedback.

It adds .d.ts files next to the corresponding .js files, and a `"types": "lib/index.d.ts"` entry to each package.json.

For testing, it uses the [`tsd`](https://github.com/SamVerschueren/tsd) tool which by default looks for TypeScript files to check in a `test-d` directory; each package has a `test-d/index.test-d.ts` file which exercises its TypeScript definitions, and the `test` script has been updated to run `tsd` as well.

Some initial questions I have:
* Is it exporting types that aren't necessarily meant to be part of the public API?
* How best to manage dependencies on `@types` packages for express/mysql/postgres?

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
