### PR TITLE
#241: Unref socket to allow node process to exit

### DIFF
--- a/packages/core/lib/segment_emitter.js
+++ b/packages/core/lib/segment_emitter.js
@@ -122,7 +122,7 @@ var SegmentEmitter = {
       if (this.useBatchingTemporarySocket) {
         this.socket = new BatchingTemporarySocket();
       } else {
-        this.socket = dgram.createSocket('udp4');
+        this.socket = dgram.createSocket('udp4').unref();
       }
     }
     var client = this.socket;
@@ -187,8 +187,5 @@ var SegmentEmitter = {
     this.useBatchingTemporarySocket = true;
   }
 };
-
-if (SegmentEmitter.socket && (typeof SegmentEmitter.socket.unref === 'function'))
-  SegmentEmitter.socket.unref();
 
 module.exports = SegmentEmitter;

--- a/packages/core/test/unit/segments/attributes/subsegment.test.js
+++ b/packages/core/test/unit/segments/attributes/subsegment.test.js
@@ -238,7 +238,8 @@ describe('Subsegment', function() {
       parent = new Subsegment('test');
 
       sandbox.stub(dgram, 'createSocket').returns({
-        send: emitStub
+        send: emitStub,
+        unref: sinon.stub().returnsThis()
       });
 
       child = parent.addNewSubsegment('child');


### PR DESCRIPTION
*Issue #241:*

*Description of changes:*

Updated `segment_emitter.js` to `unref()` the UDP socket when it is created.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
