### PR TITLE
feat(http): Remove querystring from RemoteRequestData.url

### DIFF
--- a/packages/core/lib/patchers/http_p.js
+++ b/packages/core/lib/patchers/http_p.js
@@ -69,7 +69,7 @@ function enableCapture(module, downstreamXRayEnabled) {
     if (!parent) {
       var output = '[ host: ' + hostname;
       output = options.method ? (output + ', method: ' + options.method) : output;
-      output += ', path: ' + options.path + ' ]';
+      output += ', path: ' + Utils.stripQueryStringFromPath(options.path) + ' ]';
 
       if (!contextUtils.isAutomaticMode()) {
         logger.getLogger().info('Options for request ' + output +

--- a/packages/core/lib/segments/attributes/remote_request_data.js
+++ b/packages/core/lib/segments/attributes/remote_request_data.js
@@ -1,3 +1,5 @@
+var { stripQueryStringFromPath } = require('../../utils');
+
 /**
  * Represents an outgoing HTTP/HTTPS call.
  * @constructor
@@ -12,7 +14,7 @@ function RemoteRequestData(req, res, downstreamXRayEnabled) {
 
 RemoteRequestData.prototype.init = function init(req, res, downstreamXRayEnabled) {
   this.request = {
-    url: (req.agent.protocol + '//' + req.getHeader('host') + req.path) || '',
+    url: (req.agent.protocol + '//' + req.getHeader('host') +  stripQueryStringFromPath(req.path)) || '',
     method: req.method || '',
   };
 

--- a/packages/core/lib/utils.d.ts
+++ b/packages/core/lib/utils.d.ts
@@ -2,6 +2,8 @@ import Segment = require('./segments/segment');
 
 export function getCauseTypeFromHttpStatus(status: number | string): 'error' | 'fault' | undefined;
 
+export function stripQueryStringFromPath(path: string): string;
+
 export function wildcardMatch(pattern: string, text: string): boolean;
 
 export namespace LambdaUtils {

--- a/packages/core/lib/utils.js
+++ b/packages/core/lib/utils.js
@@ -22,6 +22,23 @@ var utils = {
   },
 
   /**
+   * Removes the query string parameters from a given http request path
+   * as it may contain sensitive information
+   * 
+   * Related issue: https://github.com/aws/aws-xray-sdk-node/issues/246
+   * 
+   * Node documentation: https://nodejs.org/api/http.html#http_http_request_url_options_callback
+   * 
+   * @param {string} path - options.path in a http.request callback
+   * @returns [string] - removes query string element from path
+   * @alias module:utils.stripQueryStringFromPath
+   */
+
+  stripQueryStringFromPath: function stripQueryStringFromPath(path) {
+    return path.split('?')[0];
+  },
+
+  /**
    * Performs a case-insensitive wildcard match against two strings. This method works with pseduo-regex chars; specifically ? and * are supported.
    *   An asterisk (*) represents any combination of characters
    *   A question mark (?) represents any single character

--- a/packages/core/test/unit/segments/attributes/remote_request_data.test.js
+++ b/packages/core/test/unit/segments/attributes/remote_request_data.test.js
@@ -1,0 +1,45 @@
+var assert = require('chai').assert;
+var chai = require('chai');
+
+var RemoteRequestData = require('../../../../lib/segments/attributes/remote_request_data')
+
+chai.should();
+
+describe('RemoteRequestData', function() {
+  const defaultRequest = {
+    agent: {
+      protocol: 'https:'
+    },
+    getHeader: function() {
+      return 'host.com';
+    },
+    path: '/path/to/resource'
+  };
+
+  const defaultResponse = {
+    statusCode: 200,
+    headers: {
+      'content-length': 10,
+    }
+  };
+
+  var request = defaultRequest;
+  var response = defaultResponse;
+
+  this.beforeEach(function () {
+    request = defaultRequest;
+    response = defaultResponse;
+  });
+
+  describe.only('#constructor', function() {
+    it('should mask out query string in path', function() {
+      const requestWithPathQueryString = Object.assign(request, { path: '/path/to/resource?qs=qs' });
+      
+      assert.propertyVal(
+        new RemoteRequestData(requestWithPathQueryString, response, true).request,
+        'url',
+        'https://host.com/path/to/resource'
+      );
+    });
+  });
+});

--- a/packages/core/test/unit/segments/attributes/remote_request_data.test.js
+++ b/packages/core/test/unit/segments/attributes/remote_request_data.test.js
@@ -1,7 +1,7 @@
 var assert = require('chai').assert;
 var chai = require('chai');
 
-var RemoteRequestData = require('../../../../lib/segments/attributes/remote_request_data')
+var RemoteRequestData = require('../../../../lib/segments/attributes/remote_request_data');
 
 chai.should();
 
@@ -31,7 +31,7 @@ describe('RemoteRequestData', function() {
     response = defaultResponse;
   });
 
-  describe.only('#constructor', function() {
+  describe('#constructor', function() {
     it('should mask out query string in path', function() {
       const requestWithPathQueryString = Object.assign(request, { path: '/path/to/resource?qs=qs' });
       

--- a/packages/core/test/unit/utils.test.js
+++ b/packages/core/test/unit/utils.test.js
@@ -19,6 +19,16 @@ describe('Utils', function() {
     });
   });
 
+  describe('#stripQueryStringFromPath', function() {
+    it('should remove query string for simple path', function() {
+      assert.equal(Utils.stripQueryStringFromPath('/index.html?page=12'), '/index.html');
+    });
+
+    it('should remove query string for complex path', function() {
+      assert.equal(Utils.stripQueryStringFromPath('/really/long/path/to/content.html?page=12'), '/really/long/path/to/content.html');
+    });
+  });
+
   describe('#processTraceData', function() {
     it('should parse X-Amzn-Trace-Id with spaces', function() {
       var traceData = 'Root=1-58ed6027-14afb2e09172c337713486c0; Parent=48af77592b6dd73f; Sampled=1';


### PR DESCRIPTION
*Issue #, if available:*
Closes https://github.com/aws/aws-xray-sdk-node/issues/246
*Description of changes:*
As per the issue, x-ray should not have query string information, as it may contain sensitive information in GET requests. This PR implements a very simple method of "deleting everything after a `?`".

I didn't find tests for `RemoteRequestData`, so I added a simple one to check this behaviour. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
