### PR TITLE
Better bundling

### DIFF
--- a/packages/core/lib/aws-xray.js
+++ b/packages/core/lib/aws-xray.js
@@ -4,10 +4,17 @@ var segmentUtils = require('./segments/segment_utils');
 var utils = require('./utils');
 var LambdaEnv = require('./env/aws_lambda');
 
-var UNKNOWN = 'unknown';
+// Import Data from package.json,
+// If the importing of package.json fails leave
+// pkginfo as an empty object
+var pkginfo = {}
+try {
+  pkginfo = require('../package.json');
+} catch (err) {
+  logging.getLogger().debug('Failed to load SDK data:', err);
+}
 
-var pkginfo = module.filename ? require('pkginfo') : function() {};
-pkginfo(module);
+var UNKNOWN = 'unknown';
 
 /**
  * A module representing the AWSXRay SDK.
@@ -351,8 +358,8 @@ AWSXRay.middleware.IncomingRequestData = require('./middleware/incoming_request_
 
   var sdkData = {
     sdk: 'X-Ray for Node.js',
-    sdk_version: (module.exports && module.exports.version) ? module.exports.version : UNKNOWN,
-    package: (module.exports && module.exports.name) ? module.exports.name : UNKNOWN,
+    sdk_version: pkginfo.version ? pkginfo.version : UNKNOWN,
+    package: pkginfo.name ? pkginfo.name : UNKNOWN,
   };
 
   segmentUtils.setSDKData(sdkData);

--- a/packages/core/lib/context_utils.js
+++ b/packages/core/lib/context_utils.js
@@ -2,7 +2,7 @@
  * @module context_utils
  */
 
-var cls = require('cls-hooked');
+var cls = require('cls-hooked/context');
 
 var logger = require('./logger');
 var Segment = require('./segments/segment');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,6 @@
     "@types/cls-hooked": "*",
     "atomic-batcher": "^1.0.2",
     "cls-hooked": "^4.2.2",
-    "pkginfo": "^0.4.0",
     "semver": "^5.3.0"
   },
   "scripts": {

--- a/packages/core/test/unit/aws-xray.test.js
+++ b/packages/core/test/unit/aws-xray.test.js
@@ -44,7 +44,17 @@ describe('AWSXRay', function() {
 
       assert.property(setSDKDataStub.firstCall.args[0], 'sdk');
       assert.property(setSDKDataStub.firstCall.args[0], 'sdk_version');
+      assert.notStrictEqual(
+        setSDKDataStub.firstCall.args[0].sdk_version,
+        'unknown',
+        'Expected sdk_version to not be unknown'
+      );
       assert.property(setSDKDataStub.firstCall.args[0], 'package');
+      assert.notStrictEqual(
+        setSDKDataStub.firstCall.args[0].package,
+        'unknown',
+        'Expected package to not be unknown'
+      );
 
       assert.property(setServiceDataStub.firstCall.args[0], 'runtime');
       assert.property(setServiceDataStub.firstCall.args[0], 'runtime_version');

--- a/packages/full_sdk/lib/index.js
+++ b/packages/full_sdk/lib/index.js
@@ -4,14 +4,22 @@ AWSXRay.express = require('aws-xray-sdk-express');
 AWSXRay.captureMySQL = require('aws-xray-sdk-mysql');
 AWSXRay.capturePostgres = require('aws-xray-sdk-postgres');
 
+// Import Data from package.json,
+// If the importing of package.json fails leave
+// pkginfo as an empty object
+var pkginfo = {}
+try {
+  pkginfo = require('../package.json');
+} catch (err) {
+  AWSXRay.getLogger().debug('Failed to load SDK data:', err);
+}
+
 var UNKNOWN = 'unknown';
-var pkginfo = module.filename ? require('pkginfo') : function() {};
-pkginfo(module);
 
 (function () {
   var sdkData = AWSXRay.SegmentUtils.sdkData || { sdk: 'X-Ray for Node.js' };
-  sdkData.sdk_version = (module.exports && module.exports.version) ? module.exports.version : UNKNOWN;
-  sdkData.package = (module.exports && module.exports.name) ? module.exports.name : UNKNOWN;
+  sdkData.sdk_version = pkginfo.version ? pkginfo.version : UNKNOWN;
+  sdkData.package = pkginfo.name ? pkginfo.name : UNKNOWN;
   AWSXRay.SegmentUtils.setSDKData(sdkData);
 })();
 

--- a/packages/full_sdk/package.json
+++ b/packages/full_sdk/package.json
@@ -16,8 +16,7 @@
     "aws-xray-sdk-core": "file:../core",
     "aws-xray-sdk-express": "file:../express",
     "aws-xray-sdk-mysql": "file:../mysql",
-    "aws-xray-sdk-postgres": "file:../postgres",
-    "pkginfo": "^0.4.0"
+    "aws-xray-sdk-postgres": "file:../postgres"
   },
   "scripts": {
     "test": "tsd",

--- a/packages/test_express/test/helpers.js
+++ b/packages/test_express/test/helpers.js
@@ -2,7 +2,7 @@ var dgram = require('dgram');
 var xray = require('aws-xray-sdk-core');
 var xrayExpress = require('aws-xray-sdk-express');
 var express = require('express');
-require('cls-hooked'); // validates compat with continuation-local-storage
+require('cls-hooked/context'); // validates compat with continuation-local-storage
 var http = require('http');
 var assert = require('chai').assert;
 


### PR DESCRIPTION
Resolves #368 and kind-of #338 

*Description of changes:*
The cls-hooked and pkginfo dependencies are problematic for bundlers like rollup (see #338) to make this work better we can do 2 simple things:

1. For cls-hooked importing `cls-hooked/context` directly rather than using the compatibility layer at the package index.js file has no performance or behavior implication and simply skips a check that this is being run in node versions greater than or equal to 8 (current min engine version is 10). Ideally we'd be able to ditch the cls-hooked dependency entirely but that is a much larger change.
2. For pkginfo the package simply climbs the file path starting from a module until it finds a `package.json` file, since we know where our package.json file will be it's easy to just import the values from that file. This will resolve #368 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
