### PR TITLE
Cleaned up READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm install aws-xray-sdk --save
 
 ## Documentation
 
-This repository hosts all the packages we publish, which each have their own README. The [Core package README](https://github.com/aws/aws-xray-sdk-node/tree/master/packages/core) covers all basic use cases of the main X-Ray SDK, inlcuding its use in Lambda.
+This repository hosts all the packages we publish, which each have their own README. The [Core package README](https://github.com/aws/aws-xray-sdk-node/tree/master/packages/core) covers all basic use cases of the main X-Ray SDK, including its use in Lambda.
 The [developer guide](https://docs.aws.amazon.com/xray/latest/devguide) provides in-depth
 guidance about using the AWS X-Ray service and SDKs.
 The [API Reference](http://docs.aws.amazon.com/xray-sdk-for-nodejs/latest/reference/)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Installing
 
 The AWS X-Ray SDK for Node.js is compatible with Node.js version 10.x and later.
-There may be issues when running on versions of Node.js newer than 12.x.
+There may be issues when running on the latest odd-numbered release of Node.js.
 
 The X-Ray SDK is in the alpha stage of its 3.0.0 release. Note that these releases may be subject to more breaking changes in future versions. 
 To install the latest 3.0.0-alpha version of the Node SDK for development, just include the `alpha` distribution tag.
@@ -28,7 +28,7 @@ The latest stable version of the SDK is also available from NPM. For local devel
 npm install aws-xray-sdk
 ```
 
-Use the --save option to save the SDK as a dependency in your application's package.json.
+Use the --save option to save the SDK as a dependency in your application's `package.json`.
 
 ```
 npm install aws-xray-sdk --save
@@ -36,11 +36,11 @@ npm install aws-xray-sdk --save
 
 ## Documentation
 
-This repository hosts all the packages we publish, which each have their own README. The [Core package README](https://github.com/aws/aws-xray-sdk-node/tree/master/packages/core) covers all basic use cases of the main X-Ray SDK.
+This repository hosts all the packages we publish, which each have their own README. The [Core package README](https://github.com/aws/aws-xray-sdk-node/tree/master/packages/core) covers all basic use cases of the main X-Ray SDK, inlcuding its use in Lambda.
 The [developer guide](https://docs.aws.amazon.com/xray/latest/devguide) provides in-depth
-guidance about using the AWS X-Ray service.
+guidance about using the AWS X-Ray service and SDKs.
 The [API Reference](http://docs.aws.amazon.com/xray-sdk-for-nodejs/latest/reference/)
-provides guidance for using the SDK and module-level documentation.
+provides guidance for using this SDK and module-level documentation.
 
 [CHANGELOG.md](https://github.com/aws/aws-xray-sdk-node/blob/master/packages/full_sdk/CHANGELOG.md)
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -5,15 +5,15 @@ AWS SDK v2.7.15 or greater if using `captureAWS` or `captureAWSClient`
 
 ## AWS X-Ray
 
-The AWS X-Ray SDK (the SDK) automatically records information for incoming and outgoing
-requests and responses. It also automatically records local data
+The AWS X-Ray SDK (the SDK) allows developers to instrument their web applications 
+to automatically record information for incoming and outgoing
+requests and responses. It can also record local data
 such as function calls, time, variables (via metadata and annotations), and Amazon
-EC2 instance data (via plugins). Currently, [Express](https://github.com/aws/aws-xray-sdk-node/tree/master/packages/express) and [Restify](https://github.com/aws/aws-xray-sdk-node/tree/master/packages/restify)
+EC2, ECS, and Elastic Beanstalk metadata (via plugins). Currently, [Express](https://github.com/aws/aws-xray-sdk-node/tree/master/packages/express) and [Restify](https://github.com/aws/aws-xray-sdk-node/tree/master/packages/restify)
 applications are supported for automatic capturing via middleware. AWS Lambda functions can also be instrumented.
 
 The SDK exposes the Segment and Subsegment objects so you can create your own capturing
-mechanisms, but a few are supplied.
-These keep the current subsegment up to date in automatic mode, or propagate the current subsegment in manual mode.
+mechanisms, but a few are supplied. See Capturing Function Calls below.
 
 ## Setup
 

--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -1,44 +1,42 @@
 
 ## Requirements
 
-  AWS X-Ray SDK Core (aws-xray-sdk-core)
-  Express 4.14.0 or greater
+* AWS X-Ray SDK Core (aws-xray-sdk-core)
+* Express 4.14.0 or greater
 
 ## AWS X-Ray and Express
 
 The AWS X-Ray Express package automatically records information for incoming and outgoing
-requests and responses, via the middleware functions in this package.
+requests and responses, via the middleware functions in this package. To configure sampling, 
+dynamic naming, and more see the [set up section](https://github.com/aws/aws-xray-sdk-node/tree/master/packages/core#setup).
 
 The AWS X-Ray SDK Core has two modes - `manual` and `automatic`.
-Automatic mode uses the Continuation Local Storage package (CLS) and automatically
+Automatic mode uses the `cls-hooked` package and automatically
 tracks the current segment and subsegment. This is the default mode.
 Manual mode requires that you pass around the segment reference.
 
 In automatic mode, you can get the current segment/subsegment at any time:
+
     var segment = AWSXRay.getSegment();
 
 In manual mode, you can get the base segment off of the request object:
+
     var segment = req.segment;
 
-## Sampling rates on routes
+## Middleware Usage
 
-Sampling rates are determined by the `aws-xray-sdk-core` package, using the default
-sampling file that is provided, or by overriding this with a custom sampling file.
-For more information on sampling, see aws-xray-sdk-core [README](https://github.com/aws/aws-xray-sdk-node/tree/master/packages/core/README.md).
+The X-Ray SDK provides two middlewares: `AWSXRay.express.openSegment(<name>)`
+and `AWSXRay.express.closeSegment()`. These two middlewares must be used together 
+and wrap all of your defined routes that you'd like to trace. 
+In automatic mode, the `openSegment` middleware *must* be the last middleware added
+before defining routes, and the `closeSegment` middleware *must* be the 
+first middleware added after defining routes. Otherwise issues with the `cls-hooked`
+context may occur.
 
-## Dynamic and fixed naming modes
+## Automatic mode example
+For more automatic mode examples, see the [example code](https://github.com/aws/aws-xray-sdk-node/tree/master/packages/core#example-code).
 
-The SDK requires that a default segment name is set when using middleware.
-If it isn't set, an error is thrown. You can override this value via the `AWS_XRAY_TRACING_NAME`
-environment variable.
-
-    app.use(xrayExpress.openSegment('defaultName'));
-
-The AWS X-Ray SDK Core defaults to a fixed naming mode. This means that each time the middleware creates a new segment for an incoming request,
-the name of that segment is set to the default name. In dynamic mode, the segment name can vary between the host header of the request or the default name.
-For more information about naming modes, see the aws-xray-sdk-core [README](https://github.com/aws/aws-xray-sdk-node/tree/master/packages/core/README.md).
-
-## Automatic mode examples
+### Capture all incoming requests to `/` and `/directory`
 
     var AWSXRay = require('aws-xray-sdk-core');
     var xrayExpress = require('aws-xray-sdk-express');
@@ -50,15 +48,27 @@ For more information about naming modes, see the aws-xray-sdk-core [README](http
 
     app.get('/', function (req, res) {
       var segment = AWSXRay.getSegment();
+      segment.addAnnotaion('page', 'home');
 
       //...
 
       res.render('index');
     });
 
+    app.get('/directory', function (req, res) {
+      var segment = AWSXRay.getSegment();
+      segment.addAnnotaion('page', 'directory');
+
+      //...
+
+      res.render('directory');
+    });
+
     app.use(xrayExpress.closeSegment());
 
 ## Manual mode examples
+
+### Capture All incoming requests to `/`
 
     var AWSXRay = require('aws-xray-sdk-core');
     var xrayExpress = require('aws-xray-sdk-express');
@@ -79,3 +89,118 @@ For more information about naming modes, see the aws-xray-sdk-core [README](http
     });
 
     app.use(xrayExpress.closeSegment());   //Required at the end of your routes / first in error handling routes
+
+### Capture through function calls
+
+    var AWSXRay = require('aws-xray-sdk');
+
+    app.use(AWSXRay.express.openSegment('defaultName'));
+
+    //...
+
+    //The root segment is created by the Express middleware
+    //This creates 5 nested subsegments on the root segment
+    //and captures timing data individually for each subsegment
+
+    app.get('/', function (req, res) {
+      var segment = req.segment;
+
+      captureFunc('1', function(subsegment1) {
+        captureFunc('2', function(subsegment2) {
+          captureFunc('3', function(subsegment3) {
+            captureFunc('4', function(subsegment4) {
+              captureFunc('5', function() {
+                //subsegment need not be exposed here since we're not doing anything with it
+
+                res.render('index');
+              }, subsegment4);
+            }, subsegment3);
+          }, subsegment2);
+        }, subsegment1);
+      }, segment);
+    });
+
+    app.use(AWSXRay.express.closeSegment());
+
+### Capture through async function calls
+
+    var AWSXRay = require('aws-xray-sdk');
+
+    AWSXRay.enableManualMode();
+
+    app.use(AWSXRay.express.openSegment('defaultName'));
+
+    app.get('/', function (req, res) {
+      var segment = req.segment;
+      var host = 'samplego-env.us-east-1.elasticbeanstalk.com';
+
+      AWSXRay.captureAsyncFunc('send', function(subsegment) {
+        sendRequest(host, function() {
+          console.log("rendering!");
+          res.render('index');
+          subsegment.close();
+        }, subsegment);
+      }, segment);
+    });
+
+    app.use(AWSXRay.express.closeSegment());
+
+    function sendRequest(host, cb, subsegment) {
+      var options = {
+        host: host,
+        path: '/',
+        XRaySegment: subsegment            //required 'XRaySegment' param
+      };
+
+      var callback = function(response) {
+        var str = '';
+
+        //The whole response has been received, so we just print it out here
+        //Another chunk of data has been received, so append it to `str`
+        response.on('data', function (chunk) {
+          str += chunk;
+        });
+
+        response.on('end', function () {
+          cb();
+        });
+      }
+
+      http.request(options, callback).end();
+    };
+
+### Capture outgoing AWS requests on a single client
+
+    var s3 = AWSXRay.captureAWSClient(new AWS.S3());
+    var params = {
+      Bucket: bucketName,
+      Key: keyName,
+      Body: 'Hello!',
+      XRaySegment: subsegment             //required 'XRaySegment' param
+    };
+
+    s3.putObject(params, function(err, data) {
+      ...
+    });
+
+### Capture all outgoing AWS requests
+
+    var AWS = captureAWS(require('aws-sdk'));
+
+    //Create new clients as usual
+    //Be sure any outgoing calls that are dependent on another async
+    //function are wrapped, or duplicate segments might leak
+
+### Capture all outgoing HTTP/S requests
+
+    var tracedHttp = AWSXRay.captureHTTPs(require('http'));     //returns a copy of the http module that is patched, can patch https as well.
+
+    ...
+
+    //Include sub/segment reference in options as 'XRaySegment'
+    var options = {
+      ...
+      XRaySegment: subsegment             //required 'XRaySegment' param
+    }
+
+    tracedHttp.request(options, callback).end();

--- a/packages/full_sdk/README.md
+++ b/packages/full_sdk/README.md
@@ -1,10 +1,10 @@
 
 ## Requirements
 
-AWS SDK v2.7.15 or greater (if using `captureAWS` or `captureAWSClient`)
-Express 4.14.0 or greater (if using Express and the associated X-Ray middleware)
-MySQL 2.12.0 or greater (if using `captureMySQL`)
-Postgres 6.1.0 or greater (if using `capturePostgres`)
+* AWS SDK v2.7.15 or greater (if using `captureAWS` or `captureAWSClient`)
+* Express 4.14.0 or greater (if using Express and the associated X-Ray middleware)
+* MySQL 2.12.0 or greater (if using `captureMySQL`)
+* Postgres 6.1.0 or greater (if using `capturePostgres`)
 
 ## AWS X-Ray
 
@@ -14,7 +14,7 @@ such as function calls, time, variables (via metadata and annotations), even EC2
 Although the AWS X-Ray SDK was originally intended to capture request/response data on a web app, the SDK provides functionality for use cases
 outside this as well. The SDK exposes the 'Segment' and 'Subsegment' objects to create your own capturing mechanisms, middleware, etc.
 
-This package includes all other AWS X-Ray packages except `aws-xray-sdk-restify` which is still in beta.
+This package includes the following AWS X-Ray packages.
 
     aws-xray-sdk-core
     aws-xray-sdk-express
@@ -28,4 +28,4 @@ The core package contains the base SDK functionality.  Please see the aws-xray-s
 ### Support for web frameworks
 
 * [Express](https://github.com/aws/aws-xray-sdk-node/tree/master/packages/express)
-* [Restify](https://github.com/aws/aws-xray-sdk-node/tree/master/packages/restify)(beta)
+* [Restify](https://github.com/aws/aws-xray-sdk-node/tree/master/packages/restify)

--- a/packages/mysql/README.md
+++ b/packages/mysql/README.md
@@ -1,8 +1,8 @@
 
 ## Requirements
 
-  AWS X-Ray SDK Core
-  MySQL 2.12.0 or greater
+* AWS X-Ray SDK Core
+* MySQL 2.12.0 or greater
 
 ## AWS X-Ray and MySQL
 
@@ -10,7 +10,7 @@ The AWS X-Ray MySQL package automatically records query information and request 
 response data. Simply patch the MySQL package via `captureMySQL` as shown below.
 
 The AWS X-Ray SDK Core has two modes - `manual` and `automatic`.
-Automatic mode uses the Continuation Local Storage package (CLS) and automatically
+Automatic mode uses the `cls-hooked` package and automatically
 tracks the current segment and subsegment. This is the default mode.
 Manual mode requires that you pass around the segment reference. See the examples below.
 
@@ -18,6 +18,16 @@ Manual mode requires that you pass around the segment reference. See the example
 
     MYSQL_DATABASE_VERSION           Sets additional data for the sql subsegment.
     MYSQL_DRIVER_VERSION             Sets additional data for the sql subsegment.
+
+### Lambda Example
+    var AWSXRay = require('aws-xray-sdk');
+    var pg = AWSXRay.captureMySQL(require('mysql'));
+
+    ...
+
+    exports.handler = function (event, context, callback) {
+      // Make MySQL queries normally
+    }
 
 ## Automatic mode example
 

--- a/packages/postgres/README.md
+++ b/packages/postgres/README.md
@@ -1,8 +1,8 @@
 
 ## Requirements
 
-  AWS X-Ray SDK Core
-  Postgres 6.1.0 or greater
+* AWS X-Ray SDK Core
+* Postgres 6.1.0 or greater
 
 ## AWS X-Ray and Postgres
 
@@ -10,7 +10,7 @@ The AWS X-Ray Postgres package automatically records query information and reque
 and response data. Simply patch the Postgres package via `capturePostgres` as shown below.
 
 The AWS X-Ray SDK Core has two modes - `manual` and `automatic`.
-Automatic mode uses the Continuation Local Storage package (CLS) and automatically
+Automatic mode uses the `cls-hooked` package and automatically
 tracks the current segment and subsegment. This is the default mode.
 Manual mode requires that you pass around the segment reference. See the examples below.
 
@@ -18,6 +18,16 @@ Manual mode requires that you pass around the segment reference. See the example
 
     POSTGRES_DATABASE_VERSION        Sets additional data for the sql subsegment.
     POSTGRES_DRIVER_VERSION          Sets additional data for the sql subsegment.
+
+### Lambda Example
+    var AWSXRay = require('aws-xray-sdk');
+    var pg = AWSXRay.capturePostgres(require('pg'));
+
+    ...
+
+    exports.handler = function (event, context, callback) {
+      // Make postgres queries normally
+    }
 
 ### Automatic mode example
 

--- a/packages/restify/README.md
+++ b/packages/restify/README.md
@@ -1,47 +1,38 @@
 
 ## Requirements
 
-  AWS X-Ray SDK Core (aws-xray-sdk-core)
-  Restify 4.3.0 or greater
+* AWS X-Ray SDK Core (aws-xray-sdk-core)
+* Restify 4.3.0 or greater
 
 ## AWS X-Ray and Restify
 
 The AWS X-Ray Restify package automatically records information for incoming and outgoing
-requests and responses, via the 'enable' function in this package.
+requests and responses, via the 'enable' function in this package. To configure sampling, dynamic naming, and more see the [set up section](https://github.com/aws/aws-xray-sdk-node/tree/master/packages/core#setup).
 
 The AWS X-Ray SDK Core has two modes - `manual` and `automatic`.
-Automatic mode uses the Continuation Local Storage package (CLS) and automatically
+Automatic mode uses the `cls-hooked` package and automatically
 tracks the current segment and subsegment. This is the default mode.
 Manual mode requires that you pass around the segment reference.
 
 In automatic mode, you can get the current segment or subsegment at any time:
+
     var segment = AWSXRay.getSegment();
 
 In manual mode, you can get the base segment off of the request object:
+
     var segment = req.segment;
 
     //If the restify context plugin is being used, it is placed under 'XRaySegment'
     var segment = req.get('XRaySegment');
 
-## Sampling rates on routes
+## Middleware usage
 
-Sampling rates are determined by the AWS X-Ray SDK Core package, using the default
-sampling file that is provided, or by overriding this with a custom sampling file.
-For more information about sampling, see the aws-xray-sdk-core [README](https://github.com/aws/aws-xray-sdk-node/tree/master/packages/core/README.md).
-
-## Dynamic and fixed naming modes
-
-The SDK requires that a default segment name is set. If it isn't set,
-an error is thrown. You can override this value via the `AWS_XRAY_TRACING_NAME`
-environment variable.
-
-    AWSXRayRestify.enable(server, 'defaultName');
-
-The AWS X-Ray SDK Core defaults to a fixed naming mode. This means that each time the handler creates a new segment for an incoming request,
-the name of that segment is set to the default name. In dynamic mode, the segment name can vary between the host header of the request or the default name.
-For more information about naming modes, see the aws-xray-sdk-core [README](https://github.com/aws/aws-xray-sdk-node/tree/master/packages/core/README.md).
+The X-Ray SDK provides a single Restify middleware: 
+`AWSXRayRestify.enable(<server>, <defaultName>)`. This *must* be added as the last middleware before defining all routes you'd like to have traced, otherwise issues with the `cls-hooked` context may occur. Error capturing will be done automatically.
 
 ## Automatic mode examples
+
+For more automatic mode examples, see the [example code](https://github.com/aws/aws-xray-sdk-node/tree/master/packages/core#example-code).
 
     var AWSXRayRestify = require('aws-xray-sdk-restify');
     var restify = require('restify');
@@ -62,6 +53,8 @@ For more information about naming modes, see the aws-xray-sdk-core [README](http
     //Error capturing is attached to the server's uncaughtException and after events (for both handled and unhandled errors)
 
 ## Manual mode examples
+
+For more manual mode examples, see [manual mode examples for Express](https://github.com/aws/aws-xray-sdk-node/tree/master/packages/express#manual-mode-examples). The X-Ray SDK can be used identically inside Restify routes.
 
     var AWSXRayRestify = require('aws-xray-sdk-restify');
     var restify = require('restify');


### PR DESCRIPTION
*Issue #, if available:*
#263 

*Description of changes:*
This PR changes brushes up all the READMEs in the package to ensure they contain up-to-date, concise information.

* Encapsulate express-specific documentation to the express package readme
* Include documentation for Lambda instrumentation
* Remove duplicated documentation/sample code
* Replace references to CLS with cls-hooked
* Bring Restify out of beta

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
