### PR TITLE
Made setting context modes idempotent

### DIFF
--- a/packages/core/lib/context_utils.js
+++ b/packages/core/lib/context_utils.js
@@ -62,6 +62,11 @@ var contextUtils = {
     }
   },
 
+  /**
+   * Gets current CLS namespace for X-Ray SDK or creates one if absent.
+   * @returns {Namespace}
+   * @alias module:context_utils.getNamespace
+   */
   getNamespace: function getNamespace() {
     return cls.getNamespace(NAMESPACE) || cls.createNamespace(NAMESPACE);
   },
@@ -139,7 +144,7 @@ var contextUtils = {
 
   enableAutomaticMode: function enableAutomaticMode() {
     cls_mode = true;
-    cls.createNamespace(NAMESPACE);
+    contextUtils.getNamespace(NAMESPACE);
 
     logger.getLogger().debug('Overriding AWS X-Ray SDK mode. Set to automatic mode.');
   },
@@ -153,7 +158,7 @@ var contextUtils = {
   enableManualMode: function enableManualMode() {
     cls_mode = false;
 
-    if (contextUtils.getNamespace(NAMESPACE))
+    if (cls.getNamespace(NAMESPACE))
       cls.destroyNamespace(NAMESPACE);
 
     logger.getLogger().debug('Overriding AWS X-Ray SDK mode. Set to manual mode.');

--- a/packages/core/test/unit/context_utils.test.js
+++ b/packages/core/test/unit/context_utils.test.js
@@ -192,14 +192,18 @@ describe('ContextUtils', function() {
   });
 
   describe('#enableAutomaticMode', () => {
-    it('should respect existing CLS namespaces', () => {
+    it('should respect existing CLS namespaces', (done) => {
       ContextUtils.enableAutomaticMode();
-      const seg = new Segment();
-      ContextUtils.setSegment(seg);
+      const ns = ContextUtils.getNamespace();
+      const seg = new Segment('test');
+      ns.run(() => {
+        ContextUtils.setSegment(seg);
 
-      // Calling this again should do nothing
-      ContextUtils.enableAutomaticMode();
-      assert.deepEqual(ContextUtils.getSegment(), seg);
+        // Calling this again should do nothing
+        ContextUtils.enableAutomaticMode();
+        assert.deepEqual(ContextUtils.getSegment(), seg);
+        done();
+      });
     });
   });
 });

--- a/packages/core/test/unit/context_utils.test.js
+++ b/packages/core/test/unit/context_utils.test.js
@@ -190,4 +190,16 @@ describe('ContextUtils', function() {
       assert.equal(ContextUtils.getNamespace().name, 'AWSXRay');
     });
   });
+
+  describe('#enableAutomaticMode', () => {
+    it('should respect existing CLS namespaces', () => {
+      ContextUtils.enableAutomaticMode();
+      const seg = new Segment();
+      ContextUtils.setSegment(seg);
+
+      // Calling this again should do nothing
+      ContextUtils.enableAutomaticMode();
+      assert.deepEqual(ContextUtils.getSegment(), seg);
+    });
+  });
 });


### PR DESCRIPTION
*Issue #, if available:*
#366

*Description of changes:*
We appeared to be using the incorrect `getNamespace` method in our `enableAutomaticMode` and `enableManualMode` functions. Now `enableAutomaticMode` will check for an existing namespace before creating a new one, and `enableManualMode` will only destroy the namespace if one exists (as opposed to potentially creating then immediately destroying a namespace like it does now). So this change will ensure that redundant calls to either method don't have an effect.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
