### PR TITLE
Remove date-fns dependency

### DIFF
--- a/packages/core/lib/logger.js
+++ b/packages/core/lib/logger.js
@@ -35,20 +35,19 @@ function calculateLogLevel(level) {
   return defaultLogLevel;
 }
 
-function createTimestamp() {
-  var now = new Date(),
-      tzo = -now.getTimezoneOffset(),  // Negate to make this tzo = local - UTC
+function createTimestamp(date) {
+  var tzo = -date.getTimezoneOffset(),  // Negate to make this tzo = local - UTC
       dif = tzo >= 0 ? '+' : '-',
       pad = function(num) {
           var norm = Math.floor(Math.abs(num));
           return (norm < 10 ? '0' : '') + norm;
       };
 
-  return new Date(now.getTime() + (tzo * 60 * 1000)).toISOString()
-    .replace(/T/, ' ')
-    .replace(/Z/, ' ') +
-    dif + pad(tzo / 60) +
-    ':' + pad(tzo % 60);
+  return new Date(date.getTime() + (tzo * 60 * 1000)).toISOString()
+      .replace(/T/, ' ')
+      .replace(/Z/, ' ') +
+      dif + pad(tzo / 60) +
+      ':' + pad(tzo % 60);
 }
 
 function isLambdaFunction() {
@@ -59,7 +58,7 @@ function formatLogMessage(level, message, meta) {
   var messageParts = [];
 
   if (!isLambdaFunction()) {
-    messageParts.push(createTimestamp());
+    messageParts.push(createTimestamp(new Date()));
     messageParts.push(`[${level.toUpperCase()}]`);
   }
 

--- a/packages/core/lib/logger.js
+++ b/packages/core/lib/logger.js
@@ -1,5 +1,3 @@
-var format = require('date-fns/format');
-
 var validLogLevels = [ 'debug', 'info', 'warn', 'error', 'silent' ];
 var defaultLogLevel = validLogLevels.indexOf('error');
 var logLevel = calculateLogLevel(process.env.AWS_XRAY_DEBUG_MODE ? 'debug' : process.env.AWS_XRAY_LOG_LEVEL);
@@ -38,7 +36,19 @@ function calculateLogLevel(level) {
 }
 
 function createTimestamp() {
-  return format(new Date(), 'YYYY-MM-DD HH:mm:ss.SSS Z');
+  var now = new Date(),
+      tzo = -now.getTimezoneOffset(),  // Negate to make this tzo = local - UTC
+      dif = tzo >= 0 ? '+' : '-',
+      pad = function(num) {
+          var norm = Math.floor(Math.abs(num));
+          return (norm < 10 ? '0' : '') + norm;
+      };
+
+  return new Date(now.getTime() + (tzo * 60 * 1000)).toISOString()
+    .replace(/T/, ' ')
+    .replace(/Z/, ' ') +
+    dif + pad(tzo / 60) +
+    ':' + pad(tzo % 60);
 }
 
 function isLambdaFunction() {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,10 +30,11 @@
     "grunt-jsdoc": "^2.4.0",
     "mocha": "^6.2.0",
     "nock": "^10.0.6",
+    "rewire": "^4.0.1",
     "sinon": "^4.5.0",
     "sinon-chai": "^2.8.0",
-    "upath": "^1.2.0",
-    "tsd": "^0.10.0"
+    "tsd": "^0.10.0",
+    "upath": "^1.2.0"
   },
   "scripts": {
     "test": "mocha --recursive ./test/ -R spec && tsd",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,6 @@
     "atomic-batcher": "^1.0.2",
     "aws-sdk": "^2.304.0",
     "cls-hooked": "^4.2.2",
-    "date-fns": "^1.29.0",
     "pkginfo": "^0.4.0",
     "semver": "^5.3.0"
   },


### PR DESCRIPTION
*Issue #, if available:*
#113 

*Description of changes:*
Removes dependency on `date-fns`. It was only used to create timestamps for our logger, a task that I implemented instead in native JavaScript. Customers complained that the dependency, when non-tree-shaken, was several MB large.

Tested locally by comparing log statements before and after and confirmed timestamps are formatted identically. Lambda environments unaffected since we don't print timestamps there.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
