### PR TITLE
Automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: 'v${{ github.event.inputs.version }}'
-          release_name: 'Release v${{ github.event.inputs.version }}'
+          tag_name: 'aws-xray-sdk-node@${{ github.event.inputs.version }}'
+          release_name: 'Release ${{ github.event.inputs.version }}'
           draft: false
           prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           path: |
             node_modules
             */*/node_modules
-          key: ubuntu-latest-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.os }}-${{ hashFiles('**/package.json') }}
 
       - name: Execute tests with Lerna
         run: |
@@ -49,5 +49,5 @@ jobs:
         with:
           tag_name: 'aws-xray-sdk-node@${{ github.event.inputs.version }}'
           release_name: 'Release ${{ github.event.inputs.version }}'
-          draft: false
+          draft: true
           prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,14 +37,9 @@ jobs:
           npx lerna run test
 
       - name: Publish package to npm
-        run: npx lerna publish from-package --exact
+        run: npx lerna publish from-package --yes --exact
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Intialize git user name and email
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release X-Ray Node SDK to Github and NPM
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The version to tag the release with, e.g., 1.2.0, 1.2.1-alpha.1
+        required: true
+
+jobs:
+  publish_xray_node_sdk:
+    name: Test and publish X-Ray Node SDK to NPM registry and Github
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Cache NPM modules
+        uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ubuntu-latest-${{ hashFiles('**/package.json') }}
+
+      - name: Execute tests with Lerna
+        run: |
+          npm install
+          npx lerna bootstrap --hoist
+          npx lerna run test
+
+      - name: Publish package to npm
+        run: npx lerna publish from-package --exact
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Intialize git user name and email
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: 'v${{ github.event.inputs.version }}'
+          release_name: 'Release v${{ github.event.inputs.version }}'
+          draft: false
+          prerelease: false


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Automated release workflow for Github and NPM release

Testing setup:

Created test repo and personal NPM account to do test publish for this workflow

Repo link: https://github.com/bhautikpip/release-workflow-test
Published packages: 
https://www.npmjs.com/package/release-workflow-test-core
https://www.npmjs.com/package/release-workflow-test-express
https://www.npmjs.com/package/release-workflow-test

Workflow that published above 3 packages:
https://github.com/bhautikpip/release-workflow-test/actions/runs/488747705

@willarmiros added `NPM_TOKEN` that I have used in workflow (https://github.com/aws/aws-xray-sdk-node/pull/372/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R42) as secret.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
