### PR TITLE
Wrap the catch method also

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ To send us a pull request, please:
 5. Send us a pull request, answering any default questions in the pull request interface.
 6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
-GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and 
+GitHub provides additional documents on [forking a repository](https://help.github.com/articles/fork-a-repo/) and 
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
 

--- a/packages/core/.eslintrc.json
+++ b/packages/core/.eslintrc.json
@@ -29,6 +29,6 @@
         ]
     },
     "parserOptions": {
-        "ecmaVersion": 6
+        "ecmaVersion": 2017
     }
 }

--- a/packages/core/lib/patchers/promise_p.js
+++ b/packages/core/lib/patchers/promise_p.js
@@ -23,6 +23,21 @@ function patchPromise(Promise) {
 
     return then.call(this, onFulfilled, onRejected);
   };
+
+  var origCatch = Promise.prototype.catch;
+  if (origCatch) {
+    Promise.prototype.catch = function (onRejected) {
+      if (contextUtils.isAutomaticMode()
+        && tryGetCurrentSegment()
+      ) {
+        var ns = contextUtils.getNamespace();
+
+        onRejected = onRejected && ns.bind(onRejected);
+      }
+
+      return origCatch.call(this, onRejected);
+    };
+  }
 }
 
 function tryGetCurrentSegment() {

--- a/packages/core/lib/patchers/promise_p.js
+++ b/packages/core/lib/patchers/promise_p.js
@@ -7,15 +7,15 @@
  * so all subsegments generated within Promise are attached to the correct parent.
  */
 
-var contextUtils = require('../context_utils');
+const contextUtils = require('../context_utils');
 
 function patchPromise(Promise) {
-  var then = Promise.prototype.then;
+  const then = Promise.prototype.then;
   Promise.prototype.then = function(onFulfilled, onRejected) {
     if (contextUtils.isAutomaticMode()
       && tryGetCurrentSegment()
     ) {
-      var ns = contextUtils.getNamespace();
+      const ns = contextUtils.getNamespace();
 
       onFulfilled = onFulfilled && ns.bind(onFulfilled);
       onRejected = onRejected && ns.bind(onRejected);
@@ -24,13 +24,13 @@ function patchPromise(Promise) {
     return then.call(this, onFulfilled, onRejected);
   };
 
-  var origCatch = Promise.prototype.catch;
+  const origCatch = Promise.prototype.catch;
   if (origCatch) {
     Promise.prototype.catch = function (onRejected) {
       if (contextUtils.isAutomaticMode()
         && tryGetCurrentSegment()
       ) {
-        var ns = contextUtils.getNamespace();
+        const ns = contextUtils.getNamespace();
 
         onRejected = onRejected && ns.bind(onRejected);
       }
@@ -41,11 +41,11 @@ function patchPromise(Promise) {
 }
 
 function tryGetCurrentSegment() {
-  var segment = null;
   try {
-    segment = contextUtils.getSegment();
-  } catch(e) { /**/ }
-  return segment;
+    return contextUtils.getSegment();
+  } catch(e) {
+    return undefined;
+  }
 }
 
 function capturePromise() {

--- a/packages/core/test/unit/context_utils.test.js
+++ b/packages/core/test/unit/context_utils.test.js
@@ -24,6 +24,7 @@ describe('ContextUtils', function() {
 
     beforeEach(function() {
       sandbox = sinon.createSandbox();
+      sinon.restore();
     });
 
     afterEach(function() {

--- a/packages/core/test/unit/logger.test.js
+++ b/packages/core/test/unit/logger.test.js
@@ -1,18 +1,14 @@
-var expect = require('chai').expect;
-var rewire = require('rewire');
-var sinon = require('sinon');
-var logging = require('../../lib/logger');
+const expect = require('chai').expect;
+const rewire = require('rewire');
+const sinon = require('sinon');
+let logging = require('../../lib/logger');
 
 describe('logger', function () {
-  var spies = [];
+  const spies = [];
 
   function reloadLogger() {
-    var path = '../../lib/logger';
-    delete require.cache[require.resolve(path)];
-    logging = require(path);
-  }
-
-  before(function() {
+    const path = '../../lib/logger';
+    spies.length = 0;
     spies.push(sinon.spy(console, 'error'));
     spies.push(sinon.spy(console, 'warn'));
     spies.push(sinon.spy(console, 'info'));
@@ -21,19 +17,18 @@ describe('logger', function () {
     if (console.debug) {
       spies.push(sinon.spy(console, 'debug'));
     }
-  });
 
-  afterEach(function () {
-    spies.forEach(spy => spy.resetHistory());
-  });
+    delete require.cache[require.resolve(path)];
+    logging = require(path);
+  }
 
-  after(function () {
-    spies.forEach(spy => spy.restore());
+  afterEach(function() {
+    sinon.restore();
   });
 
   describe('console logging methods', function () {
-    before(function() {
-      process.env.AWS_XRAY_DEBUG_MODE = 'set';
+    beforeEach(function() {
+      process.env.AWS_XRAY_DEBUG_MODE = 'debug';
       reloadLogger();
     });
 
@@ -43,33 +38,33 @@ describe('logger', function () {
 
     it('Should send debug logs to console.debug', function () {
       logging.getLogger().debug('test');
-      
+
       if (console.debug) {
-        expect(console.debug).to.be.calledOnce;
+        sinon.assert.calledOnce(console.debug);
       } else {
-        expect(console.log).to.be.calledOnce;
+        sinon.assert.calledOnce(console.log);
       }
     });
 
     it('Should send info logs to console.info', function () {
       logging.getLogger().info('test');
-      expect(console.info).to.be.calledOnce;
+      sinon.assert.calledOnce(console.info);
     });
 
     it('Should send warn logs to console.warn', function () {
       logging.getLogger().warn('test');
-      expect(console.warn).to.be.calledOnce;
+      sinon.assert.calledOnce(console.warn);
     });
 
     it('Should sent error logs to console.error', function () {
       logging.getLogger().error('test');
-      expect(console.error).to.be.calledOnce;
+      sinon.assert.calledOnce(console.error);
     });
   });
 
   describe('console logging filters', function () {
     function sendLogMessages() {
-      var logger = logging.getLogger();
+      const logger = logging.getLogger();
       logger.debug('test');
       logger.info('test');
       logger.warn('test');
@@ -85,75 +80,75 @@ describe('logger', function () {
       reloadLogger();
 
       sendLogMessages();
-      spies.forEach(spy => expect(spy).to.not.be.called);
+      spies.forEach(spy => sinon.assert.notCalled(spy));
     });
 
     it('Should only emit error logs if level is error', function () {
       process.env.AWS_XRAY_LOG_LEVEL = 'error';
       reloadLogger();
-      
+
       sendLogMessages();
-      expect(console.error).to.be.calledOnce;
+      sinon.assert.calledOnce(console.error);
       spies.filter(spy => spy !== console.error)
-        .forEach(spy => expect(spy).to.not.be.called);
+        .forEach(spy => sinon.assert.notCalled(spy));
     });
 
     it('Should emit error and warn logs if level is warn', function () {
       process.env.AWS_XRAY_LOG_LEVEL = 'warn';
       reloadLogger();
-      
+
       sendLogMessages();
-      var expected = [ console.error, console.warn ];
-      expected.forEach(spy => expect(spy).to.be.called);
+      const expected = [ console.error, console.warn ];
+      expected.forEach(spy => sinon.assert.called(spy));
       spies.filter(spy => !expected.includes(spy))
-        .forEach(spy => expect(spy).to.not.be.called);
+        .forEach(spy => sinon.assert.notCalled(spy));
     });
 
     it('Should emit error, warn, and info logs if level is info', function () {
       process.env.AWS_XRAY_LOG_LEVEL = 'info';
       reloadLogger();
-      
+
       sendLogMessages();
-      var expected = [ console.error, console.warn, console.info ];
-      expected.forEach(spy => expect(spy).to.be.called);
+      const expected = [ console.error, console.warn, console.info ];
+      expected.forEach(spy => sinon.assert.called(spy));
       spies.filter(spy => !expected.includes(spy))
-        .forEach(spy => expect(spy).to.not.be.called);
+        .forEach(spy => sinon.assert.notCalled(spy));
     });
 
     it('Should emit all logs if level is debug', function () {
       process.env.AWS_XRAY_LOG_LEVEL = 'debug';
       reloadLogger();
-      
+
       sendLogMessages();
-      var filterMethod = console.debug ? (spy => spy !== console.log) : (() => true);
-      spies.filter(filterMethod).forEach(spy => expect(spy).to.be.called);
+      const filterMethod = console.debug ? (spy) => spy !== console.log : () => true;
+      spies.filter(filterMethod).forEach(spy => sinon.assert.called(spy));
     });
 
     it('Should default to error if invalid log level', function () {
       process.env.AWS_XRAY_LOG_LEVEL = 'not_a_level';
       reloadLogger();
-      
+
       sendLogMessages();
-      expect(console.error).to.be.calledOnce;
+      sinon.assert.calledOnce(console.error);
       spies.filter(spy => spy !== console.error)
-        .forEach(spy => expect(spy).to.not.be.called);
+        .forEach(spy => sinon.assert.notCalled(spy));
     });
 
     it('Should default to error if no log level', function () {
       reloadLogger();
-      
+
       sendLogMessages();
-      expect(console.error).to.be.calledOnce;
+      sinon.assert.calledOnce(console.error);
       spies.filter(spy => spy !== console.error)
-        .forEach(spy => expect(spy).to.not.be.called);
+        .forEach(spy => sinon.assert.notCalled(spy));
     });
   });
 
   describe('console logging format', function () {
-    var logMessageRegex = /(\d{4}-[01]\d-[0-3]\d) ([0-2]\d:[0-5]\d:[0-5]\d\.\d+) ([+-][0-2]\d:[0-5]\d) \[(\w+)\](.*)/;
-    var timestampRegex = /(\d{4}-[01]\d-[0-3]\d) ([0-2]\d:[0-5]\d:[0-5]\d\.\d+) ([+-][0-2]\d:[0-5]\d)/;
+    const logMessageRegex = /(\d{4}-[01]\d-[0-3]\d) ([0-2]\d:[0-5]\d:[0-5]\d\.\d+) ([+-][0-2]\d:[0-5]\d) \[(\w+)\](.*)/;
+    const timestampRegex = /(\d{4}-[01]\d-[0-3]\d) ([0-2]\d:[0-5]\d:[0-5]\d\.\d+) ([+-][0-2]\d:[0-5]\d)/;
 
-    before(function() {
+    beforeEach(function() {
       reloadLogger();
     });
 
@@ -162,113 +157,114 @@ describe('logger', function () {
     });
 
     it('should output error message', () => {
-      var logger = logging.getLogger();
-      var expectedMessage = 'error message';
+      const logger = logging.getLogger();
+      const expectedMessage = 'error message';
       logger.error(expectedMessage);
 
-      var message = console.error.args[0][0];
-      var groups = message.match(logMessageRegex);
+      const message = console.error.args[0][0];
+      const groups = message.match(logMessageRegex);
       expect(groups[4]).to.equal('ERROR');
       expect(groups[5].trim()).to.equal(expectedMessage);
     });
 
     it('should not output if message and meta falsey', () => {
-      var logger = logging.getLogger();
+      const logger = logging.getLogger();
       logger.error();
       logger.error(null);
       logger.error('', null);
 
-      spies.forEach(spy => expect(spy).not.to.be.called);
+      spies.forEach(spy => sinon.assert.notCalled(spy));
     });
 
     it('should convert falsey value to empty string', () => {
-      var logger = logging.getLogger();
+      const logger = logging.getLogger();
       logger.error(null, {});
 
-      var message = console.error.args[0][0];
-      var groups = message.match(logMessageRegex);
+      const message = console.error.args[0][0];
+      const groups = message.match(logMessageRegex);
       expect(groups[4]).to.equal('ERROR');
       expect(groups[5]).to.equal('');
     });
 
     it('should not add timestamp to lambda errors', () => {
       process.env.LAMBDA_TASK_ROOT = 'on';
-      var expectedMessage = 'error message';
-      var logger = logging.getLogger();
+      const expectedMessage = 'error message';
+      const logger = logging.getLogger();
       logger.error(expectedMessage);
 
-      var message = console.error.args[0][0];
+      sinon.assert.called(console.error);
+      const message = console.error.args[0][0];
       expect(logMessageRegex.test(message)).to.be.false;
       expect(message).to.equal(expectedMessage);
     });
 
     it('should only output metadata for lambda with no message', () => {
       process.env.LAMBDA_TASK_ROOT = 'on';
-      var expectedMetaData = 'this is some metadata';
-      var logger = logging.getLogger();
+      const expectedMetaData = 'this is some metadata';
+      const logger = logging.getLogger();
       logger.error(null, expectedMetaData);
 
-      var message = console.error.args[0][0];
+      const message = console.error.args[0][0];
       expect(logMessageRegex.test(message)).to.be.false;
       expect(message).to.equal(expectedMetaData);
     });
 
     it('should output both message and metadata for lambda', () => {
       process.env.LAMBDA_TASK_ROOT = 'on';
-      var expectedMessage = 'error message';
-      var expectedMetaData = 'metadata';
-      var logger = logging.getLogger();
+      const expectedMessage = 'error message';
+      const expectedMetaData = 'metadata';
+      const logger = logging.getLogger();
       logger.error(expectedMessage, expectedMetaData);
 
-      var message = console.error.args[0][0];
+      const message = console.error.args[0][0];
       expect(logMessageRegex.test(message)).to.be.false;
       expect(message).to.equal(expectedMessage + '\n  ' + expectedMetaData);
     });
 
     it('should generate timestamp with negative timezone offset', () => {
-      var rewiredLogger = rewire('../../lib/logger');
-      var createTimestamp = rewiredLogger.__get__('createTimestamp');
+      const rewiredLogger = rewire('../../lib/logger');
+      const createTimestamp = rewiredLogger.__get__('createTimestamp');
 
-      var date = new Date();
+      const date = new Date();
       sinon.stub(date, 'getTimezoneOffset').returns(60);
-      var stamp = createTimestamp(date);
+      const stamp = createTimestamp(date);
 
-      var groups = stamp.match(timestampRegex);
+      const groups = stamp.match(timestampRegex);
       expect(groups[3]).to.equal('-01:00');
     });
 
     it('should generate timestamp with positive timezone offset', () => {
-      var rewiredLogger = rewire('../../lib/logger');
-      var createTimestamp = rewiredLogger.__get__('createTimestamp');
+      const rewiredLogger = rewire('../../lib/logger');
+      const createTimestamp = rewiredLogger.__get__('createTimestamp');
 
-      var date = new Date();
+      const date = new Date();
       sinon.stub(date, 'getTimezoneOffset').returns(-60);
-      var stamp = createTimestamp(date);
+      const stamp = createTimestamp(date);
 
-      var groups = stamp.match(timestampRegex);
+      const groups = stamp.match(timestampRegex);
       expect(groups[3]).to.equal('+01:00');
     });
 
     it('should generate timestamp with special timezone offset', () => {
-      var rewiredLogger = rewire('../../lib/logger');
-      var createTimestamp = rewiredLogger.__get__('createTimestamp');
+      const rewiredLogger = rewire('../../lib/logger');
+      const createTimestamp = rewiredLogger.__get__('createTimestamp');
 
-      var date = new Date();
+      const date = new Date();
       sinon.stub(date, 'getTimezoneOffset').returns(108);
-      var stamp = createTimestamp(date);
+      const stamp = createTimestamp(date);
 
-      var groups = stamp.match(timestampRegex);
+      const groups = stamp.match(timestampRegex);
       expect(groups[3]).to.equal('-01:48');
     });
 
     it('should generate correctly formatted timestamp', () => {
-      var rewiredLogger = rewire('../../lib/logger');
-      var createTimestamp = rewiredLogger.__get__('createTimestamp');
+      const rewiredLogger = rewire('../../lib/logger');
+      const createTimestamp = rewiredLogger.__get__('createTimestamp');
 
-      var date = new Date(1576877599000);  // 12/20/2019 @ 9:33pm (UTC)
+      const date = new Date(1576877599000);  // 12/20/2019 @ 9:33pm (UTC)
       sinon.stub(date, 'getTimezoneOffset').returns(0);
-      var stamp = createTimestamp(date);
-      var expected = '2019-12-20 21:33:19.000 +00:00';
+      const stamp = createTimestamp(date);
+      const expected = '2019-12-20 21:33:19.000 +00:00';
 
       expect(stamp).to.equal(expected);
     });

--- a/packages/core/test/unit/patchers/promise_p.test.js
+++ b/packages/core/test/unit/patchers/promise_p.test.js
@@ -1,0 +1,146 @@
+const expect = require('chai').expect;
+const sinon = require('sinon');
+
+const { capturePromise } = require('../../../lib/patchers/promise_p');
+const contextUtils = require('../../../lib/context_utils');
+
+const origThen = Promise.prototype.then;
+const origCatch = Promise.prototype.catch;
+
+const sandbox = sinon.createSandbox();
+const getNamespaceStub = sandbox.stub(contextUtils, 'getNamespace');
+const isAutomaticModeStub = sandbox.stub(contextUtils, 'isAutomaticMode');
+const getSegmentStub = sandbox.stub(contextUtils, 'getSegment');
+const bindStub = sandbox.stub();
+
+beforeEach(() => {
+  bindStub.returnsArg(0);
+  getNamespaceStub.returns({
+    bind: bindStub
+  });
+});
+
+afterEach(() => {
+  sandbox.reset();
+  Promise.prototype.then = origThen;
+  Promise.prototype.catch = origCatch;
+});
+
+after(() => {
+  sandbox.restore();
+});
+
+function verifyBindings (shouldCapture, onFulfilled, onRejected) {
+  if (shouldCapture) {
+    if (onFulfilled) {
+      sinon.assert.calledWith(bindStub, onFulfilled);
+    }
+    if (onRejected) {
+      sinon.assert.calledWith(bindStub, onRejected);
+    }
+  } else {
+    sinon.assert.notCalled(bindStub);
+  }
+}
+
+function testThenOnFulfilled(shouldCapture) {
+  const onFulfilled = result => {
+    expect(result).to.equal('resolved');
+    verifyBindings(shouldCapture, onFulfilled);
+  };
+  return new Promise((resolve) => {
+    setTimeout(() => resolve('resolved'), 200);
+  }).then(onFulfilled);
+}
+
+function testThenOnRejected(shouldCapture, hasOnFulfilled = true) {
+  const onFulfilled = hasOnFulfilled ? () => {
+    throw new Error('Not rejected');
+  } : undefined;
+
+  const onRejected = error => {
+    expect(error.message).to.equal('rejected');
+    verifyBindings(shouldCapture, onFulfilled, onRejected);
+  };
+  return new Promise((_, reject) => {
+    setTimeout(() => reject(new Error('rejected')), 200);
+  }).then(onFulfilled, onRejected);
+}
+
+function testCatch(shouldCapture) {
+  const onRejected = error => {
+    verifyBindings(shouldCapture, undefined, onRejected);
+    expect(error.message, 'rejected');
+  };
+  return new Promise((_, reject) => {
+    setTimeout(() => reject(new Error('rejected')), 200);
+  }).catch(onRejected);
+}
+
+function createTests(shouldCapture) {
+  it('Promise.prototype.then', async () => {
+    capturePromise();
+    expect(Promise.prototype.then).not.to.equal(origThen);
+    await testThenOnFulfilled(shouldCapture);
+    await testThenOnRejected(shouldCapture);
+    await testThenOnRejected(shouldCapture, false);
+  });
+
+  it('Promise.prototype.catch', async () => {
+    capturePromise();
+    expect(Promise.prototype.catch).not.to.equal(origCatch);
+    await testCatch(shouldCapture);
+  });
+}
+
+describe('capturePromise', () => {
+  describe('no segment', () => {
+    beforeEach(() => {
+      getSegmentStub.throws('No segment');
+      isAutomaticModeStub.returns(true);
+    });
+
+    createTests(false);
+  });
+
+  describe('not automaticMode', () => {
+    beforeEach(() => {
+      getSegmentStub.returns({});
+      isAutomaticModeStub.returns(false);
+    });
+
+    createTests(false);
+  });
+
+  describe('binds methods', () => {
+    beforeEach(() => {
+      getSegmentStub.returns({});
+      isAutomaticModeStub.returns(true);
+    });
+    createTests(true);
+  });
+});
+
+describe('capturePromise.patchThirdPartyPromise', () => {
+  class FakePromise {
+  }
+  function fakeOrigThen () {}
+  function fakeOrigCatch () {}
+
+  beforeEach(() => {
+    FakePromise.prototype.then = fakeOrigThen;
+    FakePromise.prototype.catch = fakeOrigCatch;
+  });
+
+  it('wraps the provided Promise lib then function', () => {
+    capturePromise.patchThirdPartyPromise(FakePromise);
+    expect(Promise.prototype.then).to.equal(origThen);
+    expect(FakePromise.prototype.then).not.to.equal(fakeOrigThen);
+  });
+
+  it('wraps the provided Promise lib then function', () => {
+    capturePromise.patchThirdPartyPromise(FakePromise);
+    expect(Promise.prototype.catch).to.equal(origCatch);
+    expect(FakePromise.prototype.catch).not.to.equal(fakeOrigCatch);
+  });
+});


### PR DESCRIPTION
The current implementation of wrapping promises doesn't handle `new Promise().then(onSuccess).catch(onFailure)` setups.  ~~This is causing a circular dependency in ApolloServer.~~

~~I'm having trouble creating a test case for it, but am experiencing it when running in a Lambda function.~~


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
