### PR TITLE
Improved service connector error handling

### DIFF
--- a/packages/core/lib/middleware/sampling/service_connector.js
+++ b/packages/core/lib/middleware/sampling/service_connector.js
@@ -41,10 +41,12 @@ var ServiceConnector = {
           dataObj = JSON.parse(data);
         } catch (err) {
           callback(err);
+          return;
         }
 
-        if (dataObj === null) {
-          callback(new Error('AWS X-Ray GetSamplingRules API returned null response'));
+        if (!dataObj) {
+          callback(new Error('AWS X-Ray GetSamplingRules API returned empty response'));
+          return;
         }
 
         var newRules = assembleRules(dataObj);
@@ -53,8 +55,7 @@ var ServiceConnector = {
     });
 
     req.on('error', (err) => {
-      this.logger.getLogger().error(`Failed to connect to X-Ray daemon at ${options.hostname}:${options.port} to get sampling rules.`);
-      callback(err);
+      callback(new Error(`Failed to connect to X-Ray daemon at ${options.hostname}:${options.port} to get sampling rules.`));
     });
     
     req.write(body);
@@ -81,10 +82,12 @@ var ServiceConnector = {
           dataObj = JSON.parse(data);
         } catch (err) {
           callback(err);
+          return;
         }
 
-        if (dataObj === null || !dataObj['LastRuleModification']) {
+        if (!dataObj || !dataObj['LastRuleModification']) {
           callback(new Error('AWS X-Ray SamplingTargets API returned invalid response'));
+          return;
         }
 
         var targetsMapping = assembleTargets(dataObj);
@@ -94,8 +97,7 @@ var ServiceConnector = {
     });
 
     req.on('error', (err) => {
-      this.logger.getLogger().error(`Failed to connect to X-Ray daemon at ${options.hostname}:${options.port} to get sampling targets.`);
-      callback(err);
+      callback(new Error(`Failed to connect to X-Ray daemon at ${options.hostname}:${options.port} to get sampling targets.`));
     });
     
     req.write(body);

--- a/packages/core/lib/middleware/sampling/service_connector.js
+++ b/packages/core/lib/middleware/sampling/service_connector.js
@@ -24,8 +24,9 @@ var ServiceConnector = {
   fetchSamplingRules: function fetchSamplingRules(callback) {
     const body = '{}';  // Payload needed for GetSamplingRules POST request
     const options = getOptions(this.samplingRulesPath, body.length);
+    const httpReq = this.httpClient.__request ? this.httpClient.__request : this.httpClient.request;
     
-    const req = this.httpClient.request(options, res => {
+    const req = httpReq(options, res => {
       var data = '';
       res.on('data', d => {
         data += d;
@@ -65,8 +66,9 @@ var ServiceConnector = {
   fetchTargets: function fetchTargets(rules, callback) {
     const body = JSON.stringify(constructStatisticsDocs(rules));
     const options = getOptions(this.samplingTargetsPath, body.length);
+    const httpReq = this.httpClient.__request ? this.httpClient.__request : this.httpClient.request;
     
-    const req = this.httpClient.request(options, res => {
+    const req = httpReq(options, res => {
       var data = '';
       res.on('data', d => {
         data += d;

--- a/packages/core/lib/patchers/http_p.js
+++ b/packages/core/lib/patchers/http_p.js
@@ -9,8 +9,6 @@
 var url = require('url');
 
 var contextUtils = require('../context_utils');
-var DaemonConfig = require('../daemon_config');
-var ServiceConnector = require('../middleware/sampling/service_connector');
 var Utils = require('../utils');
 
 var logger = require('../logger');
@@ -74,15 +72,8 @@ function enableCapture(module, downstreamXRayEnabled) {
       callback = args[1];
     }
 
-    // Short circuit if the HTTP request has no options, is already being captured,
-    // or represents a centralized sampling request to the daemon
-    if (!options || 
-       (options.headers && (options.headers['X-Amzn-Trace-Id'])) ||
-       (options.hostname == DaemonConfig.tcp_ip && 
-        options.port == DaemonConfig.tcp_port && 
-       (options.path == ServiceConnector.samplingRulesPath || 
-        options.path == ServiceConnector.samplingTargetsPath)))
-    {
+    // Short circuit if the HTTP request has no options or is already being captured
+    if (!options || (options.headers && (options.headers['X-Amzn-Trace-Id']))) {
       return baseFunc(...args);
     }
 

--- a/packages/core/test/unit/sampling/service_connector.test.js
+++ b/packages/core/test/unit/sampling/service_connector.test.js
@@ -1,5 +1,4 @@
 var assert = require('chai').assert;
-var expect = require('chai').expect;
 var chai = require('chai');
 var sinon = require('sinon');
 var rewire = require('rewire');


### PR DESCRIPTION
*Issue #, if available:*
#285

*Description of changes:*
Cleaned up some of the `service_connector` functionality. Now we return quickly after an error instead of continuing to do pointless work, and I also changed some logging to be less verbose and more consistent for the customer. Improved and added some unit tests too.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
