### PR TITLE
Move common code into middleware utils to make creation of new middleware simpler

### DIFF
--- a/packages/core/lib/middleware/mw_utils.d.ts
+++ b/packages/core/lib/middleware/mw_utils.d.ts
@@ -24,6 +24,10 @@ export function setDefaultName(name: string): void;
 
 export function disableCentralizedSampling(): void;
 
+export function middlewareLog(message: string, url: string, segment: Segment): void;
+
+export function traceRequestResponseCycle(req: http.IncomingMessage, res: http.ServerResponse): Segment;
+
 export interface BaseRuleConfig {
   http_method: string;
   url_path: string;

--- a/packages/core/lib/middleware/mw_utils.js
+++ b/packages/core/lib/middleware/mw_utils.js
@@ -171,6 +171,8 @@ var utils = {
 
     segment.addIncomingRequestData(new IncomingRequestData(req));
 
+    this.middlewareLog('Starting middleware segment', req.url, segment);
+
     var middlewareLog = this.middlewareLog;
     var didEnd = false;
     var endSegment = function () {

--- a/packages/core/test-d/index.test-d.ts
+++ b/packages/core/test-d/index.test-d.ts
@@ -5,6 +5,7 @@ import { Socket } from 'net';
 import { expectType, expectError } from 'tsd';
 import * as url from 'url';
 import * as AWSXRay from '../lib';
+import { Segment } from '../lib';
 
 expectType<void>(AWSXRay.plugins.EC2Plugin.getData((metadata?: AWSXRay.plugins.EC2Metadata) => { }));
 expectType<void>(AWSXRay.plugins.ECSPlugin.getData((metadata?: AWSXRay.plugins.ECSMetadata) => { }));
@@ -135,6 +136,7 @@ const rulesConfig: AWSXRay.middleware.RulesConfig = {
   }
 };
 expectType<void>(AWSXRay.middleware.setSamplingRules(rulesConfig));
+expectType<void>(AWSXRay.middleware.middlewareLog('log-message', 'https://example.org', segment));
 
 expectType<Namespace>(AWSXRay.getNamespace());
 expectType<AWSXRay.Segment | AWSXRay.Subsegment | undefined>(AWSXRay.resolveSegment(segment));
@@ -163,7 +165,9 @@ expectType<void>(segment.setMatchedSamplingRule('rule'));
 expectType<void>(segment.setServiceData({ version: '2.3.0', package: 'sample-app' }));
 expectType<void>(segment.addPluginData({ elastic_beanstalk: { environment: 'my_environment_name' } }));
 const incomingMessage = new http.IncomingMessage(new Socket());
+const serverResponse = new http.ServerResponse(incomingMessage);
 expectType<void>(segment.addIncomingRequestData(new AWSXRay.middleware.IncomingRequestData(incomingMessage)));
+expectType<Segment>(AWSXRay.middleware.traceRequestResponseCycle(incomingMessage, serverResponse))
 
 function testSegmentLike(segmentLike: AWSXRay.Segment | AWSXRay.Subsegment) {
   expectType<void>(segmentLike.addAnnotation('key', true));

--- a/packages/express/lib/express_mw.js
+++ b/packages/express/lib/express_mw.js
@@ -12,8 +12,6 @@
 var AWSXRay = require('aws-xray-sdk-core');
 
 var mwUtils = AWSXRay.middleware;
-var IncomingRequestData = mwUtils.IncomingRequestData;
-var Segment = AWSXRay.Segment;
 
 var expressMW = {
 
@@ -32,40 +30,11 @@ var expressMW = {
 
     mwUtils.setDefaultName(defaultName);
 
-    return function open(req, res, next) {
-      var amznTraceHeader = mwUtils.processHeaders(req);
-      var name = mwUtils.resolveName(req.headers.host);
-      var segment = new Segment(name, amznTraceHeader.root, amznTraceHeader.parent);
-
-      mwUtils.resolveSampling(amznTraceHeader, segment, res);
-      segment.addIncomingRequestData(new IncomingRequestData(req));
+    return function (req, res, next) {
+      var segment = mwUtils.traceRequestResponseCycle(req, res);
 
       AWSXRay.getLogger().debug('Starting express segment: { url: ' + req.url + ', name: ' + segment.name + ', trace_id: ' +
         segment.trace_id + ', id: ' + segment.id + ', sampled: ' + !segment.notTraced + ' }');
-
-      var didEnd = false;
-      var endSegment = function () {
-        // ensure `endSegment` is only called once
-        // in some versions of node.js 10.x and in all versions of node.js 11.x and higher,
-        // the 'finish' and 'close' event are BOTH triggered.
-        // Previously, only one or the other was triggered:
-        // https://github.com/nodejs/node/pull/20611
-        if (didEnd) return;
-        didEnd = true;
-        if (this.statusCode === 429)
-          segment.addThrottleFlag();
-        if (AWSXRay.utils.getCauseTypeFromHttpStatus(this.statusCode))
-          segment[AWSXRay.utils.getCauseTypeFromHttpStatus(this.statusCode)] = true;
-
-        segment.http.close(this);
-        segment.close();
-
-        AWSXRay.getLogger().debug('Closed express segment successfully: { url: ' + req.url + ', name: ' + segment.name + ', trace_id: ' +
-          segment.trace_id + ', id: ' + segment.id + ', sampled: ' + !segment.notTraced + ' }');
-      };
-
-      res.on('finish', endSegment);
-      res.on('close', endSegment);
 
       if (AWSXRay.isAutomaticMode()) {
         var ns = AWSXRay.getNamespace();

--- a/packages/express/lib/express_mw.js
+++ b/packages/express/lib/express_mw.js
@@ -33,9 +33,6 @@ var expressMW = {
     return function (req, res, next) {
       var segment = mwUtils.traceRequestResponseCycle(req, res);
 
-      AWSXRay.getLogger().debug('Starting express segment: { url: ' + req.url + ', name: ' + segment.name + ', trace_id: ' +
-        segment.trace_id + ', id: ' + segment.id + ', sampled: ' + !segment.notTraced + ' }');
-
       if (AWSXRay.isAutomaticMode()) {
         var ns = AWSXRay.getNamespace();
         ns.bindEmitter(req);
@@ -66,14 +63,12 @@ var expressMW = {
       if (segment && err) {
         segment.close(err);
 
-        AWSXRay.getLogger().debug('Closed express segment with error: { url: ' + req.url + ', name: ' + segment.name + ', trace_id: ' +
-          segment.trace_id + ', id: ' + segment.id + ', sampled: ' + !segment.notTraced + ' }');
+        mwUtils.middlewareLog('Closed express segment with error', req.url, segment);
 
       } else if (segment) {
         segment.close();
 
-        AWSXRay.getLogger().debug('Closed express segment successfully: { url: ' + req.url + ', name: ' + segment.name + ', trace_id: ' +
-          segment.trace_id + ', id: ' + segment.id + ', sampled: ' + !segment.notTraced + ' }');
+        mwUtils.middlewareLog('Closed express segment successfully', req.url, segment);
       }
 
       if (next)

--- a/packages/restify/lib/restify_mw.js
+++ b/packages/restify/lib/restify_mw.js
@@ -68,7 +68,7 @@ var restifyMW = {
 
     server.on('after', function handledError(req, res, route, err) {
       if (segment && err) {
-        segment.close(err);
+        segment.addError(err);
       }
     });
   }

--- a/packages/restify/test/unit/restify_mw.test.js
+++ b/packages/restify/test/unit/restify_mw.test.js
@@ -19,7 +19,7 @@ chai.use(sinonChai);
 
 var utils = require('../test_utils');
 
-describe('Express middleware', function() {
+describe('Restify middleware', function() {
   var sandbox, server;
   var defaultName = 'defaultName';
   var hostName = 'expressMiddlewareTest';
@@ -152,8 +152,13 @@ describe('Express middleware', function() {
       it('should add a finish event to the response', function() {
         server.open(req, res);
 
-        onEventStub.should.have.been.calledOnce;
         onEventStub.should.have.been.calledWithExactly('finish', sinon.match.typeOf('function'));
+      });
+
+      it('should add a close event to the response', function() {
+        server.open(req, res);
+
+        onEventStub.should.have.been.calledWithExactly('close', sinon.match.typeOf('function'));
       });
 
       describe('in automatic mode', function() {
@@ -185,8 +190,13 @@ describe('Express middleware', function() {
       it('should add a finish event to the response', function() {
         server.open(req, res);
 
-        onEventStub.should.have.been.calledOnce;
         onEventStub.should.have.been.calledWithExactly('finish', sinon.match.typeOf('function'));
+      });
+
+      it('should add a close event to the response', function() {
+        server.open(req, res);
+
+        onEventStub.should.have.been.calledWithExactly('close', sinon.match.typeOf('function'));
       });
     });
 


### PR DESCRIPTION
*Description of changes:*

- One of the pain points of using XRay at the moment is the creation of middleware (see various issues)
- This PR introduces a `traceRequestResponseCycle()` function that will:
  - Grab the trace header from the request and resolve any sampling rules.
  - Create the segment
  - Add core request / response data to the segment
  - Add throttling / error / fault flags based on the response status code
  - Return the segment for further processing by the client
- All of this code is cribbed directly from the express middleware.
- I've Updated the express and restify middleware packages to use this function (required a tiny update to the restify tests)

If this idea is deemed appropriate then I'll add specific tests for the new function and some examples in the documentation — currently it relies on the express / restify tests to check that it's working correctly.

This should make it much easier for users to create their own middleware code for various frameworks and not have to mess around with the low-level middleware utils functions (which might be able to be deprecated in favour of this one).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
