### PR TITLE
Replace continuation-local-storage with cls-hooked

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -302,7 +302,7 @@ the X-Ray SDK provides helper functions under `AWSXRay.middleware`.
 See the [aws-xray-sdk-express](https://github.com/aws/aws-xray-sdk-node/tree/master/packages/express) module for more information.
 
 For additional information about and examples for using the CLS namespace to create
-a new context, see: https://github.com/othiym23/node-continuation-local-storage.
+a new context, see: https://github.com/jeff-lewis/cls-hooked.
 
 ### Capture subsegmenets within chained native Promise using automatic mode
 

--- a/packages/core/lib/aws-xray.js
+++ b/packages/core/lib/aws-xray.js
@@ -286,8 +286,8 @@ var AWSXRay = {
   isAutomaticMode: contextUtils.isAutomaticMode,
 
   /**
-   * Enables automatic mode. Automatic mode uses 'continuation-local-storage'.
-   * @see https://github.com/othiym23/node-continuation-local-storage
+   * Enables automatic mode. Automatic mode uses 'cls-hooked'.
+   * @see https://github.com/jeff-lewis/cls-hooked
    * @memberof AWSXRay
    * @function
    * @see module:context_utils.enableAutomaticMode

--- a/packages/core/lib/context_utils.js
+++ b/packages/core/lib/context_utils.js
@@ -2,7 +2,7 @@
  * @module context_utils
  */
 
-var cls = require('continuation-local-storage');
+var cls = require('cls-hooked');
 
 var logger = require('./logger');
 var Segment = require('./segments/segment');

--- a/packages/core/lib/context_utils.js
+++ b/packages/core/lib/context_utils.js
@@ -127,8 +127,8 @@ var contextUtils = {
   },
 
   /**
-   * Enables automatic mode. Automatic mode uses 'continuation-local-storage'.
-   * @see https://github.com/othiym23/node-continuation-local-storage
+   * Enables automatic mode. Automatic mode uses 'cls-hooked'.
+   * @see https://github.com/jeff-lewis/cls-hooked
    * @alias module:context_utils.enableAutomaticMode
    */
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "atomic-batcher": "^1.0.2",
     "aws-sdk": "^2.304.0",
-    "continuation-local-storage": "^3.2.0",
+    "cls-hooked": "^4.2.2",
     "date-fns": "^1.29.0",
     "pkginfo": "^0.4.0",
     "semver": "^5.3.0"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated `docs`, `package.json` and `context_utils.js` to use `cls-hooked` which is a fork of `continuation-local-storage` to support `async\await`. This allows the express middleware work with more frameworks such as `NestJS`. or AWS.getSegment() functions fails.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
