### PR TITLE
types(segment): add end_time to Segment

### DIFF
--- a/packages/core/lib/segments/segment.d.ts
+++ b/packages/core/lib/segments/segment.d.ts
@@ -5,6 +5,7 @@ declare class Segment {
   id: string;
   name: string;
   start_time: number;
+  end_time?: number;
   in_progress?: boolean;
   trace_id: string;
   parent_id?: string;


### PR DESCRIPTION
*Description of changes:*

I use `xray` creating the wrapper manually, and normally have something like:

```ts
const segment = new AWSXRay.Segment(rootName);
const ns = AWSXRay.getNamespace();
await ns.runPromise(async() => {
  segment.addIncomingRequestData(this.createFakeIncomingRequest(rootName));
  AWSXRay.setSegment(segment);
  await func(); // Original function
  segment.close();
  console.log({
    traceId: segment.trace_id,
    elapsed: +(segment as any).end_time - +segment.start_time, // This PR solve the (segment as any) as workaround
  });
```

To prevents the `segment as any` I mapped the `end_time` on Segment class.