### PR TITLE
Prevent Express faulted segments from being closed twice

### DIFF
--- a/packages/express/test/unit/express_mw.test.js
+++ b/packages/express/test/unit/express_mw.test.js
@@ -182,4 +182,32 @@ describe('Express middleware', function() {
       });
     });
   });
+
+  describe('#close', function() {
+    var segment, close;
+    beforeEach(function() {
+      xray.enableManualMode();
+      segment = new Segment('test');
+      sandbox = sinon.createSandbox();
+      close = expressMW.closeSegment();
+
+      req = {
+        segment: segment
+      };
+      res = {};
+    });
+
+    afterEach(function() {
+      xray.enableAutomaticMode();
+      sandbox.restore();
+    });
+    
+    it('should add error using express middleware', function() {
+      const segment = req.segment;
+      close(new Error(), req, res);
+
+      assert.property(segment, 'cause');
+      assert.property(segment.cause, 'exceptions');
+    });
+  })
 });


### PR DESCRIPTION
*Issue #, if available:*
#360

*Description of changes:*
Fixes a bug where, if there is a server fault for an express server, the segment would be closed twice. We had both the Express error-handling middleware and an event listener closing the segment before. The problem was that both places added important info: The error stack trace is only retrievable from the `closeSegment` middleware, and the HTTP response metadata is only available in the event listener. Before we were closing the segment with the error in the `closeSegment` middleware, now we are simply adding the error without closing. 

This didn't cause any behavioral impact to users because the X-Ray backend would be able to merge the data from both closed segments behind the scenes. However this should cause significant performance improvement since we no longer serialize twice, and it's less confusing to customers since we shouldn't be closing the same segment multiple times.

Added a unit and integration test to verify, and tested locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
