### PR TITLE
feat:IGNORE_ERROR context missing strategy

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -57,7 +57,7 @@ section for different usages.
     AWS_XRAY_TRACING_NAME            For overriding the default segment name to use
     with the middleware. See 'dynamic and fixed naming modes'.
     AWS_XRAY_DAEMON_ADDRESS          For setting the daemon address and port.
-    AWS_XRAY_CONTEXT_MISSING         For setting the SDK behavior when trace context is missing. Valid values are 'RUNTIME_ERROR' or 'LOG_ERROR'. The SDK's default behavior is 'RUNTIME_ERROR'.
+    AWS_XRAY_CONTEXT_MISSING         For setting the SDK behavior when trace context is missing. Valid values are 'RUNTIME_ERROR', 'IGNORE_ERROR' or 'LOG_ERROR'. The SDK's default behavior is 'RUNTIME_ERROR'.
     AWS_XRAY_LOG_LEVEL               Sets a log level for the SDK built in logger. This value is ignored if AWS_XRAY_DEBUG_MODE is set.
 
 ### Daemon configuration

--- a/packages/core/lib/context_utils.js
+++ b/packages/core/lib/context_utils.js
@@ -26,6 +26,11 @@ var contextUtils = {
         var err = new Error(message);
         logger.getLogger().error(err.stack);
       }
+    },
+    IGNORE_ERROR: {
+      contextMissing: function contextMissingIgnoreError(message) {
+        
+      }
     }
   },
 

--- a/packages/core/test/unit/context_utils.test.js
+++ b/packages/core/test/unit/context_utils.test.js
@@ -9,6 +9,8 @@ var LOG_ERROR = 'LOG_ERROR';
 var LOG_ERROR_FCN_NAME = 'contextMissingLogError';
 var RUNTIME_ERROR = 'RUNTIME_ERROR';
 var RUNTIME_ERROR_FCN_NAME = 'contextMissingRuntimeError';
+var IGNORE_ERROR = 'IGNORE_ERROR';
+var IGNORE_ERROR_FCN_NAME = 'contextMissingIgnoreError';
 
 describe('ContextUtils', function() {
   function reloadContextUtils() {
@@ -146,7 +148,12 @@ describe('ContextUtils', function() {
 
     it('should accept and set the RUNTIME_ERROR strategy', function() {
       ContextUtils.setContextMissingStrategy(RUNTIME_ERROR);
-      assert.notEqual(ContextUtils.contextMissingStrategy.contextMissing, RUNTIME_ERROR_FCN_NAME);
+      assert.equal(ContextUtils.contextMissingStrategy.contextMissing.name, RUNTIME_ERROR_FCN_NAME);
+    });
+
+    it('should accept and set the IGNORE_ERROR strategy', function() {
+      ContextUtils.setContextMissingStrategy(IGNORE_ERROR);
+      assert.equal(ContextUtils.contextMissingStrategy.contextMissing.name, IGNORE_ERROR_FCN_NAME);
     });
 
     it('should accept and set a custom strategy', function() {


### PR DESCRIPTION
Adds a new `IGNORE_ERROR` context missing strategy, this is especially useful when running Lambda code/libraries locally to not pollute logs with many lines of context missing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
