### PR TITLE
Removed AWS SDK references from TS tests

### DIFF
--- a/packages/core/test-d/index.test-d.ts
+++ b/packages/core/test-d/index.test-d.ts
@@ -1,6 +1,3 @@
-import * as AWS from 'aws-sdk';
-import { AWSError } from 'aws-sdk';
-import { PromiseResult } from 'aws-sdk/lib/request';
 import { Namespace } from 'cls-hooked';
 import * as http from 'http';
 import * as https from 'https';
@@ -66,24 +63,6 @@ function callback(param0: any, param1: any) {
 }
 tracedFcn(AWSXRay.captureCallbackFunc('callback', callback));
 tracedFcn(AWSXRay.captureCallbackFunc('callback', callback, segment));
-
-const aws = AWSXRay.captureAWS(AWS);
-const sqs = new aws.SQS();
-const queues = sqs.listQueues({
-  QueueNamePrefix: 'test',
-  XRaySegment: segment
-});
-expectType<any>(queues);
-
-const s3 = AWSXRay.captureAWSClient(new AWS.S3());
-async function main() {
-  const objects = await s3.listObjectsV2({
-    Bucket: 'test',
-    XRaySegment: segment
-  }).promise();
-
-  expectType<any>(objects);
-}
 
 expectType<typeof http>(AWSXRay.captureHTTPs(http, true));
 expectType<typeof https>(AWSXRay.captureHTTPs(https, true));

--- a/packages/test_express/package.json
+++ b/packages/test_express/package.json
@@ -15,6 +15,7 @@
     "test": "test"
   },
   "devDependencies": {
+    "aws-sdk": "^2.304.0",
     "aws-xray-sdk-core": "^3.0.0-alpha.1",
     "aws-xray-sdk-express": "^3.0.0-alpha.1",
     "chai": "^3.5.0",


### PR DESCRIPTION
*Description of changes:*
Should fix failing travis tests. I left some references in the `tsd` file to the AWS SDK, and for some reason they weren't picked up in the previous PR's travis check.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
