### PR TITLE
Handle requests without agent to fallback to request.protocol

### DIFF
--- a/packages/core/lib/segments/attributes/remote_request_data.js
+++ b/packages/core/lib/segments/attributes/remote_request_data.js
@@ -13,8 +13,11 @@ function RemoteRequestData(req, res, downstreamXRayEnabled) {
 }
 
 RemoteRequestData.prototype.init = function init(req, res, downstreamXRayEnabled) {
+  // Not all requests have "agent"
+  const protocol = req.agent ? req.agent.protocol: req.protocol + ':'
+  
   this.request = {
-    url: (req.agent && req.agent.protocol) ? (req.agent.protocol + '//' + req.getHeader('host') +  stripQueryStringFromPath(req.path)) : '',
+    url: protocol + '//' + req.getHeader('host') +  stripQueryStringFromPath(req.path),
     method: req.method || '',
   };
 

--- a/packages/core/test/unit/segments/attributes/remote_request_data.test.js
+++ b/packages/core/test/unit/segments/attributes/remote_request_data.test.js
@@ -7,6 +7,7 @@ chai.should();
 
 describe('RemoteRequestData', function() {
   const defaultRequest = {
+    protocol: 'https',
     agent: {
       protocol: 'https:'
     },
@@ -41,13 +42,16 @@ describe('RemoteRequestData', function() {
         'https://host.com/path/to/resource'
       );
     });
-    it('should return empty url if request agent is missing', function() {
-      const requestWithoutAgent = {};
+    it('should use req.protocol if agent is unavailable', function() {
+      const requestWithoutAgent = Object.assign(request, {
+        protocol: 'ftp'
+      });
+      delete requestWithoutAgent.agent
       
       assert.propertyVal(
         new RemoteRequestData(requestWithoutAgent, response, true).request,
         'url',
-        ''
+        'ftp://host.com/path/to/resource'
       );
     });
   });


### PR DESCRIPTION
*Issue #, if available:*
Relates to https://github.com/aws/aws-xray-sdk-node/issues/312

*Description of changes:*
Hi, I've encountered a crash when a request didn't have an agent on 3.1.0. I see that it's been fixed in 3.2.0, but this PR attempts to fallback to the `request.protocol` instead of returning an empty string if the agent isn't available.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
