### PR TITLE
Make resolveSegment argument optional in TypeScript definition

### DIFF
--- a/packages/core/lib/context_utils.d.ts
+++ b/packages/core/lib/context_utils.d.ts
@@ -4,7 +4,7 @@ import Subsegment = require('./segments/attributes/subsegment');
 
 export function getNamespace(): Namespace;
 
-export function resolveSegment(segment: Segment | Subsegment): Segment | Subsegment | undefined;
+export function resolveSegment(segment?: Segment | Subsegment | null): Segment | Subsegment | undefined;
 
 export function getSegment(): Segment | Subsegment | undefined;
 

--- a/packages/core/test-d/index.test-d.ts
+++ b/packages/core/test-d/index.test-d.ts
@@ -151,6 +151,9 @@ expectType<void>(AWSXRay.middleware.setSamplingRules(rulesConfig));
 
 expectType<string>(AWSXRay.getNamespace().name);
 expectType<AWSXRay.Segment | AWSXRay.Subsegment | undefined>(AWSXRay.resolveSegment(segment));
+expectType<AWSXRay.Segment | AWSXRay.Subsegment | undefined>(AWSXRay.resolveSegment(undefined));
+expectType<AWSXRay.Segment | AWSXRay.Subsegment | undefined>(AWSXRay.resolveSegment(null));
+expectType<AWSXRay.Segment | AWSXRay.Subsegment | undefined>(AWSXRay.resolveSegment());
 expectType<AWSXRay.Segment | AWSXRay.Subsegment | undefined>(AWSXRay.getSegment());
 expectType<void>(AWSXRay.setSegment(segment));
 expectType<boolean>(AWSXRay.isAutomaticMode());


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

As discussed in https://github.com/aws/aws-xray-sdk-node/pull/207#issuecomment-553702547, the `segment` argument `resolveSegment` should be marked optional and accept `null` as a valid value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
