### PR TITLE
Whitelist SageMakerRuntime InvokeEndpoint operation

### DIFF
--- a/packages/core/lib/resources/aws_whitelist.json
+++ b/packages/core/lib/resources/aws_whitelist.json
@@ -943,6 +943,15 @@
           }
         }
       }
+    },
+    "sagemakerruntime": {
+      "operations": {
+        "invokeEndpoint": {
+          "request_parameters": [
+            "EndpointName"
+          ]
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Operation name and request param acquired from this documentation:
https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SageMakerRuntime.html#invokeEndpoint-property

Sample subsegment from end-to-end test, works as expected:
```
{
    "id": "4d2c6e89dea1832c",
    "name": "SageMakerRuntime",
    "start_time": 1573675521.541,
    "end_time": 1573675521.915,
    "http": {
        "response": {
            "status": 200
        }
    },
    "aws": {
        "operation": "InvokeEndpoint",
        "region": "us-east-1",
        "request_id": "cda50e32-d682-4362-b3b1-c9d961847325",
        "retries": 0,
        "endpoint_name": "test-endpoint-2",
        "resource_names": [
            "test-endpoint-2"
        ]
    },
    "namespace": "aws"
}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
