### PR TITLE
Enable optional SQL query capture for PostgreSQL

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -59,6 +59,7 @@ section for different usages.
     AWS_XRAY_DAEMON_ADDRESS          For setting the daemon address and port.
     AWS_XRAY_CONTEXT_MISSING         For setting the SDK behavior when trace context is missing. Valid values are 'RUNTIME_ERROR', 'IGNORE_ERROR' or 'LOG_ERROR'. The SDK's default behavior is 'RUNTIME_ERROR'.
     AWS_XRAY_LOG_LEVEL               Sets a log level for the SDK built in logger. This value is ignored if AWS_XRAY_DEBUG_MODE is set.
+    AWS_XRAY_COLLECT_SQL_QUERIES     Enables SQL query capture (currently only Postgres supported)
 
 ### Daemon configuration
 

--- a/packages/postgres/lib/postgres_p.js
+++ b/packages/postgres/lib/postgres_p.js
@@ -133,6 +133,9 @@ function createSqlData(connParams, query) {
   var data = new SqlData(DATABASE_VERS, DRIVER_VERS, connParams.user,
     connParams.host + ':' + connParams.port + '/' + connParams.database,
     queryType);
+  if (process.env.AWS_XRAY_COLLECT_SQL_QUERIES) {
+    data.sanitized_query = query.text;
+  }
 
   return data;
 }


### PR DESCRIPTION
*Issue #9*

*Description of changes:*
Add an optional possibility to capture PostgreSQL SQL query and include it in subsegment data.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
