### PR TITLE
Add support for IMDSv2

### DIFF
--- a/packages/core/lib/aws-xray.js
+++ b/packages/core/lib/aws-xray.js
@@ -55,15 +55,19 @@ var AWSXRay = {
 
   config: function(plugins) {
     var pluginData = {};
+    var lastOriginName;
     plugins.forEach(function(plugin) {
       plugin.getData(function(data) {
         if (data) {
           for (var attribute in data) { pluginData[attribute] = data[attribute]; }
         }
+
+        // Set origin regardless of data added. This will change in a later version
+        lastOriginName = plugin.originName;
       });
-      segmentUtils.setOrigin(plugin.originName);
-      segmentUtils.setPluginData(pluginData);
     });
+    if (lastOriginName) segmentUtils.setOrigin(lastOriginName);
+    segmentUtils.setPluginData(pluginData);
   },
 
   /**

--- a/packages/core/lib/aws-xray.js
+++ b/packages/core/lib/aws-xray.js
@@ -55,19 +55,15 @@ var AWSXRay = {
 
   config: function(plugins) {
     var pluginData = {};
-    var lastOriginName;
     plugins.forEach(function(plugin) {
       plugin.getData(function(data) {
         if (data) {
           for (var attribute in data) { pluginData[attribute] = data[attribute]; }
         }
-
-        // Set origin regardless of data added. This will change in a later version
-        lastOriginName = plugin.originName;
       });
+      segmentUtils.setOrigin(plugin.originName);
+      segmentUtils.setPluginData(pluginData);
     });
-    if (lastOriginName) segmentUtils.setOrigin(lastOriginName);
-    segmentUtils.setPluginData(pluginData);
   },
 
   /**

--- a/packages/core/lib/segments/plugins/ec2_plugin.js
+++ b/packages/core/lib/segments/plugins/ec2_plugin.js
@@ -9,22 +9,77 @@ var EC2Plugin = {
    */
 
   getData: function(callback) {
-    var METADATA_OPTIONS = {
-      host: '169.254.169.254',
-      path: '/latest/dynamic/instance-identity/document'
-    };
+    function getMetadataToken() {
+      const TTL = 60; //seconds
+      const tokenOptions = getOptions('/api/token', 'PUT', {
+        'X-aws-ec2-metadata-token-ttl-seconds': TTL
+      });
 
-    Plugin.getPluginMetadata(METADATA_OPTIONS, function(err, data) {
-      if (err) {
-        logger.getLogger().error('Error loading EC2 plugin: ', err.stack);
-        callback();
-      } else {
-        var metadata = { ec2: { instance_id: data.instanceId, availability_zone: data.availabilityZone }};
-        callback(metadata);
-      }
-    });
+      Plugin.getToken(tokenOptions, function(err, data) {
+        if (err) {
+          logger.getLogger().debug('EC2Plugin failed to get token from IMDSv2. Falling back to IMDSv1.', err);
+          getV1Metadata();
+        } else {
+          // Successfully got token, use it for IMDSv2 metadata request
+          getV2Metadata(data);
+        }
+      });
+    }
+
+    function getV2Metadata(token) {
+      const options = getOptions('/latest/dynamic/instance-identity/document', 'GET', {
+        'X-aws-ec2-metadata-token': token
+      });
+
+      Plugin.getPluginMetadata(options, function(err, data) {
+        if (err) {
+          logger.getLogger().debug('EC2Plugin failed to get metadata from IMDSv2. Falling back to IMDSv1.', err)
+          getV1Metadata();
+        } else {
+          const metadata = { ec2: { instance_id: data.instanceId, availability_zone: data.availabilityZone }};
+          callback(metadata);
+        }
+      });
+    }
+
+    function getV1Metadata() {
+      const options = getOptions('/latest/dynamic/instance-identity/document');
+  
+      Plugin.getPluginMetadata(options, function(err, data) {
+        if (err) {
+          logger.getLogger().error('Error loading EC2 plugin: ', err);
+          callback();
+        } else {
+          const metadata = { ec2: { instance_id: data.instanceId, availability_zone: data.availabilityZone }};
+          callback(metadata);
+        }
+      });
+    }
+
+    /**
+     * This kicks off a requet to get a token used for requests to IMDSv2. If the request for the token or the 
+     * v2 metadata itself fails, we fall back to IMDSv1.
+     */
+    getMetadataToken();
   },
   originName: 'AWS::EC2::Instance'
 };
