### PR TITLE
Add callback to allow custom subsegment interaction when captureHTTPs is used

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -460,6 +460,28 @@ This creates 5 nested subsegments on the root segment and captures timing data i
     // those used by third party modules, will now be traced
     var http = require('http');
 
+### Capture all outgoing HTTP and HTTPS requests, adding custom subsegment information
+
+    const callback = (subsegment, req, res, err) => {
+      subsegment.addMetadata('accept', req.getHeader('accept'));
+
+      if (err && err.code) {
+        subsegment.addAnnotation('errorCode', err.code);
+      }
+
+      if (res) {
+        subsegment.addMetadata('content-type', res.getHeader('content-type'));
+      }
+    };
+    AWSXRay.captureHTTPsGlobal(require('http'), null, callback);
+    AWSXRay.captureHTTPsGlobal(require('https'), null, callback);
+
+    // Requests with this http client, and any other http/https client including
+    // those used by third party modules, will now be traced
+    // Additional metadata / annotations can be added in the callback based on 
+    // the request, response and any error
+    var http = require('http');
+
 ### Capture outgoing HTTP/S requests with a traced client
 
     //returns a copy of the http module that is patched, can patch https as well

--- a/packages/core/lib/patchers/http_p.d.ts
+++ b/packages/core/lib/patchers/http_p.d.ts
@@ -1,6 +1,9 @@
 import * as http from 'http';
 import * as https from 'https';
+import { Subsegment } from '../aws-xray';
 
-export function captureHTTPs<T extends typeof http | typeof https>(mod: T, downstreamXRayEnabled: boolean): T;
+type httpSubsegmentCallback = (subsegment: Subsegment, req: http.ClientRequest, res: http.IncomingMessage | null, error: Error) => void
 
-export function captureHTTPsGlobal(mod: typeof https | typeof http, downstreamXRayEnabled: boolean): void;
+export function captureHTTPs<T extends typeof http | typeof https>(mod: T, downstreamXRayEnabled: boolean, subsegmentCallback?: httpSubsegmentCallback): T;
+
+export function captureHTTPsGlobal(mod: typeof https | typeof http, downstreamXRayEnabled: boolean, subsegmentCallback?: httpSubsegmentCallback): void;

--- a/packages/core/test-d/index.test-d.ts
+++ b/packages/core/test-d/index.test-d.ts
@@ -64,11 +64,19 @@ function callback(param0: any, param1: any) {
 tracedFcn(AWSXRay.captureCallbackFunc('callback', callback));
 tracedFcn(AWSXRay.captureCallbackFunc('callback', callback, segment));
 
+function httpSubsegmentCallback(subsegment: AWSXRay.Subsegment, req: http.ClientRequest, res: http.IncomingMessage | null, error: Error) {
+  console.log({ subsegment, req, res, error })
+}
+
 expectType<typeof http>(AWSXRay.captureHTTPs(http, true));
 expectType<typeof https>(AWSXRay.captureHTTPs(https, true));
+expectType<typeof http>(AWSXRay.captureHTTPs(http, true, httpSubsegmentCallback));
+expectType<typeof https>(AWSXRay.captureHTTPs(https, true, httpSubsegmentCallback));
 
 expectType<void>(AWSXRay.captureHTTPsGlobal(http, true));
 expectType<void>(AWSXRay.captureHTTPsGlobal(https, true));
+expectType<void>(AWSXRay.captureHTTPsGlobal(http, true, httpSubsegmentCallback));
+expectType<void>(AWSXRay.captureHTTPsGlobal(https, true, httpSubsegmentCallback));
 
 expectType<void>(AWSXRay.capturePromise());
 expectType<void>(AWSXRay.capturePromise.patchThirdPartyPromise(Promise));


### PR DESCRIPTION
*Issue #162*

*Description of changes:*

* Add a callback to `captureHTTPs` and `captureHTTPsGlobal` that allows users to add metadata / annotations etc. to the subsegment based on the request, response and any error emitted.
* This seems like the most flexible way to allow additional information to be added to the subsegment.
* This feature is particularly useful when interacting with systems that are not integrated with XRay (e.g. want to record cache hit / miss headers, possibly on a per-host basis). Headers of this kind vary on a per-host basis which is why `req` is a parameter to the callback.

*Comments:*

* `captureHTTPs()` and `captureHTTPsGlobal()` appear to have an undocumented second parameter (at least it's not in the docs I've read) which makes the API for this new feature slightly less appealing.
* Having a single callback for the success and error case might be a little unwieldy. Would it be better to have two callbacks for the two cases or even to have some kind of event listener/emitter pattern?
* How defensive do we need to be about errors being thrown in the callback? Do we want to swallow/handle them? Or is it OK to let them propagate?
* The testing coverage is a little off — I've not covered the case where an error is emitted and the callback isn't provided just because that was a more intrusive change to the existing tests.
* Is there any more documentation that I should be updating.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
