### PR TITLE
Swap out continuation-local-storage types for cls-hooked

### DIFF
--- a/packages/core/lib/context_utils.d.ts
+++ b/packages/core/lib/context_utils.d.ts
@@ -1,4 +1,4 @@
-import { Namespace } from 'continuation-local-storage';
+import { Namespace } from 'cls-hooked';
 import Segment = require('./segments/segment');
 import Subsegment = require('./segments/attributes/subsegment');
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,7 @@
     "test": "test"
   },
   "dependencies": {
-    "@types/continuation-local-storage": "*",
+    "@types/cls-hooked": "*",
     "atomic-batcher": "^1.0.2",
     "aws-sdk": "^2.304.0",
     "cls-hooked": "^4.2.2",

--- a/packages/core/test-d/index.test-d.ts
+++ b/packages/core/test-d/index.test-d.ts
@@ -1,6 +1,7 @@
 import * as AWS from 'aws-sdk';
 import { AWSError } from 'aws-sdk';
 import { PromiseResult } from 'aws-sdk/lib/request';
+import { Namespace } from 'cls-hooked';
 import * as http from 'http';
 import * as https from 'https';
 import { Socket } from 'net';
@@ -148,7 +149,7 @@ const rulesConfig: AWSXRay.middleware.RulesConfig = {
 };
 expectType<void>(AWSXRay.middleware.setSamplingRules(rulesConfig));
 
-expectType<string>(AWSXRay.getNamespace().name);
+expectType<Namespace>(AWSXRay.getNamespace());
 expectType<AWSXRay.Segment | AWSXRay.Subsegment | undefined>(AWSXRay.resolveSegment(segment));
 expectType<AWSXRay.Segment | AWSXRay.Subsegment | undefined>(AWSXRay.resolveSegment(undefined));
 expectType<AWSXRay.Segment | AWSXRay.Subsegment | undefined>(AWSXRay.resolveSegment(null));


### PR DESCRIPTION
*Issue #, if available:*
TypeScript changes related to #227 

*Description of changes:*
This PR updates the TypeScript definitions following the recent removal of `continuation-local-storage`  in favor of `cls-hooked`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
