### PR TITLE
replace url.parse with WHATWG URLs

### DIFF
--- a/packages/core/lib/utils.js
+++ b/packages/core/lib/utils.js
@@ -37,7 +37,7 @@ var utils = {
    */
 
   stripQueryStringFromPath: function stripQueryStringFromPath(path) {
-    return path.split('?')[0];
+    return path ? path.split('?')[0] : '';
   },
 
   /**

--- a/packages/core/test-d/index.test-d.ts
+++ b/packages/core/test-d/index.test-d.ts
@@ -98,8 +98,8 @@ expectType<boolean>(AWSXRay.utils.LambdaUtils.validTraceData());
 expectType<boolean>(AWSXRay.utils.LambdaUtils.populateTraceData(segment, 'moop'));
 expectType<{ [key: string]: string }>(AWSXRay.utils.processTraceData());
 expectType<{ [key: string]: string }>(AWSXRay.utils.processTraceData('Root=1-58ed6027-14afb2e09172c337713486c0;'));
-const urlWithoutQuery: Omit<url.UrlWithStringQuery, 'query'> = AWSXRay.utils.objectWithoutProperties(
-  url.parse('url'), ['query'],
+const urlWithoutQuery: Omit<url.URL, 'hash'> = AWSXRay.utils.objectWithoutProperties(
+  new url.URL('url'), ['hash'],
   true
 );
 expectError(urlWithoutQuery.query);

--- a/packages/core/test/unit/patchers/http_p.test.js
+++ b/packages/core/test/unit/patchers/http_p.test.js
@@ -3,7 +3,7 @@ var expect = require('chai').expect;
 var chai = require('chai');
 var sinon = require('sinon');
 var sinonChai = require('sinon-chai');
-var URL = require('url');
+var url = require('url');
 var events = require('events');
 
 var captureHTTPs = require('../../../lib/patchers/http_p').captureHTTPs;
@@ -114,7 +114,6 @@ describe('HTTP/S', function() {
 
       resolveManualStub = sandbox.stub(contextUtils, 'resolveManualSegmentParams');
       sandbox.stub(contextUtils, 'isAutomaticMode').returns(true);
-      sandbox.stub(contextUtils, 'resolveSegment').returns(segment);
       addRemoteDataStub = sandbox.stub(subsegment, 'addRemoteRequestData').returns();
       closeStub = sandbox.stub(subsegment, 'close').returns();
 
@@ -128,290 +127,322 @@ describe('HTTP/S', function() {
       sandbox.restore();
     });
 
-    describe('on invocation', function() {
-      var capturedHttp, fakeRequest, fakeResponse, httpClient, requestSpy, resumeSpy, sandbox;
-
-      beforeEach(function() {
-        sandbox = sinon.createSandbox();
-        segment = new Segment('test', traceId);
-
-        fakeRequest = buildFakeRequest();
-        fakeResponse = buildFakeResponse();
-        fakeResponse.req = fakeRequest;
-
-        httpClient = { request: function(...args) {
-          const callback = args[typeof args[1] === 'object' ? 2 : 1];
-          callback(fakeResponse);
-          return fakeRequest;
-        }};
-        httpClient.get = httpClient.request;
-
-        resumeSpy = sandbox.spy(fakeResponse, 'resume');
-        requestSpy = sandbox.spy(httpClient, 'request');
-        capturedHttp = captureHTTPs(httpClient, true);
+    describe('#withContextAvailable', () => {
+      beforeEach(() => {
+        sandbox.stub(contextUtils, 'resolveSegment').returns(segment);
       });
 
-      afterEach(function() {
+      afterEach(() => {
         sandbox.restore();
       });
 
-      it('should call to resolve any manual params', function() {
-        var options = {hostname: 'hostname', path: '/'};
-        capturedHttp.request(options);
+      describe('on invocation', function() {
+        var capturedHttp, fakeRequest, fakeResponse, httpClient, requestSpy, resumeSpy, sandbox;
 
-        resolveManualStub.should.have.been.calledWith(options);
-      });
+        beforeEach(function() {
+          sandbox = sinon.createSandbox();
+          segment = new Segment('test', traceId);
 
-      it('should consume the response if no callback is provided by user', function() {
-        capturedHttp.request(httpOptions);  // no callback
-        resumeSpy.should.have.been.calledOnce;
-      });
-
-      it('should not consume the response if a callback is provided by user', function() {
-        capturedHttp.request(httpOptions, () => {});
-        resumeSpy.should.not.have.been.called;
-      });
-
-      it('should not consume the response if a response listener is provided by user', function() {
-        fakeRequest.on('response', () => {});
-        capturedHttp.request(httpOptions);
-        resumeSpy.should.not.have.been.called;
-      });
-
-      it('should create a new subsegment with name as hostname', function() {
-        var options = {hostname: 'hostname', path: '/'};
-        capturedHttp.request(options);
-        newSubsegmentStub.should.have.been.calledWith(options.hostname);
-      });
-
-      it('should create a new subsegment with name as host when hostname is missing', function() {
-        capturedHttp.request(httpOptions);
-        newSubsegmentStub.should.have.been.calledWith(httpOptions.host);
-      });
-
-      it('should create a new subsegment with name as "Unknown host" when host and hostname is missing', function() {
-        capturedHttp.request({path: '/'});
-        newSubsegmentStub.should.have.been.calledWith('Unknown host');
-      });
-
-      it('should pass when a string is passed', function() {
-        capturedHttp.request('http://hostname/api');
-        newSubsegmentStub.should.have.been.calledWith('hostname');
-        capturedHttp.get('http://hostname/api');
-        newSubsegmentStub.should.have.been.calledWith('hostname');
-      });
-
-      it('should pass when a URL is passed', function() {
-        var options = URL.parse('http://hostname/api');
-        capturedHttp.request(options);
-        newSubsegmentStub.should.have.been.calledWith('hostname');
-      });
-
-      it('should call the base method', function() {
-        capturedHttp.request({'Segment': segment});
-        assert(requestSpy.called);
-      });
-
-      it('should attach an event handler to the "end" event', function() {
-        capturedHttp.request(httpOptions);
-        assert.isFunction(fakeResponse._events.end);
-      });
-
-      it('should inject the tracing headers', function() {
-        capturedHttp.request(httpOptions);
-
-        // example: 'Root=1-59138384-82ff54d5ba9282f0c680adb3;Parent=53af362e4e4efeb8;Sampled=1'
-        var xAmznTraceId = new RegExp('^Root=' + traceId + ';Parent=([a-f0-9]{16});Sampled=1$');
-        var options = requestSpy.firstCall.args[0];
-        assert.match(options.headers['X-Amzn-Trace-Id'], xAmznTraceId);
-      });
-
-      it('should inject the tracing headers into the options if a URL is also provided', function() {
-        capturedHttp.request(`http://${httpOptions.host}${httpOptions.path}`, httpOptions);
-
-        // example: 'Root=1-59138384-82ff54d5ba9282f0c680adb3;Parent=53af362e4e4efeb8;Sampled=1'
-        var xAmznTraceId = new RegExp('^Root=' + traceId + ';Parent=([a-f0-9]{16});Sampled=1$');
-        var options = requestSpy.firstCall.args[1];
-        assert.match(options.headers['X-Amzn-Trace-Id'], xAmznTraceId);
-      });
-
-      it('should return the request object', function() {
-        var request = capturedHttp.request(httpOptions);
-        assert.equal(request, fakeRequest);
-      });
-    });
-
-    describe('on the "end" event', function() {
-      var capturedHttp, fakeRequest, fakeResponse, httpClient, sandbox;
-
-      beforeEach(function() {
-        sandbox = sinon.createSandbox();
-
-        fakeRequest = buildFakeRequest();
-        fakeResponse = buildFakeResponse();
-        // We need to manually link resume and end to mimic the real response
-        // per https://nodejs.org/api/http.html#http_class_http_clientrequest
-        fakeResponse.resume = function() {
-          fakeResponse.emit('end');
-        };
-
-        httpClient = { request: function(options, callback) {
+          fakeRequest = buildFakeRequest();
+          fakeResponse = buildFakeResponse();
           fakeResponse.req = fakeRequest;
-          callback(fakeResponse);
-          return fakeRequest;
-        }};
 
-        capturedHttp = captureHTTPs(httpClient);
+          httpClient = { request: function(...args) {
+            const callback = args[typeof args[1] === 'object' ? 2 : 1];
+            callback(fakeResponse);
+            return fakeRequest;
+          }};
+          httpClient.get = httpClient.request;
+
+          resumeSpy = sandbox.spy(fakeResponse, 'resume');
+          requestSpy = sandbox.spy(httpClient, 'request');
+          capturedHttp = captureHTTPs(httpClient, true);
+        });
+
+        afterEach(function() {
+          sandbox.restore();
+        });
+
+        it('should call to resolve any manual params', function() {
+          var options = {hostname: 'hostname', path: '/'};
+          capturedHttp.request(options);
+
+          resolveManualStub.should.have.been.calledWith(options);
+        });
+
+        it('should consume the response if no callback is provided by user', function() {
+          capturedHttp.request(httpOptions);  // no callback
+          resumeSpy.should.have.been.calledOnce;
+        });
+
+        it('should not consume the response if a callback is provided by user', function() {
+          capturedHttp.request(httpOptions, () => {});
+          resumeSpy.should.not.have.been.called;
+        });
+
+        it('should not consume the response if a response listener is provided by user', function() {
+          fakeRequest.on('response', () => {});
+          capturedHttp.request(httpOptions);
+          resumeSpy.should.not.have.been.called;
+        });
+
+        it('should create a new subsegment with name as hostname', function() {
+          var options = {hostname: 'hostname', path: '/'};
+          capturedHttp.request(options);
+          newSubsegmentStub.should.have.been.calledWith(options.hostname);
+        });
+
+        it('should create a new subsegment with name as host when hostname is missing', function() {
+          capturedHttp.request(httpOptions);
+          newSubsegmentStub.should.have.been.calledWith(httpOptions.host);
+        });
+
+        it('should create a new subsegment with name as "Unknown host" when host and hostname is missing', function() {
+          capturedHttp.request({path: '/'});
+          newSubsegmentStub.should.have.been.calledWith('Unknown host');
+        });
+
+        it('should pass when a string is passed', function() {
+          capturedHttp.request('http://hostname/api');
+          newSubsegmentStub.should.have.been.calledWith('hostname');
+          capturedHttp.get('http://hostname/api');
+          newSubsegmentStub.should.have.been.calledWith('hostname');
+        });
+
+        it('should pass when a URL is passed', function() {
+          var options = new url.URL('http://hostname/api');
+          capturedHttp.request(options);
+          newSubsegmentStub.should.have.been.calledWith('hostname');
+        });
+
+        it('should call the base method', function() {
+          capturedHttp.request({'Segment': segment});
+          assert(requestSpy.called);
+        });
+
+        it('should attach an event handler to the "end" event', function() {
+          capturedHttp.request(httpOptions);
+          assert.isFunction(fakeResponse._events.end);
+        });
+
+        it('should inject the tracing headers', function() {
+          capturedHttp.request(httpOptions);
+
+          // example: 'Root=1-59138384-82ff54d5ba9282f0c680adb3;Parent=53af362e4e4efeb8;Sampled=1'
+          var xAmznTraceId = new RegExp('^Root=' + traceId + ';Parent=([a-f0-9]{16});Sampled=1$');
+          var options = requestSpy.firstCall.args[0];
+          assert.match(options.headers['X-Amzn-Trace-Id'], xAmznTraceId);
+        });
+
+        it('should inject the tracing headers into the options if a URL is also provided', function() {
+          capturedHttp.request(`http://${httpOptions.host}${httpOptions.path}`, httpOptions);
+
+          // example: 'Root=1-59138384-82ff54d5ba9282f0c680adb3;Parent=53af362e4e4efeb8;Sampled=1'
+          var xAmznTraceId = new RegExp('^Root=' + traceId + ';Parent=([a-f0-9]{16});Sampled=1$');
+          var options = requestSpy.firstCall.args[1];
+          assert.match(options.headers['X-Amzn-Trace-Id'], xAmznTraceId);
+        });
+
+        it('should return the request object', function() {
+          var request = capturedHttp.request(httpOptions);
+          assert.equal(request, fakeRequest);
+        });
       });
 
-      afterEach(function() {
-        sandbox.restore();
-        delete segment.notTraced;
+      describe('on the "end" event', function() {
+        var capturedHttp, fakeRequest, fakeResponse, httpClient, sandbox;
+
+        beforeEach(function() {
+          sandbox = sinon.createSandbox();
+
+          fakeRequest = buildFakeRequest();
+          fakeResponse = buildFakeResponse();
+          // We need to manually link resume and end to mimic the real response
+          // per https://nodejs.org/api/http.html#http_class_http_clientrequest
+          fakeResponse.resume = function() {
+            fakeResponse.emit('end');
+          };
+
+          httpClient = { request: function(options, callback) {
+            fakeResponse.req = fakeRequest;
+            callback(fakeResponse);
+            return fakeRequest;
+          }};
+
+          capturedHttp = captureHTTPs(httpClient);
+        });
+
+        afterEach(function() {
+          sandbox.restore();
+          delete segment.notTraced;
+        });
+
+        it('should not set "http.traced" if the enableXRayDownstream flag is not set', function(done) {
+          fakeResponse.statusCode = 200;
+          capturedHttp.request(httpOptions);
+
+          setTimeout(function() {
+            addRemoteDataStub.should.have.been.calledWithExactly(fakeRequest, fakeResponse, false);
+            done();
+          }, 50);
+        });
+
+        it('should set "http.traced" on the subsegment if the root is sampled and enableXRayDownstream is set', function(done) {
+          capturedHttp = captureHTTPs(httpClient, true);
+          fakeResponse.statusCode = 200;
+          capturedHttp.request(httpOptions);
+
+          setTimeout(function() {
+            addRemoteDataStub.should.have.been.calledWithExactly(fakeRequest, fakeResponse, true);
+            done();
+          }, 50);
+        });
+
+        it('should call any custom subsegment callback', function(done) {
+          var subsegmentCallback = sandbox.spy();
+          capturedHttp = captureHTTPs(httpClient, true, subsegmentCallback);
+          fakeResponse.statusCode = 200;
+          capturedHttp.request(httpOptions);
+
+          setTimeout(function() {
+            subsegmentCallback.should.have.been.calledWithExactly(subsegment, fakeRequest, fakeResponse);
+            done();
+          }, 50);
+        });
+
+        it('should close the subsegment', function(done) {
+          fakeResponse.statusCode = 200;
+          capturedHttp.request(httpOptions);
+
+          setTimeout(function() {
+            closeStub.should.have.been.calledWithExactly();
+            done();
+          }, 50);
+        });
+
+        it('should flag the subsegment as throttled if status code 429 is seen', function(done) {
+          var addThrottleStub = sandbox.stub(subsegment, 'addThrottleFlag');
+
+          fakeResponse.statusCode = 429;
+          capturedHttp.request(httpOptions);
+
+          setTimeout(function() {
+            addThrottleStub.should.have.been.calledOnce;
+            done();
+          }, 50);
+        });
+
+        it('should check the cause of the http status code', function(done) {
+          var utilsCodeStub = sandbox.stub(Utils, 'getCauseTypeFromHttpStatus');
+
+          fakeResponse.statusCode = 500;
+          capturedHttp.request(httpOptions);
+
+          setTimeout(function() {
+            utilsCodeStub.should.have.been.calledWith(fakeResponse.statusCode);
+            done();
+          }, 50);
+        });
       });
 
-      it('should not set "http.traced" if the enableXRayDownstream flag is not set', function(done) {
-        fakeResponse.statusCode = 200;
-        capturedHttp.request(httpOptions);
+      describe('when the request "error" event fires', function() {
+        var capturedHttp, error, fakeRequest, httpClient, req, sandbox, subsegmentCallback;
 
-        setTimeout(function() {
-          addRemoteDataStub.should.have.been.calledWithExactly(fakeRequest, fakeResponse, false);
-          done();
-        }, 50);
-      });
+        beforeEach(function() {
+          sandbox = sinon.createSandbox();
 
-      it('should set "http.traced" on the subsegment if the root is sampled and enableXRayDownstream is set', function(done) {
-        capturedHttp = captureHTTPs(httpClient, true);
-        fakeResponse.statusCode = 200;
-        capturedHttp.request(httpOptions);
+          httpClient = { request: function() {} };
 
-        setTimeout(function() {
-          addRemoteDataStub.should.have.been.calledWithExactly(fakeRequest, fakeResponse, true);
-          done();
-        }, 50);
-      });
+          subsegmentCallback = sandbox.spy();
+          capturedHttp = captureHTTPs(httpClient, null, subsegmentCallback);
 
-      it('should call any custom subsegment callback', function(done) {
-        var subsegmentCallback = sandbox.spy();
-        capturedHttp = captureHTTPs(httpClient, true, subsegmentCallback);
-        fakeResponse.statusCode = 200;
-        capturedHttp.request(httpOptions);
+          fakeRequest = buildFakeRequest();
 
-        setTimeout(function() {
-          subsegmentCallback.should.have.been.calledWithExactly(subsegment, fakeRequest, fakeResponse);
-          done();
-        }, 50);
-      });
+          sandbox.stub(capturedHttp, '__request').returns(fakeRequest);
+          error = {};
 
-      it('should close the subsegment', function(done) {
-        fakeResponse.statusCode = 200;
-        capturedHttp.request(httpOptions);
+          req = capturedHttp.request(httpOptions);
+        });
 
-        setTimeout(function() {
-          closeStub.should.have.been.calledWithExactly();
-          done();
-        }, 50);
-      });
+        afterEach(function() {
+          sandbox.restore();
+        });
 
-      it('should flag the subsegment as throttled if status code 429 is seen', function(done) {
-        var addThrottleStub = sandbox.stub(subsegment, 'addThrottleFlag');
+        // (request -> ECONNREFUSED -> error event).
+        // The way I verify if 'end' fired is if the subsegment.http.response was captured on the alternate code path.
+        // The only way to trigger this is a ECONNREFUSED error, as it is the only event which fires and has no response object.
 
-        fakeResponse.statusCode = 429;
-        capturedHttp.request(httpOptions);
+        it('should capture the request ECONNREFUSED error', function(done) {
+          fakeRequest.on('error', function() {});
+          fakeRequest.emit('error', error);
 
-        setTimeout(function() {
-          addThrottleStub.should.have.been.calledOnce;
-          done();
-        }, 50);
-      });
+          setTimeout(function() {
+            addRemoteDataStub.should.have.been.calledWith(req);
+            closeStub.should.have.been.calledWithExactly(error);
+            subsegmentCallback.should.have.been.calledWithExactly(subsegment, fakeRequest, null, error);
+            done();
+          }, 50);
+        });
 
-      it('should check the cause of the http status code', function(done) {
-        var utilsCodeStub = sandbox.stub(Utils, 'getCauseTypeFromHttpStatus');
+        // (request -> end event, then if error -> error event)
+        // sets subsegment.http = { response: { status: 500 }} to set the state that the 'end' event fired.
 
-        fakeResponse.statusCode = 500;
-        capturedHttp.request(httpOptions);
+        it('should capture the request code error', function(done) {
+          subsegment.http = { response: { status: 500 }};
+          fakeRequest.on('error', function() {});
+          fakeRequest.emit('error', error);
 
-        setTimeout(function() {
-          utilsCodeStub.should.have.been.calledWith(fakeResponse.statusCode);
-          done();
-        }, 50);
-      });
-    });
+          setTimeout(function() {
+            closeStub.should.have.been.calledWithExactly(error, true);
+            done();
+          }, 50);
+        });
 
-    describe('when the request "error" event fires', function() {
-      var capturedHttp, error, fakeRequest, httpClient, req, sandbox, subsegmentCallback;
-
-      beforeEach(function() {
-        sandbox = sinon.createSandbox();
-
-        httpClient = { request: function() {} };
-
-        subsegmentCallback = sandbox.spy();
-        capturedHttp = captureHTTPs(httpClient, null, subsegmentCallback);
-
-        fakeRequest = buildFakeRequest();
-
-        sandbox.stub(capturedHttp, '__request').returns(fakeRequest);
-        error = {};
-
-        req = capturedHttp.request(httpOptions);
-      });
-
-      afterEach(function() {
-        sandbox.restore();
-      });
-
-      // (request -> ECONNREFUSED -> error event).
-      // The way I verify if 'end' fired is if the subsegment.http.response was captured on the alternate code path.
-      // The only way to trigger this is a ECONNREFUSED error, as it is the only event which fires and has no response object.
-
-      it('should capture the request ECONNREFUSED error', function(done) {
-        fakeRequest.on('error', function() {});
-        fakeRequest.emit('error', error);
-
-        setTimeout(function() {
-          addRemoteDataStub.should.have.been.calledWith(req);
-          closeStub.should.have.been.calledWithExactly(error);
-          subsegmentCallback.should.have.been.calledWithExactly(subsegment, fakeRequest, null, error);
-          done();
-        }, 50);
-      });
-
-      // (request -> end event, then if error -> error event)
-      // sets subsegment.http = { response: { status: 500 }} to set the state that the 'end' event fired.
-
-      it('should capture the request code error', function(done) {
-        subsegment.http = { response: { status: 500 }};
-        fakeRequest.on('error', function() {});
-        fakeRequest.emit('error', error);
-
-        setTimeout(function() {
-          closeStub.should.have.been.calledWithExactly(error, true);
-          done();
-        }, 50);
-      });
-
-      it('should re-emit the error if unhandled', function() {
-        assert.throws(function() { fakeRequest.emitter.emit('error', error); });
-      });
-
-      it('should call any custom subsegment callback', function(done) {
-        fakeRequest.on('error', function() {});
-        fakeRequest.emit('error', error);
-
-        setTimeout(function() {
-          subsegmentCallback.should.have.been.calledWithExactly(subsegment, fakeRequest, null, error);
-          done();
-        }, 50);
-      });
-
-      if (process.version.startsWith('v') && process.version >= 'v12.17') {
-        it('should still re-emit if there are multiple errorMonitors attached', function() {
-          fakeRequest.on(events.errorMonitor, function() {});
-          fakeRequest.on(events.errorMonitor, function() {});
-
+        it('should re-emit the error if unhandled', function() {
           assert.throws(function() { fakeRequest.emitter.emit('error', error); });
         });
-      }
+
+        it('should call any custom subsegment callback', function(done) {
+          fakeRequest.on('error', function() {});
+          fakeRequest.emit('error', error);
+
+          setTimeout(function() {
+            subsegmentCallback.should.have.been.calledWithExactly(subsegment, fakeRequest, null, error);
+            done();
+          }, 50);
+        });
+
+        if (process.version.startsWith('v') && process.version >= 'v12.17') {
+          it('should still re-emit if there are multiple errorMonitors attached', function() {
+            fakeRequest.on(events.errorMonitor, function() {});
+            fakeRequest.on(events.errorMonitor, function() {});
+
+            assert.throws(function() { fakeRequest.emitter.emit('error', error); });
+          });
+        }
+      });
+    });
+
+    describe('#withoutContextAvailable', function() {
+      let capturedHttp, httpClient, fakeRequest;
+      beforeEach(() => {
+        fakeRequest = {'foo': 'bar'};
+        httpClient = { request: () => {
+          return fakeRequest;
+        }};
+        capturedHttp = captureHTTPs(httpClient, true);
+        sandbox.stub(contextUtils, 'resolveSegment').returns(null);
+      });
+
+      afterEach(() => {
+        sandbox.restore();
+      });
+
+      it('should return the original request without making a subsegment', () => {
+        const request = capturedHttp.request(new url.URL('http://amazon.com'));
+        assert.equal(request, fakeRequest);
+        expect(newSubsegmentStub).not.to.be.called;
+      });
     });
   });
 });

--- a/packages/core/test/unit/utils.test.js
+++ b/packages/core/test/unit/utils.test.js
@@ -20,12 +20,20 @@ describe('Utils', function() {
   });
 
   describe('#stripQueryStringFromPath', function() {
+    it('should do nothing for pathnames without query string', function() {
+      assert.equal(Utils.stripQueryStringFromPath('/index.html'), '/index.html');
+    });
+
     it('should remove query string for simple path', function() {
       assert.equal(Utils.stripQueryStringFromPath('/index.html?page=12'), '/index.html');
     });
 
     it('should remove query string for complex path', function() {
       assert.equal(Utils.stripQueryStringFromPath('/really/long/path/to/content.html?page=12'), '/really/long/path/to/content.html');
+    });
+
+    it('should return empty string on falsy inputs', function() {
+      assert.equal(Utils.stripQueryStringFromPath(undefined), '');
     });
   });
 


### PR DESCRIPTION
*Issue #, if available:*
#344

*Description of changes:*
* Replace usages of `url.parse` with `new url.URL()`, the recommended approach since `url.parse` is being [deprecated](https://nodejs.org/dist/latest-v12.x/docs/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost).
* Ensure that we do not crash when patching a request made with a WHATWG URL object by reading its properties correctly and making `stripQueryStringFromPath` safer.
* Added unit tests and tested on my sample app.

NOTE: almost all of the diff in `http_p.test.js` is just whitespace, only the very last test is new with this PR. I had to refactor the testing structure to add a test case for the context-missing logic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
