### PR TITLE
Deprecate package-specific changelogs

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog for AWS X-Ray Core SDK for JavaScript
+
+**Beginning after v3.2.0, ChangeLog entries for this package are recorded in the [top-level CHANGELOG file](../../CHANGELOG.md).**
+
 <!--LATEST=3.2.0-->
 <!--ENTRYINSERT-->
 ## 3.2.0

--- a/packages/express/CHANGELOG.md
+++ b/packages/express/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog for AWS X-Ray SDK Express for JavaScript
+
+**Beginning after v3.2.0, ChangeLog entries for this package are recorded in the [top-level CHANGELOG file](../../CHANGELOG.md).**
+
 <!--LATEST=3.2.0-->
 <!--ENTRYINSERT-->
 ## 2.5.0


### PR DESCRIPTION
*Description of changes:*
We should store all changelog entries for the entire repo in a single CHANGELOG file at the root of the repo, as is standard practice for monorepos, to avoid confusion. This PR adds a note that future CHANGELOG entries will only be added to the top-level CHANGELOG.md file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
