### PR TITLE
replaced error listeners with errorMonitor

### DIFF
--- a/packages/core/lib/patchers/http_p.js
+++ b/packages/core/lib/patchers/http_p.js
@@ -161,12 +161,16 @@ function enableCapture(module, downstreamXRayEnabled, subsegmentCallback) {
 
         var cause = Utils.getCauseTypeFromHttpStatus(res.statusCode);
 
+        console.log('closing!!');
+
         if (cause)
           subsegment[cause] = true;
 
         subsegment.addRemoteRequestData(res.req, res, !!downstreamXRayEnabled);
         subsegment.close();
       });
+
+      // console.log(res.req.listenerCount('response'));
 
       if (typeof callback === 'function') {
         if (contextUtils.isAutomaticMode()) {
@@ -179,10 +183,11 @@ function enableCapture(module, downstreamXRayEnabled, subsegmentCallback) {
         } else {
           callback(res);
         }
-        // if no callback provided by user application, then we consume the response
-        // so the 'end' event fires
+        // if no callback provided by user application, AND no explicit response listener
+        // added by user application, then we consume the response so the 'end' event fires
         // See: https://nodejs.org/api/http.html#http_class_http_clientrequest
-      } else {
+      } else if (res.req && res.req.listenerCount('response') === 0) {
+        console.log('resuming!');
         res.resume();
       }
     });

--- a/packages/core/lib/patchers/http_p.js
+++ b/packages/core/lib/patchers/http_p.js
@@ -142,7 +142,7 @@ function enableCapture(module, downstreamXRayEnabled, subsegmentCallback) {
       // Only need to remove our listener & re-emit if we're not listening using the errorMonitor,
       // e.g. the app is running on Node 10. Otherwise the errorMonitor will re-emit automatically.
       // See: https://github.com/aws/aws-xray-sdk-node/issues/318
-      // TODO: Remove this logic when the 'error' listener is removed once node 10 support is deprecated
+      // TODO: Remove this logic once node 12 support is deprecated
       if (!events.errorMonitor && this.listenerCount('error') <= 1) {
         this.removeListener('error', errorCapturer);
         this.emit('error', e);
@@ -179,14 +179,15 @@ function enableCapture(module, downstreamXRayEnabled, subsegmentCallback) {
         } else {
           callback(res);
         }
-        // if no callback provided and there is only SDK added response listener,
-        // we consume the response so the actual end can fire.
-      } else if (res && res.listenerCount('end') === 1) {
+        // if no callback provided by user application, then we consume the response
+        // so the 'end' event fires
+        // See: https://nodejs.org/api/http.html#http_class_http_clientrequest
+      } else {
         res.resume();
       }
     });
 
-    // Use errorMonitor if available (in Node 12+), otherwise fall back to standard error listener
+    // Use errorMonitor if available (in Node 12.17+), otherwise fall back to standard error listener
     // See: https://nodejs.org/dist/latest-v12.x/docs/api/events.html#events_eventemitter_errormonitor
     req.on(events.errorMonitor || 'error', errorCapturer);
 

--- a/packages/core/lib/patchers/http_p.js
+++ b/packages/core/lib/patchers/http_p.js
@@ -161,16 +161,12 @@ function enableCapture(module, downstreamXRayEnabled, subsegmentCallback) {
 
         var cause = Utils.getCauseTypeFromHttpStatus(res.statusCode);
 
-        console.log('closing!!');
-
         if (cause)
           subsegment[cause] = true;
 
         subsegment.addRemoteRequestData(res.req, res, !!downstreamXRayEnabled);
         subsegment.close();
       });
-
-      // console.log(res.req.listenerCount('response'));
 
       if (typeof callback === 'function') {
         if (contextUtils.isAutomaticMode()) {
@@ -187,7 +183,6 @@ function enableCapture(module, downstreamXRayEnabled, subsegmentCallback) {
         // added by user application, then we consume the response so the 'end' event fires
         // See: https://nodejs.org/api/http.html#http_class_http_clientrequest
       } else if (res.req && res.req.listenerCount('response') === 0) {
-        console.log('resuming!');
         res.resume();
       }
     });

--- a/packages/core/test/unit/patchers/http_p.test.js
+++ b/packages/core/test/unit/patchers/http_p.test.js
@@ -137,6 +137,7 @@ describe('HTTP/S', function() {
 
         fakeRequest = buildFakeRequest();
         fakeResponse = buildFakeResponse();
+        fakeResponse.req = fakeRequest;
 
         httpClient = { request: function(...args) {
           const callback = args[typeof args[1] === 'object' ? 2 : 1];
@@ -168,6 +169,12 @@ describe('HTTP/S', function() {
 
       it('should not consume the response if a callback is provided by user', function() {
         capturedHttp.request(httpOptions, () => {});
+        resumeSpy.should.not.have.been.called;
+      });
+
+      it('should not consume the response if a response listener is provided by user', function() {
+        fakeRequest.on('response', () => {});
+        capturedHttp.request(httpOptions);
         resumeSpy.should.not.have.been.called;
       });
 

--- a/packages/postgres/lib/postgres_p.js
+++ b/packages/postgres/lib/postgres_p.js
@@ -3,6 +3,7 @@
  */
 
 var AWSXRay = require('aws-xray-sdk-core');
+var events = require('events');
 var SqlData = AWSXRay.database.SqlData;
 
 var DATABASE_VERS = process.env.POSTGRES_DATABASE_VERSION;
@@ -106,13 +107,14 @@ function captureQuery() {
       var errorCapturer = function (err) {
         subsegment.close(err);
 
-        if (this._events && this._events.error && this._events.error.length === 1) {
+        // TODO: Remove this logic once Node 10 is deprecated
+        if (!events.errorMonitor && this.listenerCount('error') <= 1) {
           this.removeListener('error', errorCapturer);
           this.emit('error', err);
         }
       };
 
-      query.on('error', errorCapturer);
+      query.on(events.errorMonitor || 'error', errorCapturer);
     }
 
     subsegment.addSqlData(createSqlData(this.connectionParameters, query));


### PR DESCRIPTION
*Issue #, if available:*
#318, #18 

*Description of changes:*
Changed our `errorCapturer` to listen on the `errorMonitor` event instead of the `error` event. As pointed out in related issue, the old way could be unreliably re-emitting errors to customer code. Since `errorMonitor` was only introduced in Node 12, we will have to fall back to the old way of error capturing in Node 10 until it is deprecated.

Also added a unit test and tested on my sample app to verify behavior.

*EDIT*
Also added other fix described in comment below.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
