### PR TITLE
Make @types/cls-hooked a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "devDependencies": {
     "@hapi/hapi": "^20.0.0",
     "@types/chai": "^4.2.12",
-    "@types/cls-hooked": "^4.2.2",
     "@types/koa": "^2.11.3",
     "@types/mocha": "^8.0.0",
     "@types/node": "^10.17.28",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "@hapi/hapi": "^20.0.0",
     "@types/chai": "^4.2.12",
+    "@types/cls-hooked": "^4.2.2",
     "@types/koa": "^2.11.3",
     "@types/mocha": "^8.0.0",
     "@types/node": "^10.17.28",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,6 @@
     "test": "test"
   },
   "dependencies": {
-    "@types/cls-hooked": "*",
     "atomic-batcher": "^1.0.2",
     "cls-hooked": "^4.2.2",
     "pkginfo": "^0.4.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,9 @@
   "directories": {
     "test": "test"
   },
+  "//": "@types/cls-hooked is exposed in API so must be in dependencies, not devDependencies",
   "dependencies": {
+    "@types/cls-hooked": "^4.2.2",
     "atomic-batcher": "^1.0.2",
     "cls-hooked": "^4.2.2",
     "pkginfo": "^0.4.0",


### PR DESCRIPTION
*Description of changes:*
Type defs are not needed at runtime and should therefore be dev dependencies.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
