### PR TITLE
Update .d.ts files to reflect 'downstreamXRayEnabled' is optional

### DIFF
--- a/packages/core/lib/patchers/http_p.d.ts
+++ b/packages/core/lib/patchers/http_p.d.ts
@@ -4,6 +4,6 @@ import { Subsegment } from '../aws-xray';
 
 type httpSubsegmentCallback = (subsegment: Subsegment, req: http.ClientRequest, res: http.IncomingMessage | null, error: Error) => void
 
-export function captureHTTPs<T extends typeof http | typeof https>(mod: T, downstreamXRayEnabled: boolean, subsegmentCallback?: httpSubsegmentCallback): T;
+export function captureHTTPs<T extends typeof http | typeof https>(mod: T, downstreamXRayEnabled?: boolean, subsegmentCallback?: httpSubsegmentCallback): T;
 
-export function captureHTTPsGlobal(mod: typeof https | typeof http, downstreamXRayEnabled: boolean, subsegmentCallback?: httpSubsegmentCallback): void;
+export function captureHTTPsGlobal(mod: typeof https | typeof http, downstreamXRayEnabled?: boolean, subsegmentCallback?: httpSubsegmentCallback): void;

--- a/packages/core/lib/segments/attributes/subsegment.d.ts
+++ b/packages/core/lib/segments/attributes/subsegment.d.ts
@@ -27,7 +27,7 @@ declare class Subsegment {
 
   addError(err: Error | string, remote?: boolean): void;
 
-  addRemoteRequestData(req: http.ClientRequest, res: http.IncomingMessage, downstreamXRayEnabled: boolean): void;
+  addRemoteRequestData(req: http.ClientRequest, res: http.IncomingMessage, downstreamXRayEnabled?: boolean): void;
 
   addFaultFlag(): void;
 

--- a/packages/core/test-d/index.test-d.ts
+++ b/packages/core/test-d/index.test-d.ts
@@ -69,11 +69,15 @@ function httpSubsegmentCallback(subsegment: AWSXRay.Subsegment, req: http.Client
   console.log({ subsegment, req, res, error })
 }
 
+expectType<typeof http>(AWSXRay.captureHTTPs(http));
+expectType<typeof https>(AWSXRay.captureHTTPs(https));
 expectType<typeof http>(AWSXRay.captureHTTPs(http, true));
 expectType<typeof https>(AWSXRay.captureHTTPs(https, true));
 expectType<typeof http>(AWSXRay.captureHTTPs(http, true, httpSubsegmentCallback));
 expectType<typeof https>(AWSXRay.captureHTTPs(https, true, httpSubsegmentCallback));
 
+expectType<void>(AWSXRay.captureHTTPsGlobal(http));
+expectType<void>(AWSXRay.captureHTTPsGlobal(https));
 expectType<void>(AWSXRay.captureHTTPsGlobal(http, true));
 expectType<void>(AWSXRay.captureHTTPsGlobal(https, true));
 expectType<void>(AWSXRay.captureHTTPsGlobal(http, true, httpSubsegmentCallback));
@@ -207,6 +211,7 @@ expectType<void>(subsegment.addAttribute('name', 'value'));
 expectType<void>(subsegment.addPrecursorId('id'));
 expectType<void>(subsegment.addSqlData({}));
 const clientRequest = new http.ClientRequest('http://localhost');
+expectType<void>(subsegment.addRemoteRequestData(clientRequest, incomingMessage));
 expectType<void>(subsegment.addRemoteRequestData(clientRequest, incomingMessage, true));
 expectType<true | undefined>(subsegment.streamSubsegments());
 expectType<{ [key: string]: any }>(subsegment.toJSON());


### PR DESCRIPTION
*Description of changes:*

The `downstreamXRayEnabled` option is, well, optional according to the JSDoc -- it's actually not even mentioned in the [README.md](https://github.com/aws/aws-xray-sdk-node/tree/master/packages/core#capture-all-outgoing-http-and-https-requests), so updating the types to reflect that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
