### PR TITLE
Use `Date.now` instead of `new Date().getTime`

### DIFF
--- a/packages/core/lib/segments/segment_utils.js
+++ b/packages/core/lib/segments/segment_utils.js
@@ -6,7 +6,7 @@ var utils = {
   streamingThreshold: DEFAULT_STREAMING_THRESHOLD,
 
   getCurrentTime: function getCurrentTime() {
-    return new Date().getTime()/1000;
+    return Date.now() / 1000;
   },
 
   setOrigin: function setOrigin(origin) {


### PR DESCRIPTION
*Description of changes:*

`Date.now` is more performant since it doesn't have to create a date object. (https://stackoverflow.com/a/12517433)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
