### PR TITLE
Update Lambda trace IDs

### DIFF
--- a/packages/core/lib/aws-xray.d.ts
+++ b/packages/core/lib/aws-xray.d.ts
@@ -7,6 +7,7 @@ import * as middleware from './middleware/mw_utils';
 import Segment = require('./segments/segment');
 import Subsegment = require('./segments/attributes/subsegment');
 import sqlData = require('./database/sql_data');
+import TraceID = require('./segments/attributes/trace_id');
 
 export namespace plugins {
   const EC2Plugin: typeof ec2Plugin;
@@ -65,6 +66,7 @@ export {
 export {
   Segment,
   Subsegment,
+  TraceID,
   segmentUtils as SegmentUtils
 }
 

--- a/packages/core/lib/env/aws_lambda.js
+++ b/packages/core/lib/env/aws_lambda.js
@@ -90,18 +90,16 @@ var facadeSegment = function facadeSegment() {
     }
     else {
       this.reset();
-      contextUtils.contextMissingStrategy.contextMissing('Missing AWS Lambda trace data for X-Ray. Expected _X_AMZN_TRACE_ID to be set.');
+      contextUtils.contextMissingStrategy.contextMissing('Missing AWS Lambda trace data for X-Ray. ' +
+          'Ensure Active Tracing is enabled and no subsegments are created outside the function handler.');
     }
   };
 
-  console.log('In init. _X_AMZN_TRACE_ID contains data: ' + xAmznTraceId);
-
-  // Test for valid trace data during SDK startup. It's possible we're outside the handler and don't have access to
+  // Test for valid trace data during SDK startup. It's likely we're still in the cold-start portion of the
+  // code at this point and a valid trace header has not been set
   if (LambdaUtils.validTraceData(xAmznTraceId)) {
     if (LambdaUtils.populateTraceData(segment, xAmznTraceId))
       xAmznTraceIdPrev = xAmznTraceId;
-  } else {
-    logger.getLogger().warn('Entering no-op mode. _X_AMZN_TRACE_ID contained incomplete data: ' + xAmznTraceId);
   }
 
   return segment;

--- a/packages/core/lib/env/aws_lambda.js
+++ b/packages/core/lib/env/aws_lambda.js
@@ -6,11 +6,7 @@ var SegmentEmitter = require('../segment_emitter');
 var SegmentUtils = require('../segments/segment_utils');
 
 var logger = require('../logger');
-
-/**
-* Used to initialize segments on AWS Lambda with extra data from the context.
-*/
-
+const TraceID = require('../segments/attributes/trace_id');
 
 /**
  * @namespace
@@ -18,6 +14,9 @@ var logger = require('../logger');
  */
 var xAmznTraceIdPrev = null;
 
+/**
+* Used to initialize segments on AWS Lambda with extra data from the context.
+*/
 module.exports.init = function init() {
   contextUtils.enableManualMode = function() {
     logger.getLogger().warn('AWS Lambda does not support AWS X-Ray manual mode.');
@@ -62,7 +61,7 @@ var facadeSegment = function facadeSegment() {
     }
   }
 
-  segment.trace_id = null;
+  segment.trace_id = TraceID.Invalid().toString();
   segment.isClosed = function() { return true; };
   segment.in_progress = false;
   segment.counter = 1;
@@ -70,8 +69,8 @@ var facadeSegment = function facadeSegment() {
   segment.facade = true;
 
   segment.reset = function reset() {
-    this.trace_id = null;
-    this.id = null;
+    this.trace_id = TraceID.Invalid().toString();
+    this.id = '00000000';
     delete this.subsegments;
     this.notTraced = true;
   };
@@ -80,6 +79,8 @@ var facadeSegment = function facadeSegment() {
     var xAmznLambda = process.env._X_AMZN_TRACE_ID;
 
     if (xAmznLambda) {
+
+      // This check resets the trace data whenever a new trace header is read to not leak data between invocations
       if (xAmznLambda != xAmznTraceIdPrev) {
         this.reset();
 
@@ -93,9 +94,14 @@ var facadeSegment = function facadeSegment() {
     }
   };
 
+  console.log('In init. _X_AMZN_TRACE_ID contains data: ' + xAmznTraceId);
+
+  // Test for valid trace data during SDK startup. It's possible we're outside the handler and don't have access to
   if (LambdaUtils.validTraceData(xAmznTraceId)) {
     if (LambdaUtils.populateTraceData(segment, xAmznTraceId))
       xAmznTraceIdPrev = xAmznTraceId;
+  } else {
+    logger.getLogger().warn('Entering no-op mode. _X_AMZN_TRACE_ID contained incomplete data: ' + xAmznTraceId);
   }
 
   return segment;

--- a/packages/core/lib/segments/attributes/trace_id.d.ts
+++ b/packages/core/lib/segments/attributes/trace_id.d.ts
@@ -5,6 +5,8 @@ declare class TraceID {
 
   constructor();
 
+  static Invalid(): TraceID;
+
   static FromString(rawId: string): TraceID;
 
   toString(): string;

--- a/packages/core/lib/segments/attributes/trace_id.js
+++ b/packages/core/lib/segments/attributes/trace_id.js
@@ -8,12 +8,21 @@ var logger = require('../../logger');
 class TraceID {
   /**
    * Constructs a new trace ID using the current time.
+   * @param {string} [tsHex] - time stamp to use for trace ID in hexadecimal format
+   * @param {string} [numberhex] - string of hexadecimal characters for random portion of Trace ID
    * @constructor
    */ 
-  constructor() {
+  constructor(tsHex, numberhex) {
     this.version = 1;
-    this.timestamp = Math.round(new Date().getTime() / 1000).toString(16);
-    this.id = crypto.randomBytes(12).toString('hex');
+    this.timestamp = tsHex || Math.round(new Date().getTime() / 1000).toString(16);
+    this.id = numberhex || crypto.randomBytes(12).toString('hex');
+  }
+
+  /**
+   * @returns {TraceID} - a hardcoded trace ID using zeroed timestamp and random ID
+   */
+  static Invalid() {
+    return new TraceID('00000000', '000000000000000000000000');
   }
 
   /**

--- a/packages/core/lib/segments/segment.js
+++ b/packages/core/lib/segments/segment.js
@@ -16,7 +16,6 @@ var logger = require('../logger');
  * @param {string} [rootId] - The trace ID of the spawning parent, included in the 'X-Amzn-Trace-Id' header of the incoming request.  If one is not supplied, it will be generated.
  * @param {string} [parentId] - The sub/segment ID of the spawning parent, included in the 'X-Amzn-Trace-Id' header of the incoming request.
  */
-
 function Segment(name, rootId, parentId) {
   this.init(name, rootId, parentId);
 }

--- a/packages/core/test-d/index.test-d.ts
+++ b/packages/core/test-d/index.test-d.ts
@@ -6,6 +6,7 @@ import { expectType, expectError } from 'tsd';
 import * as url from 'url';
 import * as AWSXRay from '../lib';
 import { Segment } from '../lib';
+import TraceID from '../lib/segments/attributes/trace_id';
 
 expectType<void>(AWSXRay.plugins.EC2Plugin.getData((metadata?: AWSXRay.plugins.EC2Metadata) => { }));
 expectType<void>(AWSXRay.plugins.ECSPlugin.getData((metadata?: AWSXRay.plugins.ECSMetadata) => { }));
@@ -39,7 +40,12 @@ AWSXRay.getLogger().error('error');
 expectType<void>(AWSXRay.setDaemonAddress('192.168.0.23:8080'));
 
 const traceId = '1-57fbe041-2c7ad569f5d6ff149137be86';
+const traceId2 = new TraceID();
 const segment = new AWSXRay.Segment('test', traceId);
+
+expectType<TraceID>(TraceID.FromString(traceId));
+expectType<TraceID>(TraceID.Invalid());
+expectType<string>(traceId2.toString());
 
 expectType<string>(AWSXRay.captureFunc('tracedFcn', () => 'OK', segment));
 expectType<void>(AWSXRay.captureFunc('tracedFcn', () => { return; }));

--- a/packages/core/test-d/index.test-d.ts
+++ b/packages/core/test-d/index.test-d.ts
@@ -5,8 +5,7 @@ import { Socket } from 'net';
 import { expectType, expectError } from 'tsd';
 import * as url from 'url';
 import * as AWSXRay from '../lib';
-import { Segment } from '../lib';
-import TraceID from '../lib/segments/attributes/trace_id';
+import { Segment, TraceID } from '../lib';
 
 expectType<void>(AWSXRay.plugins.EC2Plugin.getData((metadata?: AWSXRay.plugins.EC2Metadata) => { }));
 expectType<void>(AWSXRay.plugins.ECSPlugin.getData((metadata?: AWSXRay.plugins.ECSMetadata) => { }));

--- a/packages/core/test/unit/env/aws_lambda.test.js
+++ b/packages/core/test/unit/env/aws_lambda.test.js
@@ -12,6 +12,7 @@ var LambdaUtils = require('../../../lib/utils').LambdaUtils;
 var Segment = require('../../../lib/segments/segment');
 var SegmentUtils = require('../../../lib/segments/segment_utils');
 var SegmentEmitter = require('../../../lib/segment_emitter');
+const TraceID = require('../../../lib/segments/attributes/trace_id');
 
 describe('AWSLambda', function() {
   var sandbox;
@@ -77,6 +78,7 @@ describe('AWSLambda', function() {
 
       var facade = setSegmentStub.args[0][0];
       assert.equal(facade.name, 'facade');
+      assert.equal(facade.trace_id, TraceID.Invalid().toString());
     });
 
     describe('the facade segment', function() {
@@ -133,12 +135,11 @@ describe('AWSLambda', function() {
         facade.trace_id = 'traceIdHere';
         facade.id = 'parentIdHere';
         facade.subsegments = [ { subsegment: 'here' } ];
-        facade.trace_id = 'traceIdHere';
 
         facade.reset();
 
-        assert.isNull(facade.trace_id);
-        assert.isNull(facade.id);
+        assert.isNotNull(facade.trace_id);
+        assert.isNotNull(facade.id);
         assert.isUndefined(facade.subsegments);
         assert.isTrue(facade.notTraced);
       });


### PR DESCRIPTION
*Description of changes:*
Ensure that Lambda trace IDs will *never* be `null`, even outside the function handler. This extends #284. Also change the wording in the Lambda CME to clarify common cases that would cause the `_X_AMZN_TRACE_ID` to not be present, rather than simply stating it's not present.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
