### PR TITLE
fix(types): Add missing subsegments types

### DIFF
--- a/packages/core/lib/segments/attributes/subsegment.d.ts
+++ b/packages/core/lib/segments/attributes/subsegment.d.ts
@@ -5,6 +5,7 @@ declare class Subsegment {
   name: string;
   start_time: number;
   in_progress?: boolean;
+  subsegments?: Array<Subsegment>;
 
   constructor(name: string);
 

--- a/packages/core/lib/segments/segment.d.ts
+++ b/packages/core/lib/segments/segment.d.ts
@@ -9,6 +9,7 @@ declare class Segment {
   trace_id: string;
   parent_id?: string;
   origin?: string;
+  subsegments?: Array<Subsegment>;
 
   constructor(name: string, rootId?: string | null, parentId?: string | null);
 


### PR DESCRIPTION
Closes https://github.com/aws/aws-xray-sdk-node/issues/246

`Segment.subsegments` and `Subsegmet.subsegments` types were missing from the `.d.ts` definition files. ([proof](https://github.com/aws/aws-xray-sdk-node/blob/master/packages/core/lib/segments/segment.js#L198))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
