### PR TITLE
Remove Lambda handshake file

### DIFF
--- a/packages/core/lib/env/aws_lambda.js
+++ b/packages/core/lib/env/aws_lambda.js
@@ -1,5 +1,3 @@
-var fs = require('fs');
-
 var contextUtils = require('../context_utils');
 var LambdaUtils = require('../utils').LambdaUtils;
 var Segment = require('../segments/segment');
@@ -23,15 +21,6 @@ module.exports.init = function init() {
   contextUtils.enableManualMode = function() {
     logger.getLogger().warn('AWS Lambda does not support AWS X-Ray manual mode.');
   };
-
-  fs.mkdir('/tmp/', function() {
-    fs.mkdir('/tmp/.aws-xray/', function() {
-      var filename = '/tmp/.aws-xray/initialized';
-      fs.closeSync(fs.openSync(filename, 'a'));
-      var now = new Date();
-      fs.utimesSync(filename, now, now);
-    });
-  });
 
   SegmentEmitter.disableReusableSocket();
   SegmentUtils.setStreamingThreshold(0);

--- a/packages/core/test-d/index.test-d.ts
+++ b/packages/core/test-d/index.test-d.ts
@@ -104,7 +104,6 @@ const urlWithoutQuery: Omit<url.UrlWithStringQuery, 'query'> = AWSXRay.utils.obj
   url.parse('url'), ['query'],
   true
 );
-expectType<string | undefined>(urlWithoutQuery.path);
 expectError(urlWithoutQuery.query);
 
 new AWSXRay.database.SqlData('databaseVer', 'driverVer', 'user', 'url', 'queryType');

--- a/packages/core/test/unit/env/aws_lambda.test.js
+++ b/packages/core/test/unit/env/aws_lambda.test.js
@@ -1,6 +1,5 @@
 var assert = require('chai').assert;
 var chai = require('chai');
-var fs = require('fs');
 var sinon = require('sinon');
 var sinonChai = require('sinon-chai');
 
@@ -40,16 +39,11 @@ describe('AWSLambda', function() {
   });
 
   describe('#init', function() {
-    var disableReusableSocketStub, openSyncStub, populateStub, sandbox, setSegmentStub, validateStub;
+    var disableReusableSocketStub, populateStub, sandbox, setSegmentStub, validateStub;
 
     beforeEach(function() {
       sandbox = sinon.sandbox.create();
       disableReusableSocketStub = sandbox.stub(SegmentEmitter, 'disableReusableSocket');
-      openSyncStub = sandbox.stub(fs, 'openSync');
-      sandbox.stub(fs, 'mkdir').yields();
-      sandbox.stub(fs, 'closeSync');
-      sandbox.stub(fs, 'utimesSync');
-
       validateStub = sandbox.stub(LambdaUtils, 'validTraceData').returns(true);
       populateStub = sandbox.stub(LambdaUtils, 'populateTraceData').returns(true);
       setSegmentStub = sandbox.stub(contextUtils, 'setSegment');
@@ -57,11 +51,6 @@ describe('AWSLambda', function() {
 
     afterEach(function() {
       sandbox.restore();
-    });
-
-    it('should create the AWS XRay init file', function() {
-      Lambda.init();
-      openSyncStub.should.have.been.calledOnce;
     });
 
     it('should disable reusable socket', function() {
@@ -118,10 +107,6 @@ describe('AWSLambda', function() {
     beforeEach(function() {
       sandbox = sinon.sandbox.create();
       sandbox.stub(SegmentEmitter, 'disableReusableSocket');
-      sandbox.stub(fs, 'openSync');
-      sandbox.stub(fs, 'mkdir').yields();
-      sandbox.stub(fs, 'closeSync');
-      sandbox.stub(fs, 'utimesSync');
 
       sandbox.stub(LambdaUtils, 'validTraceData').returns(true);
       populateStub = sandbox.stub(LambdaUtils, 'populateTraceData').returns(true);


### PR DESCRIPTION
*Description of changes:*
Removes code to create a file formerly intended to act as a "handshake" with Lambda in their environment. This file was never read by Lambda, and is thus no longer necessary.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
