### PR TITLE
Add more validation to Subsegment.addAnnotation to match documentation.

### DIFF
--- a/packages/core/lib/segments/attributes/subsegment.js
+++ b/packages/core/lib/segments/attributes/subsegment.js
@@ -112,8 +112,8 @@ Subsegment.prototype.addPrecursorId = function(id) {
 /**
  * Adds a key-value pair that can be queryable through GetTraceSummaries.
  * Only acceptable types are string, float/int and boolean.
- * @param {string} key - The name of key to add.
- * @param {boolean|string|number} value - The value to add for the given key.
+ * @param {string} key - The name of key to add. Alphanumeric and underscores allowed. 500 characters allowed.
+ * @param {boolean|string|number} value - The value to add for the given key. If string, must be less than 1000 unicode characters.
  */
 
 Subsegment.prototype.addAnnotation = function(key, value) {
@@ -123,6 +123,15 @@ Subsegment.prototype.addAnnotation = function(key, value) {
   } else if (typeof key !== 'string') {
     throw new Error('Failed to add annotation key: ' + key + ' value: ' + value + ' to subsegment ' +
       this.name + '. Key must be of type string.');
+  } else if (typeof key === 'string'  && key.length > 500) {
+    throw new Error('Failed to add annotation key: ' + key + ' value: ' + value + ' to subsegment ' +
+      this.name + '. Key must not be longer than 500 characters.');
+  } else if (typeof key === 'string' && !/^[A-Za-z0-9_]+$/.test(key)) {
+    throw new Error('Failed to add annotation key: ' + key + ' value: ' + value + ' to subsegment ' +
+      this.name + '. Key must be alphanumeric or underscores.');
+  } else if (typeof value === 'string'  && [...value].length > 1000) {
+    throw new Error('Failed to add annotation key: ' + key + ' value: ' + value + ' to subsegment ' +
+      this.name + '. Value must not be longer than 1000 unicode characters.');
   }
 
   if (this.annotations === undefined)

--- a/packages/core/test/unit/segments/segment.test.js
+++ b/packages/core/test/unit/segments/segment.test.js
@@ -113,6 +113,32 @@ describe('Segment', function() {
     });
   });
 
+  describe('#addAnnotation', function() {
+    var segment, subsegment, key, value;
+
+    beforeEach(function() {
+      segment = new Segment('test');
+      subsegment = segment.addNewSubsegment('newSubsegment');
+      key = 'key';
+      value = 'value';
+    });
+
+    it('should throw an error if trying to add with invalid key', function() {
+      assert.throws( function() { subsegment.addAnnotation('invalid key with non-alphanumerics', 'validValue'); }, Error);
+      assert.throws( function() { subsegment.addAnnotation('invalid_key_because_of_length'+'1'.repeat(500), 'validValue'); }, Error);
+      assert.throws( function() { subsegment.addAnnotation(3, 'validValue'); }, Error);
+    });
+
+    it('should throw an error if trying to add with invalid value', function() {
+      assert.throws( function() { subsegment.addAnnotation('validKey', '🤓'.repeat(1001)); }, Error);
+    });
+
+    it('should set annotations[key] to value', function() {
+      subsegment.addAnnotation(key, value);
+      assert.propertyVal(subsegment.annotations, key, value);
+    });
+  });
+
   describe('#addSDKData', function() {
     var segment, version;
 


### PR DESCRIPTION
*Issue #, if available:*
An issue was posted for the Python library, and I had run into it in the Node library.

*Description of changes:*
Added validation to the addAnnotation method within the subsegment.js. Added tests to segment.test.js. Made sure to check string length properly for annotation values which can have unicode characters. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
