### PR TITLE
Support new syntax for https.request

### DIFF
--- a/packages/core/lib/logger.js
+++ b/packages/core/lib/logger.js
@@ -37,15 +37,15 @@ function calculateLogLevel(level) {
 
 function createTimestamp(date) {
   var tzo = -date.getTimezoneOffset(),  // Negate to make this tzo = local - UTC
-      dif = tzo >= 0 ? '+' : '-',
-      pad = function(num) {
-          var norm = Math.floor(Math.abs(num));
-          return (norm < 10 ? '0' : '') + norm;
-      };
+    dif = tzo >= 0 ? '+' : '-',
+    pad = function(num) {
+      var norm = Math.floor(Math.abs(num));
+      return (norm < 10 ? '0' : '') + norm;
+    };
 
   return new Date(date.getTime() + (tzo * 60 * 1000)).toISOString()
-      .replace(/T/, ' ')
-      .replace(/Z/, ' ') +
+    .replace(/T/, ' ')
+    .replace(/Z/, ' ') +
       dif + pad(tzo / 60) +
       ':' + pad(tzo % 60);
 }

--- a/packages/core/lib/patchers/http_p.js
+++ b/packages/core/lib/patchers/http_p.js
@@ -59,20 +59,22 @@ function enableCapture(module, downstreamXRayEnabled) {
     let callback;
     let hasUrl;
     let urlObj;
+
+    let arg0 = args[0];
     if (typeof args[1] === 'object') {
       hasUrl = true;
-      urlObj = typeof args[0] === 'string' ? url.parse(args[0]) : args[0];
+      urlObj = typeof arg0 === 'string' ? url.parse(arg0) : arg0;
       options = args[1],
       callback = args[2];
     } else {
       hasUrl = false;
-      options = args[0];
+      options = arg0;
       callback = args[1];
     }
+
     if (!options || (options.headers && (options.headers['X-Amzn-Trace-Id']))) {
       return baseFunc(...args);
     }
-
     if (typeof options === 'string') {
       options = url.parse(options);
     }
@@ -131,7 +133,7 @@ function enableCapture(module, downstreamXRayEnabled) {
 
     var optionsCopy = Utils.objectWithoutProperties(options, ['Segment'], true);
 
-    var req = baseFunc(...(hasUrl ? [urlObj, optionsCopy] : [options]), function(res) {
+    var req = baseFunc(...(hasUrl ? [arg0, optionsCopy] : [options]), function(res) {
       res.on('end', function() {
         if (res.statusCode === 429)
           subsegment.addThrottleFlag();

--- a/packages/core/lib/segments/segment.js
+++ b/packages/core/lib/segments/segment.js
@@ -92,7 +92,7 @@ Segment.prototype.setUser = function (user) {
     logger.getLogger().error('Set user: ' + user + ' failed. User IDs must be of type string.');
   }
   this.user = user;
-}
+};
 
 /**
  * Adds a key-value pair to the metadata.default attribute when no namespace is given.


### PR DESCRIPTION
**Issue #240**

*Description of changes:*
Support the new `request(url, options, callback)` syntax from NodeJS >= `v10`: https://nodejs.org/docs/latest-v10.x/api/https.html#https_https_request_url_options_callback


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
