### PR TITLE
Use addError to set parent exceptions instead of .exception

### DIFF
--- a/packages/core/.eslintrc.json
+++ b/packages/core/.eslintrc.json
@@ -29,6 +29,6 @@
         ]
     },
     "parserOptions": {
-        "ecmaVersion": 6
+        "ecmaVersion": 2019
     }
 }

--- a/packages/core/lib/segments/attributes/subsegment.js
+++ b/packages/core/lib/segments/attributes/subsegment.js
@@ -182,20 +182,8 @@ Subsegment.prototype.addError = function addError(err, remote) {
 
   this.addFaultFlag();
 
-  if (this.segment && this.segment.exception) {
-    if (err === this.segment.exception.ex) {
-      this.fault = true;
-      this.cause = { id: this.segment.exception.cause };
-      return;
-    }
-    delete this.segment.exception;
-  }
-
   if (this.segment) {
-    this.segment.exception = {
-      ex: err,
-      cause: this.id
-    };
+    this.segment.addError(err, remote, this.id);
   } else {
     //error, cannot propagate exception if not added to segment
   }

--- a/packages/core/test/unit/segments/segment.test.js
+++ b/packages/core/test/unit/segments/segment.test.js
@@ -336,13 +336,11 @@ describe('Segment', function() {
       addErrorStub.should.have.not.been.called;
     });
 
-    it('should delete properties "in_progress" and "exception"', function() {
+    it('should delete properties "in_progress"', function() {
       segment.in_progress = true;
-      segment.exception = err;
       segment.close();
 
       assert.notProperty(segment, 'in_progress');
-      assert.notProperty(segment, 'exception');
     });
 
     it('should flush the segment on close', function() {
@@ -406,12 +404,11 @@ describe('Segment', function() {
   });
 
   describe('#flush', function() {
-    var err, sandbox, segment;
+    var sandbox, segment;
 
     beforeEach(function() {
       sandbox = sinon.createSandbox();
       segment = new Segment('test');
-      err = new Error('Test error');
     });
 
     afterEach(function() {
@@ -420,18 +417,16 @@ describe('Segment', function() {
     });
 
     describe('if traced', function() {
-      it('should remove properties "notTraced", "counter" and "exception"', function() {
+      it('should remove properties "notTraced", and "counter"', function() {
         var sendStub = sandbox.stub(SegmentEmitter, 'send');
         segment.notTraced = false;
         segment.in_progress = true;
-        segment.exception = err;
         segment.counter = 1;
 
         segment.flush();
 
         sendStub.should.have.been.calledOnce;
         var sentSegment = sendStub.lastCall.args[0];
-        assert.notProperty(sentSegment, 'exception');
         assert.notProperty(sentSegment, 'counter');
         assert.notProperty(sentSegment, 'notTraced');
       });


### PR DESCRIPTION
Currently when an exception is added to a subsegment the `Segment.exception` doesn't get cleaned up.  This causes errors when internal services try to stringify the exception.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
