### PR TITLE
Fix: mysql2 query argument order compatibility

### DIFF
--- a/packages/mysql/lib/mysql_p.js
+++ b/packages/mysql/lib/mysql_p.js
@@ -142,8 +142,20 @@ function resolveArguments(argsObj) {
   if (argsObj && argsObj.length > 0) {
     if (argsObj[0] instanceof Object) {
       args.sql = argsObj[0];
-      args.values = argsObj[0].values;
-      args.callback = argsObj[1];
+      
+      // Patch for mysql2
+      if (argsObj[0].values) {
+        args.values = argsObj[0].values; // mysql implementation
+      } else if(typeof argsObj[2] === 'function'){
+        args.values = typeof argsObj[1] !== 'function' ? argsObj[1] : null; // mysql2 implementation
+      }
+      args.callback = typeof argsObj[1] === 'function'
+        ? argsObj[1] 
+        : (
+          typeof argsObj[2] === 'function'
+            ? argsObj[2] 
+            : undefined
+          );
       if (!argsObj[1] && argsObj[0].on instanceof Function) args.sql = argsObj[0];
     } else {
       args.sql = argsObj[0];


### PR DESCRIPTION
*Issue #:* #380

*Description of changes:*

Fixes issue with `mysql2` driver where x-ray monkey patch for`connection.query` and `connection.execute` incorrectly parsed arguments. Specificlly `mysql2` argument order is: 
* 1st argument is of type Object;
* 2nd argument is an array of values for binding to sql query; and
* 3rd argument is callback.

*Unit tests added:*
1. Tests if arguments are correctly parsed and sent to base mysql2 query driver

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
