### PR TITLE
refs #294, add support for AWS SDK v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "private": true,
   "license": "Apache-2.0",
   "devDependencies": {
+    "@aws-sdk/config-resolver": "^3.3.0",
+    "@aws-sdk/middleware-stack": "^3.3.0",
+    "@aws-sdk/node-config-provider": "^3.3.0",
+    "@aws-sdk/smithy-client": "^3.3.0",
+    "@aws-sdk/types": "^3.3.0",
     "@hapi/hapi": "^20.0.0",
     "@types/chai": "^4.2.12",
     "@types/koa": "^2.11.3",
@@ -39,6 +44,7 @@
     "sinon": "^9.0.2",
     "sinon-chai": "^3.5.0",
     "tsd": "^0.13.1",
+    "typescript": "^4.1.3",
     "upath": "^1.2.0"
   },
   "engines": {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -464,6 +464,8 @@ function sendRequest(host, cb) {
 
 ### Capture all outgoing AWS requests
 
+This is only available for AWS SDK v2 due to the service-oriented architecture of AWS SDK v3.
+
 ```js
 var AWS = captureAWS(require('aws-sdk'));
 
@@ -471,6 +473,23 @@ var AWS = captureAWS(require('aws-sdk'));
 ```
 
 ### Capture outgoing AWS requests on a single client
+
+
+AWS SDK v3
+
+```js
+import { S3, PutObjectCommand } from '@aws-sdk/client-s3';
+
+const s3 = AWSXRay.captureAWSv3Client(new S3({}));
+
+await s3.send(new PutObjectCommand({
+  Bucket: bucketName,
+  Key: keyName,
+  Body: 'Hello!',
+}));
+```
+
+AWS SDK v2
 
 ```js
 var s3 = AWSXRay.captureAWSClient(new AWS.S3());
@@ -622,6 +641,24 @@ function sendRequest(host, cb, subsegment) {
 
 ### Capture outgoing AWS requests on a single client
 
+AWS SDK v3
+
+```js
+import { S3, PutObjectCommand } from '@aws-sdk/client-s3';
+
+// subsegment is an optional parameter that is required for manual mode
+// and can be omitted in automatic mode (e.g. inside a Lambda function).
+const s3 = AWSXRay.captureAWSv3Client(new S3({}), subsegment);
+
+await s3.send(new PutObjectCommand({
+  Bucket: bucketName,
+  Key: keyName,
+  Body: 'Hello!',
+}));
+```
+
+AWS SDK v2
+
 ```js
 var s3 = AWSXRay.captureAWSClient(new AWS.S3());
 var params = {
@@ -637,6 +674,8 @@ s3.putObject(params, function(err, data) {
 ```
 
 ### Capture all outgoing AWS requests
+
+This is only available for AWS SDK v2 due to the service-oriented architecture of AWS SDK v3.
 
 ```js
 var AWS = captureAWS(require('aws-sdk'));

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -643,6 +643,9 @@ function sendRequest(host, cb, subsegment) {
 
 AWS SDK v3
 
+You must re-capture the client every time the subsegment is attached
+to a new parent.
+
 ```js
 import { S3, PutObjectCommand } from '@aws-sdk/client-s3';
 

--- a/packages/core/lib/aws-xray.d.ts
+++ b/packages/core/lib/aws-xray.d.ts
@@ -39,6 +39,8 @@ export { captureAsyncFunc, captureCallbackFunc, captureFunc } from './capture'
 
 export { captureAWS, captureAWSClient } from './patchers/aws_p';
 
+export type { captureAWSClient as captureAWSv3Client } from './patchers/aws3_p';
+
 export { captureHTTPs, captureHTTPsGlobal } from './patchers/http_p';
 
 export { capturePromise } from './patchers/promise_p';

--- a/packages/core/lib/aws-xray.js
+++ b/packages/core/lib/aws-xray.js
@@ -181,6 +181,16 @@ var AWSXRay = {
   captureAWSClient: require('./patchers/aws_p').captureAWSClient,
 
   /**
+   * @param {AWSv3.Service} service - An instance of a AWS SDK v3 service to wrap.
+   * @param {Segment=} segment - Optional segment for manual mode.
+   * @memberof AWSXRay
+   * @function
+   * @see module:aws3_p.captureAWSClient
+   */
+
+  captureAWSv3Client: require('./patchers/aws3_p').captureAWSClient,
+
+  /**
    * @param {http|https} module - The built in Node.js HTTP or HTTPS module.
    * @memberof AWSXRay
    * @function

--- a/packages/core/lib/aws-xray.js
+++ b/packages/core/lib/aws-xray.js
@@ -182,7 +182,7 @@ var AWSXRay = {
 
   /**
    * @param {AWSv3.Service} service - An instance of a AWS SDK v3 service to wrap.
-   * @param {Segment=} segment - Optional segment for manual mode.
+   * @param {Segment|Subsegment} segment - Optional segment for manual mode.
    * @memberof AWSXRay
    * @function
    * @see module:aws3_p.captureAWSClient

--- a/packages/core/lib/patchers/aws3_p.d.ts
+++ b/packages/core/lib/patchers/aws3_p.d.ts
@@ -1,0 +1,8 @@
+import type { MetadataBearer, Client } from '@aws-sdk/types';
+import type { RegionInputConfig } from '@aws-sdk/config-resolver';
+import { SegmentLike } from '../aws-xray';
+declare type DefaultConfiguration = RegionInputConfig & {
+    signingName: string;
+};
+export declare function captureAWSClient<Input extends object, Output extends MetadataBearer, Configuration extends DefaultConfiguration>(client: Client<Input, Output, Configuration>, manualSegment?: SegmentLike): Client<Input, Output, Configuration>;
+export {};

--- a/packages/core/lib/patchers/aws3_p.js
+++ b/packages/core/lib/patchers/aws3_p.js
@@ -1,0 +1,112 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.captureAWSClient = void 0;
+const service_error_classification_1 = require("@aws-sdk/service-error-classification");
+const aws_1 = __importDefault(require("../segments/attributes/aws"));
+const querystring_1 = require("querystring");
+const subsegment_1 = __importDefault(require("../segments/attributes/subsegment"));
+var contextUtils = require('../context_utils');
+var logger = require('../logger');
+const utils_1 = require("../utils");
+async function buildAttributesFromMetadata(client, command, metadata) {
+    const { extendedRequestId, requestId, httpStatusCode: statusCode, attempts } = metadata;
+    const serviceIdentifier = client.config.signingName;
+    let operation = command.constructor.name.slice(0, -7);
+    const aws = new aws_1.default({
+        extendedRequestId,
+        requestId,
+        retryCount: attempts,
+        request: {
+            operation,
+            httpRequest: {
+                region: await client.config.region(),
+                statusCode,
+            },
+            params: command.input,
+        },
+    }, serviceIdentifier);
+    const http = { response: { status: statusCode || 0 } };
+    return [aws, http];
+}
+function addFlags(http, subsegment, err) {
+    var _a;
+    if (err && service_error_classification_1.isThrottlingError(err)) {
+        subsegment.addThrottleFlag();
+    }
+    else if (((_a = http.response) === null || _a === void 0 ? void 0 : _a.status) === 429) {
+        subsegment.addThrottleFlag();
+    }
+    const cause = utils_1.getCauseTypeFromHttpStatus(http.response.status);
+    if (cause === 'fault') {
+        subsegment.addFaultFlag();
+    }
+    else if (cause === 'error') {
+        subsegment.addErrorFlag();
+    }
+}
+function captureAWSClient(client, manualSegment) {
+    // create local copy so that we can later call it
+    const send = client.send;
+    const serviceIdentifier = client.config.signingName;
+    client.send = async (...args) => {
+        const [command] = args;
+        const segment = manualSegment || contextUtils.resolveSegment();
+        let operation = command.constructor.name.slice(0, -7);
+        if (!segment) {
+            const output = serviceIdentifier + '.' + operation;
+            if (!contextUtils.isAutomaticMode()) {
+                logger.getLogger().info('Call ' + output + ' requires a segment object' +
+                    ' on the request params as "XRaySegment" for tracing in manual mode. Ignoring.');
+            }
+            else {
+                logger.getLogger().info('Call ' + output +
+                    ' is missing the sub/segment context for automatic mode. Ignoring.');
+            }
+            return send.apply(client, args);
+        }
+        const subsegment = segment.addNewSubsegment(serviceIdentifier);
+        subsegment.addAttribute('namespace', 'aws');
+        try {
+            const res = (await send.apply(client, [command]));
+            if (!res)
+                throw new Error('Failed to get response from instrumented AWS Client.');
+            const [aws, http] = await buildAttributesFromMetadata(client, command, res.$metadata);
+            subsegment.addAttribute('aws', aws);
+            subsegment.addAttribute('http', http);
+            addFlags(http, subsegment);
+            subsegment.close();
+            return res;
+        }
+        catch (err) {
+            const stack = new Error().stack;
+            const [aws, http] = await buildAttributesFromMetadata(client, command, err.$metadata);
+            subsegment.addAttribute('aws', aws);
+            subsegment.addAttribute('http', http);
+            const errObj = { message: err.message, name: err.name, stack };
+            addFlags(http, subsegment, err);
+            subsegment.close(errObj, true);
+            throw err;
+        }
+    };
+    client.middlewareStack.add((next) => async (args) => {
+        const segment = manualSegment || contextUtils.resolveSegment();
+        if (!segment)
+            return next(args);
+        const parent = (segment instanceof subsegment_1.default
+            ? segment.segment
+            : segment);
+        args.request.headers['X-Amzn-Trace-Id'] = querystring_1.stringify({
+            Root: parent.trace_id,
+            Parent: segment.id,
+            Sampled: parent.notTraced ? '0' : '1',
+        }, ';');
+        return next(args);
+    }, {
+        step: 'build',
+    });
+    return client;
+}
+exports.captureAWSClient = captureAWSClient;

--- a/packages/core/lib/patchers/aws3_p.ts
+++ b/packages/core/lib/patchers/aws3_p.ts
@@ -30,7 +30,7 @@ async function buildAttributesFromMetadata(
   metadata: ResponseMetadata,
 ): Promise<[ServiceSegment, HttpResponse]> {
   const { extendedRequestId, requestId, httpStatusCode: statusCode, attempts } = metadata;
-  const serviceIdentifier = client.config.signingName as string;
+  const serviceIdentifier = client.config.serviceId as string;
 
   let operation: string = command.constructor.name.slice(0, -7);
 
@@ -71,7 +71,7 @@ function addFlags(http: HttpResponse, subsegment: Subsegment, err?: SdkError): v
 }
 
 type DefaultConfiguration = RegionInputConfig & {
-  signingName: string;
+  serviceId: string;
 };
 
 export function captureAWSClient<
@@ -82,7 +82,7 @@ export function captureAWSClient<
   // create local copy so that we can later call it
   const send = client.send;
 
-  const serviceIdentifier = client.config.signingName;
+  const serviceIdentifier = client.config.serviceId;
 
   client.send = async (...args: Parameters<typeof client.send>): Promise<Output> => {
     const [command] = args;

--- a/packages/core/lib/patchers/aws3_p.ts
+++ b/packages/core/lib/patchers/aws3_p.ts
@@ -1,0 +1,173 @@
+import type {
+  MetadataBearer,
+  ResponseMetadata,
+  Command,
+  Client,
+} from '@aws-sdk/types';
+
+import type { RegionInputConfig } from '@aws-sdk/config-resolver';
+
+import { isThrottlingError } from '@aws-sdk/service-error-classification';
+
+import ServiceSegment from '../segments/attributes/aws';
+
+import { stringify } from 'querystring';
+
+import Subsegment from '../segments/attributes/subsegment';
+
+var contextUtils = require('../context_utils');
+
+var logger = require('../logger');
+
+import { getCauseTypeFromHttpStatus } from '../utils';
+import { SdkError } from '@aws-sdk/smithy-client';
+import { SegmentLike } from '../aws-xray';
+
+type HttpResponse = { response: { status: number } };
+
+async function buildAttributesFromMetadata(
+  client: any,
+  command: any,
+  metadata: ResponseMetadata,
+): Promise<[ServiceSegment, HttpResponse]> {
+  const { extendedRequestId, requestId, httpStatusCode: statusCode, attempts } = metadata;
+  const serviceIdentifier = client.config.signingName as string;
+
+  let operation: string = command.constructor.name.slice(0, -7);
+
+  const aws = new ServiceSegment(
+    {
+      extendedRequestId,
+      requestId,
+      retryCount: attempts,
+      request: {
+        operation,
+        httpRequest: {
+          region: await client.config.region(),
+          statusCode,
+        },
+        params: command.input,
+      },
+    },
+    serviceIdentifier,
+  );
+
+  const http = { response: { status: statusCode || 0 } };
+  return [aws, http];
+}
+
+function addFlags(http: HttpResponse, subsegment: Subsegment, err?: SdkError): void {
+  if (err && isThrottlingError(err)) {
+    subsegment.addThrottleFlag();
+  } else if (http.response?.status === 429) {
+    subsegment.addThrottleFlag();
+  }
+
+  const cause = getCauseTypeFromHttpStatus(http.response.status);
+  if (cause === 'fault') {
+    subsegment.addFaultFlag();
+  } else if (cause === 'error') {
+    subsegment.addErrorFlag();
+  }
+}
+
+type DefaultConfiguration = RegionInputConfig & {
+  signingName: string;
+};
+
+export function captureAWSClient<
+  Input extends object,
+  Output extends MetadataBearer,
+  Configuration extends DefaultConfiguration
+>(client: Client<Input, Output, Configuration>, manualSegment?: SegmentLike): Client<Input, Output, Configuration> {
+  // create local copy so that we can later call it
+  const send = client.send;
+
+  const serviceIdentifier = client.config.signingName;
+
+  client.send = async (...args: Parameters<typeof client.send>): Promise<Output> => {
+    const [command] = args;
+    const segment = manualSegment || contextUtils.resolveSegment();
+
+    let operation: string = command.constructor.name.slice(0, -7);
+
+    if (!segment) {
+      const output = serviceIdentifier + '.' + operation;
+
+      if (!contextUtils.isAutomaticMode()) {
+        logger.getLogger().info('Call ' + output + ' requires a segment object' +
+          ' on the request params as "XRaySegment" for tracing in manual mode. Ignoring.');
+      } else {
+        logger.getLogger().info('Call ' + output +
+          ' is missing the sub/segment context for automatic mode. Ignoring.');
+      }
+      return send.apply(client, args) as Promise<Output>;
+    }
+
+    const subsegment = segment.addNewSubsegment(serviceIdentifier);
+    subsegment.addAttribute('namespace', 'aws');
+
+    try {
+      const res = (await send.apply(client, [command])) as Output;
+
+      if (!res) throw new Error('Failed to get response from instrumented AWS Client.');
+
+      const [aws, http] = await buildAttributesFromMetadata(
+        client,
+        command,
+        res.$metadata,
+      );
+
+      subsegment.addAttribute('aws', aws);
+      subsegment.addAttribute('http', http);
+
+      addFlags(http, subsegment);
+      subsegment.close();
+      return res;
+    } catch (err) {
+      const stack = new Error().stack;
+
+      const [aws, http] = await buildAttributesFromMetadata(
+        client,
+        command,
+        err.$metadata,
+      );
+
+      subsegment.addAttribute('aws', aws);
+      subsegment.addAttribute('http', http);
+
+      const errObj = { message: err.message, name: err.name, stack };
+
+      addFlags(http, subsegment, err);
+
+      subsegment.close(errObj, true);
+      throw err;
+    }
+  };
+
+  client.middlewareStack.add(
+    (next) => async (args: any) => {
+      const segment = manualSegment || contextUtils.resolveSegment();
+      if (!segment) return next(args);
+
+      const parent = (segment instanceof Subsegment
+        ? segment.segment
+        : segment);
+
+      args.request.headers['X-Amzn-Trace-Id'] = stringify(
+        {
+          Root: parent.trace_id,
+          Parent: segment.id,
+          Sampled: parent.notTraced ? '0' : '1',
+        },
+        ';',
+      );
+      return next(args);
+    },
+    {
+      step: 'build',
+    },
+  );
+
+  return client;
+}

--- a/packages/core/lib/segments/attributes/subsegment.d.ts
+++ b/packages/core/lib/segments/attributes/subsegment.d.ts
@@ -1,4 +1,5 @@
 import * as http from 'http';
+import { Segment, SegmentLike } from '../../aws-xray';
 
 declare class Subsegment {
   id: string;
@@ -6,6 +7,8 @@ declare class Subsegment {
   start_time: number;
   in_progress?: boolean;
   subsegments?: Array<Subsegment>;
+  parent: SegmentLike;
+  segment: Segment;
 
   constructor(name: string);
 

--- a/packages/core/lib/segments/segment.d.ts
+++ b/packages/core/lib/segments/segment.d.ts
@@ -11,6 +11,7 @@ declare class Segment {
   parent_id?: string;
   origin?: string;
   subsegments?: Array<Subsegment>;
+  notTraced?: boolean;
 
   constructor(name: string, rootId?: string | null, parentId?: string | null);
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,8 @@
   "author": "Amazon Web Services",
   "contributors": [
     "Sandra McMullen <mcmuls@amazon.com>",
-    "William Armiros <armiros@amazon.com>"
+    "William Armiros <armiros@amazon.com>",
+    "Moritz Onken <onken@netcubed.de>"
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -17,6 +18,7 @@
   },
   "//": "@types/cls-hooked is exposed in API so must be in dependencies, not devDependencies",
   "dependencies": {
+    "@aws-sdk/service-error-classification": "^3.4.1",
     "@types/cls-hooked": "^4.2.2",
     "atomic-batcher": "^1.0.2",
     "cls-hooked": "^4.2.2",

--- a/packages/core/test/unit/patchers/aws3_p.test.js
+++ b/packages/core/test/unit/patchers/aws3_p.test.js
@@ -1,0 +1,212 @@
+var assert = require('chai').assert;
+var chai = require('chai');
+var sinon = require('sinon');
+var sinonChai = require('sinon-chai');
+
+var Aws = require('../../../lib/segments/attributes/aws');
+var awsPatcher = require('../../../lib/patchers/aws3_p');
+var contextUtils = require('../../../lib/context_utils');
+var Segment = require('../../../lib/segments/segment');
+var Utils = require('../../../lib/utils');
+
+var { constructStack } = require('@aws-sdk/middleware-stack');
+
+var logger = require('../../../lib/logger').getLogger();
+
+chai.should();
+chai.use(sinonChai);
+
+var traceId = '1-57fbe041-2c7ad569f5d6ff149137be86';
+
+describe('AWS v3 patcher', function() {
+  describe('#captureAWSClient', function() {
+    var customStub, sandbox, addMiddleware;
+
+    var awsClient = {
+      send: function() {},
+      config: {
+        signingName: 's3',
+      },
+      middlewareStack: constructStack(),
+    };
+
+    beforeEach(function() {
+      sandbox = sinon.createSandbox();
+      customStub = sandbox.stub(awsClient, 'send');
+      addMiddleware = sandbox.stub(awsClient.middlewareStack, 'add');
+    });
+
+    afterEach(function() {
+      sandbox.restore();
+    });
+
+    it('should call middlewareStack.add and return the service', function() {
+      var patched = awsPatcher.captureAWSClient(awsClient);
+      addMiddleware.should.have.been.calledOnce;
+      assert.equal(patched, awsClient);
+    });
+  });
+
+  describe('#captureAWSRequest', function() {
+    var awsClient, awsRequest, sandbox, segment, stubResolve, stubResolveManual, sub;
+
+    before(function() {
+      awsClient = {
+        send: async (req) => {
+          const handler = awsClient.middlewareStack.resolve((args) => args);
+          await handler(req);
+          const error = req.response.error;
+          if (error) {
+            const err = new Error(error.message);
+            err.name = error.code;
+            err.$metadata = req.response.$metadata;
+            throw err;
+          }
+          return req.response;
+        },
+        config: {
+          signingName: 's3',
+          region: async () => 'us-east-1',
+        },
+        middlewareStack: constructStack(),
+      };
+      awsClient = awsPatcher.captureAWSClient(awsClient);
+    });
+
+    beforeEach(function() {
+      sandbox = sinon.createSandbox();
+
+      awsRequest = new (class ListBucketsCommand {
+        constructor() {
+          this.request = {
+            method: 'GET',
+            url: '/',
+            connection: {
+              remoteAddress: 'localhost'
+            },
+            headers: {}
+          };
+          this.response = {
+            $metadata: {}
+          };
+        }
+      })();
+
+      segment = new Segment('testSegment', traceId);
+      sub = segment.addNewSubsegment('subseg');
+
+      stubResolveManual = sandbox.stub(contextUtils, 'resolveManualSegmentParams');
+      stubResolve = sandbox.stub(contextUtils, 'resolveSegment').returns(segment);
+      sandbox.stub(segment, 'addNewSubsegment').returns(sub);
+    });
+
+    afterEach(function() {
+      sandbox.restore();
+    });
+
+    it.skip('should call to resolve any manual params', function() {
+      awsClient.send(awsRequest);
+
+      stubResolveManual.should.have.been.calledWith(awsRequest.params);
+    });
+
+    it('should log an info statement and exit if parent is not found on the context or on the call params', function(done) {
+      stubResolve.returns();
+      var logStub = sandbox.stub(logger, 'info');
+
+      awsClient.send(awsRequest);
+
+      setTimeout(function() {
+        logStub.should.have.been.calledOnce;
+        done();
+      }, 50);
+    });
+
+    it('should inject the tracing headers', async function() {
+      sandbox.stub(contextUtils, 'isAutomaticMode').returns(true);
+
+      awsClient.middlewareStack.add((next) => (args) => {
+        stubResolve.returns(sub);
+        next(args);
+        stubResolve.returns(segment);
+      }, { step: 'build', priority: 'high' });
+
+      await awsClient.send(awsRequest);
+
+      var expected = new RegExp('^Root=' + traceId + ';Parent=' + sub.id + ';Sampled=1$');
+      assert.match(awsRequest.request.headers['X-Amzn-Trace-Id'], expected);
+    });
+
+    it('should close on complete with no errors when code 200 is seen', async function() {
+      var closeStub = sandbox.stub(sub, 'close').returns();
+      sandbox.stub(contextUtils, 'isAutomaticMode').returns(true);
+      sandbox.stub(sub, 'addAttribute').returns();
+      sandbox.stub(Aws.prototype, 'init').returns();
+
+      awsRequest.response = {
+        $metadata: { httpStatusCode: 200 },
+      };
+
+      await awsClient.send(awsRequest);
+
+      closeStub.should.have.been.calledWithExactly();
+    });
+
+    it('should mark the subsegment as throttled and error if code 429 is seen', async function() {
+      var throttleStub = sandbox.stub(sub, 'addThrottleFlag').returns();
+
+      sandbox.stub(contextUtils, 'isAutomaticMode').returns(true);
+      sandbox.stub(sub, 'addAttribute').returns();
+      sandbox.stub(Aws.prototype, 'init').returns();
+
+      awsRequest.response = {
+        error: { message: 'throttling', code: 'ThrottlingError' },
+        $metadata: { httpStatusCode: 429 },
+      };
+
+      await awsClient.send(awsRequest).catch(() => null);
+
+      throttleStub.should.have.been.calledOnce;
+      assert.isTrue(sub.error);
+    });
+
+    it('should mark the subsegment as throttled and error if code service.throttledError returns true, regardless of status code', async function() {
+      var throttleStub = sandbox.stub(sub, 'addThrottleFlag').returns();
+
+      sandbox.stub(contextUtils, 'isAutomaticMode').returns(true);
+      sandbox.stub(sub, 'addAttribute').returns();
+      sandbox.stub(Aws.prototype, 'init').returns();
+
+      awsRequest.response = {
+        error: { message: 'throttling', code: 'ProvisionedThroughputExceededException' },
+        $metadata: { httpStatusCode: 400 },
+      };
+
+      await awsClient.send(awsRequest).catch(() => null);
+
+      throttleStub.should.have.been.calledOnce;
+      assert.isTrue(sub.error);
+    });
+
+    it('should capture an error on the response and mark exception as remote', async function() {
+      var closeStub = sandbox.stub(sub, 'close').returns();
+      var getCauseStub = sandbox.stub(Utils, 'getCauseTypeFromHttpStatus').returns();
+
+      sandbox.stub(contextUtils, 'isAutomaticMode').returns(true);
+      sandbox.stub(sub, 'addAttribute').returns();
+      sandbox.stub(Aws.prototype, 'init').returns();
+
+      var error = { message: 'big error', code: 'Error' };
+
+      awsRequest.response = {
+        error,
+        $metadata: { httpStatusCode: 500 },
+      };
+
+      await awsClient.send(awsRequest).catch(() => null);
+
+      getCauseStub.should.have.been.calledWithExactly(500);
+      closeStub.should.have.been.calledWithExactly(sinon.match({ message: error.message, name: error.code}), true);
+    });
+  });
+});

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2019",
+    "strict": true,
+    "strictNullChecks": true,
+    "declaration": true,
+    "esModuleInterop": true
+  },
+  "files": ["lib/patchers/aws3_p.ts"]
+}

--- a/packages/express/test-d/index.test-d.ts
+++ b/packages/express/test-d/index.test-d.ts
@@ -1,5 +1,5 @@
 import * as AWSXRay from 'aws-xray-sdk-core';
-import * as express from 'express';
+import express from 'express';
 import { expectType } from 'tsd';
 import * as xrayExpress from '../lib';
 

--- a/packages/express/tsconfig.json
+++ b/packages/express/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true
+  }
+}

--- a/packages/full_sdk/tsconfig.json
+++ b/packages/full_sdk/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true
+  }
+}

--- a/packages/mysql/tsconfig.json
+++ b/packages/mysql/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true
+  }
+}

--- a/packages/postgres/tsconfig.json
+++ b/packages/postgres/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true
+  }
+}

--- a/packages/restify/tsconfig.json
+++ b/packages/restify/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
#294

* add support for AWS SDK v3

I used typescript for the actual patcher because it makes the code safer and I wanted to make sure that types are maintained when using the XRay patcher. I included the complied JavaScript code as well so that tests can be run without adding more typescript flavor to the project.
There is no `captureAWS` for now and I also haven't looked at manual mode much because I'm unsure about how to pass in the xray params in a type-safe way.

Obviously the aws-sdk-v3 is not GA yet so this just serves as a placeholder and to get some additional eyes on the code.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