+
+function getOptions(path, method, headers) {
+  if (!method) {
+    method = 'GET';
+  }
+
+  if (!headers) {
+    headers = {};
+  }
+
+  return {
+    host: '169.254.169.254',
+    path: path,
+    method: method,
+    headers: headers
+  };
+}
 
 module.exports = EC2Plugin;

--- a/packages/core/lib/segments/plugins/ec2_plugin.js
+++ b/packages/core/lib/segments/plugins/ec2_plugin.js
@@ -1,78 +1,89 @@
 var Plugin = require('./plugin');
-
 var logger = require('../../logger');
+var http = require('http');
 
 var EC2Plugin = {
   /**
    * A function to get the instance data from the EC2 metadata service.
    * @param {function} callback - The callback for the plugin loader.
    */
-
   getData: function(callback) {
-    const TOKEN_PATH = '/latest/api/token';
     const METADATA_PATH = '/latest/dynamic/instance-identity/document';
 
-    function getMetadataToken() {
-      const TTL = 60; //seconds
-      const tokenOptions = getOptions(TOKEN_PATH, 'PUT', {
-        'X-aws-ec2-metadata-token-ttl-seconds': TTL
-      });
-
-      Plugin.getToken(tokenOptions, function(err, data) {
-        if (err) {
-          logger.getLogger().debug('EC2Plugin failed to get token from IMDSv2. Falling back to IMDSv1.', err.toString());
-          getV1Metadata();
-        } else {
-          // Successfully got token, use it for IMDSv2 metadata request
-          getV2Metadata(data);
-        }
-      });
-    }
-
-    function getV2Metadata(token) {
-      const options = getOptions(METADATA_PATH, 'GET', {
-        'X-aws-ec2-metadata-token': token
-      });
+    function populateMetadata(token) {
+      const options = getOptions(
+        METADATA_PATH,
+        'GET',
+        token ? { 'X-aws-ec2-metadata-token': token } : {}
+      );
 
       Plugin.getPluginMetadata(options, function(err, data) {
-        if (err) {
-          logger.getLogger().debug('EC2Plugin failed to get metadata from IMDSv2. Falling back to IMDSv1.', err.toString())
-          getV1Metadata();
-        } else if (data) {
-          const metadata = { ec2: { instance_id: data.instanceId, availability_zone: data.availabilityZone }};
-          callback(metadata);
-        } else {
-          logger.getLogger().debug('Failed to get required EC2 metadata from IMDSv2. Falling back to IMDSv1.');
-          getV1Metadata();
+        if (err || !data) {
+          logger.getLogger().error('Error loading EC2 plugin metadata: ', err ? err.toString() : 'Could not retrieve data from IMDS.');
+          callback();
+          return;
         }
-      });
-    }
 
-    function getV1Metadata() {
-      const options = getOptions('/latest/dynamic/instance-identity/document');
-  
-      Plugin.getPluginMetadata(options, function(err, data) {
-        if (err) {
-          logger.getLogger().error('Error loading EC2 plugin: ', err.toString());
-          callback();
-        } else if (data) {
-          const metadata = { ec2: { instance_id: data.instanceId, availability_zone: data.availabilityZone }};
-          callback(metadata);
-        } else {
-          logger.getLogger().error('Failed to get required EC2 metadata from IMDS');
-          callback();
-        }
+        const metadata = { ec2: { instance_id: data.instanceId, availability_zone: data.availabilityZone }};
+        callback(metadata);
       });
     }
 
     /**
-     * This kicks off a requet to get a token used for requests to IMDSv2. If the request for the token or the 
-     * v2 metadata itself fails, we fall back to IMDSv1.
+     * This kicks off a requet to get a token used for requests to IMDSv2. If the request for the token 
+     * fails, we fall back to IMDSv1. Otherwise, the token will be used for an IMDSv2 request.
      */
-    getMetadataToken();
+    getToken(function(token) {
+      if (token === null) {
+        logger.getLogger().debug('EC2Plugin failed to get token from IMDSv2. Falling back to IMDSv1.');
+      }
+
+      populateMetadata(token);
+    });
   },
   originName: 'AWS::EC2::Instance'
 };
+
+/**
+ * Asynchronously retrieves a token used in requests to EC2 instance metadata service.
+ * @param {function} callback - callback to plugin
+ */
+function getToken(callback) {
+  const httpReq = http.__request ? http.__request : http.request;
+  const TTL = 60; //seconds
+  const TOKEN_PATH = '/latest/api/token';
+  const options = getOptions(TOKEN_PATH, 'PUT', {
+    'X-aws-ec2-metadata-token-ttl-seconds': TTL
+  });
+
+  let req = httpReq(options, function(res) {
+    let body = '';
+
+    res.on('data', function(chunk) {
+      body += chunk;
+    });
+
+    res.on('end', function() {
+      if (this.statusCode === 200 || this.statusCode === 300) {
+        callback(body);
+      } else {
+        callback(null);
+      }
+    });
+  });
+
+  req.on('error', function() {
+    callback(null);
+  });
+
+  req.on('timeout', function() {
+    req.abort();
+    callback(null);
+  });
+
+  req.setTimeout(Plugin.METADATA_TIMEOUT);
+  req.end();
+}
 
 function getOptions(path, method, headers) {
   if (!method) {

--- a/packages/core/lib/segments/plugins/plugin.js
+++ b/packages/core/lib/segments/plugins/plugin.js
@@ -57,42 +57,6 @@ var Plugin = {
     };
 
     getMetadata();
-  },
-
-  /**
-   * Asynchronously retrieves a token used in requests to EC2 instance metadata service.
-   * @param {object} options - The HTTP options to make the request with
-   * @param {function} callback - callback to plugin
-   */
-  getToken: function(options, callback) {
-    let httpReq = http.__request ? http.__request : http.request;
-
-    let req = httpReq(options, function(res) {
-      let body = '';
-
-      res.on('data', function(chunk) {
-        body += chunk;
-      });
-
-      res.on('end', function() {
-        if (this.statusCode === 200 || this.statusCode === 300) {
-          callback(null, body);
-        } else {
-          callback(new Error(`Failed to retrieve token with options: ${options}`));
-        }
-      });
-    });
-
-    req.on('error', function(err) {
-      callback(err);
-    });
-
-    req.on('timeout', function() {
-      req.abort();
-    });
-
-    req.setTimeout(Plugin.METADATA_TIMEOUT);
-    req.end();
   }
 };
 

--- a/packages/core/lib/segments/plugins/plugin.js
+++ b/packages/core/lib/segments/plugins/plugin.js
@@ -1,10 +1,17 @@
 var http = require('http');
 
 var Plugin = {
+  METADATA_TIMEOUT: 1000, // Millis
+
+  /**
+   * Asynchronously retrieves metadata from on-instance endpoint with an HTTP request using retries for
+   * requests that time out.
+   * @param {object} options - The HTTP options to make the request with
+   * @param {function} callback - callback to plugin
+   */
   getPluginMetadata: function(options, callback) {
-    var METADATA_TIMEOUT = 1000;
-    var METADATA_RETRY_TIMEOUT = 250;
-    var METADATA_RETRIES = 20;
+    const METADATA_RETRY_TIMEOUT = 250; // Millis
+    const METADATA_RETRIES = 5;
 
     var retries = METADATA_RETRIES;
 
@@ -17,30 +24,75 @@ var Plugin = {
         res.on('data', function(chunk) {
           body += chunk;
         });
+
         res.on('end', function() {
           if (this.statusCode === 200 || this.statusCode === 300) {
-            body = JSON.parse(body);
+            try {
+              body = JSON.parse(body);
+            } catch (e) {
+              callback(e);
+              return;
+            }
+            
             callback(null, body);
-          } else if (retries > 0 && this.statusCode === 400){
+          } else if (retries > 0 && Math.floor(this.statusCode / 100) === 5) {
             retries--;
             setTimeout(getMetadata, METADATA_RETRY_TIMEOUT);
-          } else { callback(); }
+          } else {
+            callback(new Error(`Failed to retrieve metadata with options: ${options}`));
+          }
         });
-      }).on('error', function(err) {
+      });
+
+      req.on('error', function(err) {
         callback(err);
       });
 
-      req.on('socket', function(socket) {
-        socket.on('timeout', function() {
-          req.abort();
-        });
-        socket.setTimeout(METADATA_TIMEOUT);
+      req.on('timeout', function() {
+        req.abort();
       });
 
+      req.setTimeout(Plugin.METADATA_TIMEOUT);
       req.end();
     };
 
     getMetadata();
+  },
+
+  /**
+   * Asynchronously retrieves a token used in requests to EC2 instance metadata service.
+   * @param {object} options - The HTTP options to make the request with
+   * @param {function} callback - callback to plugin
+   */
+  getToken: function(options, callback) {
+    let httpReq = http.__request ? http.__request : http.request;
+
+    let req = httpReq(options, function(res) {
+      let body = '';
+
+      res.on('data', function(chunk) {
+        body += chunk;
+      });
+
+      res.on('end', function() {
+        if (this.statusCode === 200 || this.statusCode === 300) {
+          callback(null, body);
+        } else {
+          callback(new Error(`Failed to retrieve token with options: ${options}`));
+        }
+      });
+    });
+
+    req.on('error', function(err) {
+      callback(err);
+    });
+
+    req.on('timeout', function() {
+      req.abort();
+    });
+
+    req.setTimeout(Plugin.METADATA_TIMEOUT);
+    req.end();
   }
 };
 

--- a/packages/core/test/unit/segments/plugins/ec2_plugin.test.js
+++ b/packages/core/test/unit/segments/plugins/ec2_plugin.test.js
@@ -15,7 +15,7 @@ describe('EC2Plugin', function() {
     instanceId: 'i-1234567890abcdef0'
   };
   const HOST = '169.254.169.254';
-  const TOKEN_PATH = '/api/token';
+  const TOKEN_PATH = '/latest/api/token';
   const METADATA_PATH = '/latest/dynamic/instance-identity/document';
   const TOKEN = 'fancyToken';
   const METADATA_HEADER = {

--- a/packages/core/test/unit/segments/plugins/ec2_plugin.test.js
+++ b/packages/core/test/unit/segments/plugins/ec2_plugin.test.js
@@ -3,120 +3,137 @@ var assert = require('chai').assert;
 var chai = require('chai');
 var sinon = require('sinon');
 var sinonChai = require('sinon-chai');
+var nock = require('nock');
+var rewire = require('rewire');
 
 chai.use(sinonChai);
 
-var EC2Plugin = require('../../../../lib/segments/plugins/ec2_plugin');
+// Rewired to get access to getToken function
+var EC2Plugin = rewire('../../../../lib/segments/plugins/ec2_plugin');
 var Plugin = require('../../../../lib/segments/plugins/plugin');
 
 describe('EC2Plugin', function() {
-  const data = {
-    availabilityZone: 'us-east-1d',
-    instanceId: 'i-1234567890abcdef0'
-  };
   const HOST = '169.254.169.254';
-  const TOKEN_PATH = '/latest/api/token';
-  const METADATA_PATH = '/latest/dynamic/instance-identity/document';
   const TOKEN = 'fancyToken';
-  const METADATA_HEADER = {
-    'X-aws-ec2-metadata-token': TOKEN
-  };
 
-  let sandbox;
+  describe('#getData', function() {
+    const data = {
+      availabilityZone: 'us-east-1d',
+      instanceId: 'i-1234567890abcdef0'
+    };
+    const METADATA_PATH = '/latest/dynamic/instance-identity/document';
+    const METADATA_HEADER = {
+      'X-aws-ec2-metadata-token': TOKEN
+    };
 
-  beforeEach(function() {
-    sandbox = sinon.sandbox.create();
-  });
+    let sandbox, revert;
 
-  afterEach(function() {
-    sandbox.restore();
-  });
+    beforeEach(function() {
+      sandbox = sinon.sandbox.create();
+    });
 
-  it('should return metadata from IMDSv2 if first requests are successful', function(done) {
-    let getTokenStub = sandbox.stub(Plugin, 'getToken').yields(null, TOKEN);
-    let getMetaStub = sandbox.stub(Plugin, 'getPluginMetadata').yields(null, data);
-    
+    afterEach(function() {
+      sandbox.restore();
+      revert();
+    });
 
-    EC2Plugin.getData(function(metadata) {
-      const tokenOptions = getTokenStub.getCall(0).args[0];
-      const metaOptions = getMetaStub.getCall(0).args[0];
+    it('should return metadata from IMDSv2 if first requests are successful', function(done) {
+      revert = EC2Plugin.__set__('getToken', function(callback) {
+        callback(TOKEN);
+      });
 
-      getTokenStub.should.have.been.calledOnce;
-      getMetaStub.should.have.been.calledOnce;
-      
-      // verify all v2 arguments
-      assert.equal(tokenOptions.host, HOST);
-      assert.equal(tokenOptions.path, TOKEN_PATH);
-      assert.equal(metaOptions.host, HOST);
-      assert.equal(metaOptions.path, METADATA_PATH);
-      assert.deepEqual(metaOptions.headers, METADATA_HEADER);
+      let getMetaStub = sandbox
+        .stub(Plugin, 'getPluginMetadata')
+        .yields(null, data);
 
-      // verify correct data received
-      assert.equal(metadata.ec2.instance_id, data.instanceId);
-      assert.equal(metadata.ec2.availability_zone, data.availabilityZone);
-      done();
+      EC2Plugin.getData(function(metadata) {
+        const metaOptions = getMetaStub.getCall(0).args[0];
+
+        // getTokenStub.should.have.been.calledOnce;
+        getMetaStub.should.have.been.calledOnce;
+
+        // verify all v2 arguments
+        assert.equal(metaOptions.host, HOST);
+        assert.equal(metaOptions.path, METADATA_PATH);
+        assert.deepEqual(metaOptions.headers, METADATA_HEADER);
+
+        // verify correct data received
+        assert.equal(metadata.ec2.instance_id, data.instanceId);
+        assert.equal(metadata.ec2.availability_zone, data.availabilityZone);
+        done();
+      });
+    });
+
+    it('should fall back to IMDSv1 if token request fails', function(done) {
+      revert = EC2Plugin.__set__('getToken', function(callback) {
+        callback(null);
+      });
+
+      let getMetaStub = sandbox
+        .stub(Plugin, 'getPluginMetadata')
+        .yields(null, data);
+
+      EC2Plugin.getData(function(metadata) {
+        const metaOptions = getMetaStub.getCall(0).args[0];
+        getMetaStub.should.have.been.calledOnce;
+
+        // verify we used v1 args
+        assert.equal(metaOptions.host, HOST);
+        assert.equal(metaOptions.path, METADATA_PATH);
+        assert.deepEqual(metaOptions.headers, {});
+
+        // verify correct data received
+        assert.equal(metadata.ec2.instance_id, data.instanceId);
+        assert.equal(metadata.ec2.availability_zone, data.availabilityZone);
+        done();
+      });
+    });
+
+    it('should return undefined if an error is recieved for both versions of IMDS', function(done) {
+      revert = EC2Plugin.__set__('getToken', function(callback) {
+        callback(null);
+      });
+
+      let getMetaStub = sandbox
+        .stub(Plugin, 'getPluginMetadata')
+        .yields(new Error('MetaError'));
+
+      EC2Plugin.getData(function(data) {
+        getMetaStub.should.have.been.calledOnce;
+        expect(data).to.be.undefined;
+        done();
+      });
     });
   });
 
-  it('should fall back to IMDSv1 if token request fails', function(done) {
-    let getTokenStub = sandbox.stub(Plugin, 'getToken').yields(new Error('tokenError'));
-    let getMetaStub = sandbox.stub(Plugin, 'getPluginMetadata').yields(null, data);
+  describe('#getToken', function() {
+    let getToken = EC2Plugin.__get__('getToken');
+    let getTokenRequest;
+    const TOKEN_HOST = `http://${HOST}`;
+    const TOKEN_PATH = '/latest/api/token';
 
-    EC2Plugin.getData(function(metadata) {
-      const metaOptions = getMetaStub.getCall(0).args[0];
-      getTokenStub.should.have.been.calledOnce;
-      getMetaStub.should.have.been.calledOnce;
+    it('should return token on 200 OK', function(done) {
+      getTokenRequest = nock(TOKEN_HOST)
+        .put(TOKEN_PATH)
+        .reply(200, TOKEN);
 
-      // verify we used v1 args
-      assert.equal(metaOptions.host, HOST);
-      assert.equal(metaOptions.path, METADATA_PATH);
-      assert.deepEqual(metaOptions.headers, {});
-
-      // verify correct data received
-      assert.equal(metadata.ec2.instance_id, data.instanceId);
-      assert.equal(metadata.ec2.availability_zone, data.availabilityZone);
-      done();
+      getToken(function(data) {
+        assert.equal(data, TOKEN);
+        getTokenRequest.done();
+        done();
+      });
     });
-  });
 
-  it('should fall back to IMDSv1 if IMDSv2 metadata request fails', function(done) {
-    let getTokenStub = sandbox.stub(Plugin, 'getToken').yields(null, TOKEN);
-    let getMetaStub = sandbox.stub(Plugin, 'getPluginMetadata');
-    getMetaStub.onCall(0).yields(new Error('MetaError'));
-    getMetaStub.onCall(1).yields(null, data);
+    it('should return null on 4xx', function(done) {
+      getTokenRequest = nock(TOKEN_HOST)
+        .put(TOKEN_PATH)
+        .reply(400);
 
-    EC2Plugin.getData(function(metadata) {
-      const metaOptions1 = getMetaStub.getCall(0).args[0];
-      const metaOptions2 = getMetaStub.getCall(1).args[0];
-      getTokenStub.should.have.been.calledOnce;
-      getMetaStub.should.have.been.calledTwice;
-
-      // verify we used v2 args on second request
-      assert.equal(metaOptions1.host, HOST);
-      assert.equal(metaOptions1.path, METADATA_PATH);
-      assert.deepEqual(metaOptions1.headers, METADATA_HEADER);
-
-      // verify we used v1 args on second request
-      assert.equal(metaOptions2.host, HOST);
-      assert.equal(metaOptions2.path, METADATA_PATH);
-      assert.deepEqual(metaOptions2.headers, {});
-
-      // verify correct data received
-      assert.equal(metadata.ec2.instance_id, data.instanceId);
-      assert.equal(metadata.ec2.availability_zone, data.availabilityZone);
-      done();
-    });
-  });
-
-  it('should return undefined if an error is recieved for both versions of IMDS', function(done) {
-    let getTokenStub = sandbox.stub(Plugin, 'getToken').yields(null, TOKEN);
-    let getMetaStub = sandbox.stub(Plugin, 'getPluginMetadata').yields(new Error('MetaError'));
-
-    EC2Plugin.getData(function(data) {
-      getTokenStub.should.have.been.calledOnce;
-      getMetaStub.should.have.been.calledTwice;
-      expect(data).to.be.undefined;
-      done();
+      getToken(function(data) {
+        assert.isNull(data);
+        getTokenRequest.done();
+        done();
+      });
     });
   });
 });

--- a/packages/core/test/unit/segments/plugins/ec2_plugin.test.js
+++ b/packages/core/test/unit/segments/plugins/ec2_plugin.test.js
@@ -1,4 +1,5 @@
 var expect = require('chai').expect;
+var assert = require('chai').assert;
 var chai = require('chai');
 var sinon = require('sinon');
 var sinonChai = require('sinon-chai');
@@ -9,12 +10,19 @@ var EC2Plugin = require('../../../../lib/segments/plugins/ec2_plugin');
 var Plugin = require('../../../../lib/segments/plugins/plugin');
 
 describe('EC2Plugin', function() {
-  var data = {
+  const data = {
     availabilityZone: 'us-east-1d',
     instanceId: 'i-1234567890abcdef0'
   };
+  const HOST = '169.254.169.254';
+  const TOKEN_PATH = '/api/token';
+  const METADATA_PATH = '/latest/dynamic/instance-identity/document';
+  const TOKEN = 'fancyToken';
+  const METADATA_HEADER = {
+    'X-aws-ec2-metadata-token': TOKEN
+  };
 
-  var getStub, sandbox;
+  let sandbox;
 
   beforeEach(function() {
     sandbox = sinon.sandbox.create();
@@ -24,22 +32,89 @@ describe('EC2Plugin', function() {
     sandbox.restore();
   });
 
-  it('should return an object holding EC2 metadata if it recieved data', function(done) {
-    getStub = sandbox.stub(Plugin, 'getPluginMetadata').yields(null, data);
+  it('should return metadata from IMDSv2 if first requests are successful', function(done) {
+    let getTokenStub = sandbox.stub(Plugin, 'getToken').yields(null, TOKEN);
+    let getMetaStub = sandbox.stub(Plugin, 'getPluginMetadata').yields(null, data);
+    
 
-    EC2Plugin.getData(function(data) {
-      getStub.should.have.been.calledOnce;
-      expect(data.ec2).not.to.be.empty;
+    EC2Plugin.getData(function(metadata) {
+      const tokenOptions = getTokenStub.getCall(0).args[0];
+      const metaOptions = getMetaStub.getCall(0).args[0];
+
+      getTokenStub.should.have.been.calledOnce;
+      getMetaStub.should.have.been.calledOnce;
+      
+      // verify all v2 arguments
+      assert.equal(tokenOptions.host, HOST);
+      assert.equal(tokenOptions.path, TOKEN_PATH);
+      assert.equal(metaOptions.host, HOST);
+      assert.equal(metaOptions.path, METADATA_PATH);
+      assert.deepEqual(metaOptions.headers, METADATA_HEADER);
+
+      // verify correct data received
+      assert.equal(metadata.ec2.instance_id, data.instanceId);
+      assert.equal(metadata.ec2.availability_zone, data.availabilityZone);
       done();
     });
   });
 
-  it('should return undefined if an error is recieved', function(done) {
-    var err = new Error('error');
-    getStub = sandbox.stub(Plugin, 'getPluginMetadata').yields(err);
+  it('should fall back to IMDSv1 if token request fails', function(done) {
+    let getTokenStub = sandbox.stub(Plugin, 'getToken').yields(new Error('tokenError'));
+    let getMetaStub = sandbox.stub(Plugin, 'getPluginMetadata').yields(null, data);
+
+    EC2Plugin.getData(function(metadata) {
+      const metaOptions = getMetaStub.getCall(0).args[0];
+      getTokenStub.should.have.been.calledOnce;
+      getMetaStub.should.have.been.calledOnce;
+
+      // verify we used v1 args
+      assert.equal(metaOptions.host, HOST);
+      assert.equal(metaOptions.path, METADATA_PATH);
+      assert.deepEqual(metaOptions.headers, {});
+
+      // verify correct data received
+      assert.equal(metadata.ec2.instance_id, data.instanceId);
+      assert.equal(metadata.ec2.availability_zone, data.availabilityZone);
+      done();
+    });
+  });
+
+  it('should fall back to IMDSv1 if IMDSv2 metadata request fails', function(done) {
+    let getTokenStub = sandbox.stub(Plugin, 'getToken').yields(null, TOKEN);
+    let getMetaStub = sandbox.stub(Plugin, 'getPluginMetadata');
+    getMetaStub.onCall(0).yields(new Error('MetaError'));
+    getMetaStub.onCall(1).yields(null, data);
+
+    EC2Plugin.getData(function(metadata) {
+      const metaOptions1 = getMetaStub.getCall(0).args[0];
+      const metaOptions2 = getMetaStub.getCall(1).args[0];
+      getTokenStub.should.have.been.calledOnce;
+      getMetaStub.should.have.been.calledTwice;
+
+      // verify we used v2 args on second request
+      assert.equal(metaOptions1.host, HOST);
+      assert.equal(metaOptions1.path, METADATA_PATH);
+      assert.deepEqual(metaOptions1.headers, METADATA_HEADER);
+
+      // verify we used v1 args on second request
+      assert.equal(metaOptions2.host, HOST);
+      assert.equal(metaOptions2.path, METADATA_PATH);
+      assert.deepEqual(metaOptions2.headers, {});
+
+      // verify correct data received
+      assert.equal(metadata.ec2.instance_id, data.instanceId);
+      assert.equal(metadata.ec2.availability_zone, data.availabilityZone);
+      done();
+    });
+  });
+
+  it('should return undefined if an error is recieved for both versions of IMDS', function(done) {
+    let getTokenStub = sandbox.stub(Plugin, 'getToken').yields(null, TOKEN);
+    let getMetaStub = sandbox.stub(Plugin, 'getPluginMetadata').yields(new Error('MetaError'));
 
     EC2Plugin.getData(function(data) {
-      getStub.should.have.been.calledOnce;
+      getTokenStub.should.have.been.calledOnce;
+      getMetaStub.should.have.been.calledTwice;
       expect(data).to.be.undefined;
       done();
     });

--- a/packages/core/test/unit/segments/plugins/plugin.test.js
+++ b/packages/core/test/unit/segments/plugins/plugin.test.js
@@ -1,5 +1,4 @@
 var expect = require('chai').expect;
-var assert = require('chai').assert;
 var nock = require('nock');
 
 var Plugin = require('../../../../lib/segments/plugins/plugin');
@@ -69,44 +68,6 @@ describe('Plugin', function() {
       getPluginMetadata(OPTIONS, function(err, data) {
         expect(data).to.be.empty;
         getMetadata.done();
-        done();
-      });
-    });
-  });
-
-  describe('#getToken', function() {
-    const token = 'fancyToken';
-    let getToken = Plugin.getToken;
-    let getTokenRequest;
-    const TOKEN_PATH = '/token';
-    const TOKEN_OPTIONS = {
-      host: 'localhost',
-      path: '/token',
-      method: 'PUT'
-    }
-
-    it('should return token on 200 OK', function(done) {
-      getTokenRequest = nock(METADATA_HOST)
-        .put(TOKEN_PATH)
-        .reply(200, token);
-
-      getToken(TOKEN_OPTIONS, function(err, data) {
-        assert.isNull(err);
-        assert.equal(data, token);
-        getTokenRequest.done();
-        done();
-      });
-    });
-
-    it('should return an error on 4xx', function(done) {
-      getTokenRequest = nock(METADATA_HOST)
-        .put(TOKEN_PATH)
-        .reply(400);
-
-      getToken(TOKEN_OPTIONS, function(err, data) {
-        assert.isNotNull(err);
-        assert.isDefined(err);
-        getTokenRequest.done();
         done();
       });
     });


### PR DESCRIPTION
*Description of changes:*
Changed the EC2Plugin to use instance metadata service (IMDS) v2 first to collect instance metadata, and use IMDSv1 as a fallback. One difference between this implementation and the [python](https://github.com/aws/aws-xray-sdk-python/pull/226) is that we retrieve the [dynamic instance identity document](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html) instead of calling the instance ID and AZ endpoints individually. This is because the Node SDK retrieves the document asynchronously, so even though its requests take longer the customer won't notice.

There were some issues with the original `Plugin.js` implementation, which is meant to be a helper class for making metadata endpoint requests, that I addressed. Specifically, I reduced the number of retries from 20 to 5, since that was very excessive. I also changed the retry logic to retry on 5xx errors instead of 4xx errors, since 4xx errors will persist irrespective of how many retries you make.

Tested this on an EC2 instance with V2 metadata enabled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
