### PR TITLE
chore: prepares 3.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,20 +9,7 @@
 The AWS X-Ray SDK for Node.js is compatible with Node.js version 10.x and later.
 There may be issues when running on the latest odd-numbered release of Node.js.
 
-The X-Ray SDK is in the alpha stage of its 3.0.0 release. Note that these releases may be subject to more breaking changes in future versions. 
-To install the latest 3.0.0-alpha version of the Node SDK for development, just include the `alpha` distribution tag.
-
-```
-npm install aws-xray-sdk@alpha
-```
-
-Use the --save option to save the alpha SDK as a dependency in your application's package.json.
-
-```
-npm install aws-xray-sdk@alpha --save
-```
-
-The latest stable version of the SDK is also available from NPM. For local development, install the SDK in your project directory with npm.
+The latest stable version of the SDK is available from NPM. For local development, install the SDK in your project directory with npm.
 
 ```
 npm install aws-xray-sdk
@@ -43,6 +30,10 @@ The [API Reference](http://docs.aws.amazon.com/xray-sdk-for-nodejs/latest/refere
 provides guidance for using this SDK and module-level documentation.
 
 [CHANGELOG.md](https://github.com/aws/aws-xray-sdk-node/blob/master/packages/full_sdk/CHANGELOG.md)
+
+## Sample App
+
+To get started with a functional web application instrumented with the X-Ray SDK, check out our [sample app](https://github.com/aws-samples/aws-xray-sdk-node-sample).
 
 ## Getting Help
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog for AWS X-Ray Core SDK for JavaScript
-<!--LATEST=3.0.0-alpha.2-->
+<!--LATEST=3.0.0-->
 <!--ENTRYINSERT-->
+## 3.0.0
+* **BREAKING** change: Releasing all changes in 3.0.0-alpha.1 and 3.0.0-alpha.2 as stable. See below changelog entries. [#ISSUE157](https://github.com/aws/aws-xray-sdk-node/issues/157)
+* improvement: Deprecated support for Node 8 [#PR 273](https://github.com/aws/aws-xray-sdk-node/pull/273)
+* bugfix: Catch errors on requests to daemon [#ISSUE267](https://github.com/aws/aws-xray-sdk-node/issues/267)
+* bugfix: Correct AWS patcher TS defitnitions [#ISSUE276](https://github.com/aws/aws-xray-sdk-node/issues/276)
+
 ## 3.0.0-alpha.2
 * **BREAKING** change: Removed dependency on the aws-sdk, including all dependent TS definitions [PR #255](https://github.com/aws/aws-xray-sdk-node/pull/255)
 * improvement: Support Node 10 syntax for `http.request` [PR #247](https://github.com/aws/aws-xray-sdk-node/pull/247)

--- a/packages/express/CHANGELOG.md
+++ b/packages/express/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog for AWS X-Ray SDK Express for JavaScript
-<!--LATEST=3.0.0-alpha.2-->
+<!--LATEST=3.0.0-->
 <!--ENTRYINSERT-->
 ## 2.5.0
 * improvement: Added TypeScript definitions [PR #207](https://github.com/aws/aws-xray-sdk-node/pull/207)

--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -33,6 +33,10 @@ before defining routes, and the `closeSegment` middleware *must* be the
 first middleware added after defining routes. Otherwise issues with the `cls-hooked`
 context may occur.
 
+## Sample App
+
+To get started with a functional express application instrumented with the X-Ray SDK, check out our [sample app](https://github.com/aws-samples/aws-xray-sdk-node-sample).
+
 ## Automatic mode example
 For more automatic mode examples, see the [example code](https://github.com/aws/aws-xray-sdk-node/tree/master/packages/core#example-code).
 

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -18,7 +18,7 @@
     "@types/express": "*"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^3.0.0-alpha.2"
+    "aws-xray-sdk-core": "^3.0.0"
   },
   "devDependencies": {
     "aws-xray-sdk-core": "^3.0.0-alpha.2",

--- a/packages/full_sdk/CHANGELOG.md
+++ b/packages/full_sdk/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog for AWS X-Ray SDK for JavaScript
-<!--LATEST=3.0.0-alpha.2-->
+<!--LATEST=3.0.0-->
 <!--ENTRYINSERT-->
+## 3.0.0
+* change: Updated aws-xray-sdk-core to 3.0.0. See aws-xray-sdk-core's CHANGELOG.md for package changes.
+* change: Updated aws-xray-sdk-express to 3.0.0. No further changes.
+* change: Updated aws-xray-sdk-mysql to 3.0.0. No further changes.
+* change: Updated aws-xray-sdk-postgres to 3.0.0. No further changes.
+* change: Updated aws-xray-sdk-restify to 3.0.0. 
+  * improvement: Brought aws-xray-sdk-restify out of beta [commit](https://github.com/aws/aws-xray-sdk-node/commit/f6e7c2e311dda848aa3915b9c0e0ad2d714745fa#diff-ca41f70ee3218f6dc7b034e823f9e485)
+
 ## 3.0.0-alpha.2
 * change: Updated aws-xray-sdk-core to 3.0.0-alpha.2. See aws-xray-sdk-core's CHANGELOG.md for package changes.
 * change: Updated aws-xray-sdk-express to 3.0.0-alpha.2. No further changes.

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -18,7 +18,7 @@
     "@types/mysql": "*"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^3.0.0-alpha.2"
+    "aws-xray-sdk-core": "^3.0.0"
   },
   "devDependencies": {
     "aws-xray-sdk-core": "^3.0.0-alpha.2",

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -18,7 +18,7 @@
     "@types/pg": "*"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^3.0.0-alpha.2"
+    "aws-xray-sdk-core": "^3.0.0"
   },
   "devDependencies": {
     "aws-xray-sdk-core": "^3.0.0-alpha.2",

--- a/packages/restify/package.json
+++ b/packages/restify/package.json
@@ -18,7 +18,7 @@
     "@types/restify": "*"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^3.0.0-alpha.2"
+    "aws-xray-sdk-core": "^3.0.0"
   },
   "devDependencies": {
     "aws-xray-sdk-core": "^3.0.0-alpha.2",


### PR DESCRIPTION
*Issue #, if available:*
#157

*Description of changes:*
Takes the SDK out of alpha, and points to the new sample app.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
