### PR TITLE
corrected AWS patcher TS defs

### DIFF
--- a/packages/core/lib/patchers/aws_p.d.ts
+++ b/packages/core/lib/patchers/aws_p.d.ts
@@ -1,13 +1,9 @@
-/* The types returned from patching AWS clients is left as any because using types defined
- * by the aws-sdk would require us to depend on that package, which would make our bundle size unreasonable.
- * Instead, it is recommended to cast patched AWS clients back to their original types.
+/* The type accepted and returned from patching AWS clients is generic because using types defined
+ * by the aws-sdk would require us to depend on it, which would make our bundle size too large.
  * 
- * See: https://github.com/aws/aws-xray-sdk-node/issues/113
+ * See: https://github.com/aws/aws-xray-sdk-node/pull/255
  */ 
 
-export type PatchedAWS = any;
-export type PatchedAWSClient = any; 
+export function captureAWS<T>(awssdk: T): T;
 
-export function captureAWS(awssdk: any): PatchedAWS;
-
-export function captureAWSClient(service: any): PatchedAWSClient;
+export function captureAWSClient<T>(service: T): T;

--- a/packages/core/lib/patchers/aws_p.js
+++ b/packages/core/lib/patchers/aws_p.js
@@ -23,7 +23,7 @@ var throttledErrorDefault = function throttledErrorDefault() {
  * for additional details.
  * @param {AWS} awssdk - The Javascript AWS SDK.
  * @alias module:aws_p.captureAWS
- * @returns {any} - Typed as any to avoid dependency on AWS SDK. Otherwise would be AWS.
+ * @returns {AWS} 
  * @see https://github.com/aws/aws-sdk-js
  */
 
@@ -47,7 +47,7 @@ var captureAWS = function captureAWS(awssdk) {
  * call paramaters, and must reference a Segment or Subsegment object.
  * @param {AWS.Service} service - An instance of a AWS service to wrap.
  * @alias module:aws_p.captureAWSClient
- * @returns {any} - Typed as any to avoid dependency on AWS SDK. Otherwise would be AWS.Service.
+ * @returns {AWS.Service}
  * @see https://github.com/aws/aws-sdk-js
  */
 


### PR DESCRIPTION
*Issue #, if available:*
#276 

*Description of changes:*
Corrects the AWS SDK TypeScript definitions so that they return the same type they patched, rather than `any`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
