### PR TITLE
Fix: allow all mysql query options

### DIFF
--- a/packages/mysql/lib/mysql_p.js
+++ b/packages/mysql/lib/mysql_p.js
@@ -141,12 +141,7 @@ function resolveArguments(argsObj) {
 
   if (argsObj && argsObj.length > 0) {
     if (argsObj[0] instanceof Object) {
-      args.sql = argsObj[0].sql;
-
-      if (argsObj[0].timeout) {
-        args.timeout = argsObj[0].timeout;
-      }
-
+      args.sql = argsObj[0];
       args.values = argsObj[0].values;
       args.callback = argsObj[1];
       if (!argsObj[1] && argsObj[0].on instanceof Function) args.sql = argsObj[0];
@@ -203,9 +198,7 @@ function captureOperation(name) {
       }
     }
 
-    const sql = args.timeout ? { sql: args.sql, timeout: args.timeout } : args.sql;
-
-    command = originalOperation.call(this, sql, args.values, args.callback);
+    command = originalOperation.call(this, args.sql, args.values, args.callback);
 
     if (!args.callback) {
       var errorCapturer = function (err) {

--- a/packages/mysql/test/unit/mysql_p.test.js
+++ b/packages/mysql/test/unit/mysql_p.test.js
@@ -115,15 +115,16 @@ describe('captureMySQL', function() {
         }, 50);
       });
 
-      it('should pass timeout to basequery if supplied', function (done) {
+      it('should pass any additional query options if supplied', function (done) {
         var stubClose = sandbox.stub(subsegment, 'close');
         var session = { run: function (fcn) { fcn(); } };
         var stubRun = sandbox.stub(session, 'run');
+        var typeCast = sinon.stub();
 
         sandbox.stub(AWSXRay, 'getNamespace').returns(session);
-        query.call(connectionObj, {sql: 'sql here', timeout: 234}, function () { });
+        query.call(connectionObj, { sql: 'sql here', timeout: 234, typeCast, nestTables: true }, function () { });
 
-        stubBaseQuery.should.have.been.calledWith(sinon.match({ sql: 'sql here', timeout: 234 }), undefined, sinon.match.func);
+        stubBaseQuery.should.have.been.calledWith({ sql: 'sql here', timeout: 234, typeCast, nestTables: true }, undefined, sinon.match.func);
         stubBaseQuery.args[0][2].call(queryObj);
 
         setTimeout(function () {


### PR DESCRIPTION
*Issue #, if available:* 
**N/A** (figured I'd just submit the PR vs. open another issue) 😉 

*Description of changes:*
Updates the `mysql` package to support all query options by passing along the entire object to the original call. This fixes a bug where any additional options provided when calling `query` (e.g. `typeCast`, `nestTables`, etc.) are getting ignored.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
