### PR TITLE
Promise callback with queryConfig options.

### DIFF
--- a/packages/postgres/lib/postgres_p.js
+++ b/packages/postgres/lib/postgres_p.js
@@ -38,7 +38,7 @@ function resolveArguments(argsObj) {
     if (argsObj[0] instanceof Object) {
       args.sql = argsObj[0].text;
       args.values = argsObj[0].values;
-      args.callback = argsObj[1] || argsObj[0].callback;
+      args.callback = typeof argsObj[1] === 'function' ? argsObj[1] : (typeof argsObj[2] === 'function' ? argsObj[2] :  argsObj[0].callback);
     } else {
       args.sql = argsObj[0];
       args.values = typeof argsObj[1] !== 'function' ? argsObj[1] : null;


### PR DESCRIPTION
Resolves https://github.com/aws/aws-xray-sdk-node/issues/335

When you execute a PG query with an QueryConfig object the implicit promise callback is the 3 element in the args.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
