### PR TITLE
Add proper TypeScript build logic

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -40,6 +40,20 @@ jobs:
           path: $HOME/.npm
           key: ${{ matrix.os }}-${{ hashFiles('package-lock.json') }}
 
+      - name: Install rsync on Windows
+        if: matrix.os == 'windows-latest'
+        run: |
+          ls -al C:/Program Files/Git/usr/bin/
+          echo "performing curl!"
+          curl -sLO http://repo.msys2.org/msys/x86_64/rsync-3.2.3-1-x86_64.pkg.tar.zst
+          echo "decompressing!"
+          ls -al
+          tar -xf rsync-3.2.3-1-x86_64.pkg.tar.zst
+          echo "copying!"
+          ls -al
+          cp rsync.exe C:/Program Files/Git/usr/bin/
+
+
       - name: Execute tests with Lerna
         if: '!matrix.coverage'
         run: |

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -43,7 +43,6 @@ jobs:
       - name: Install rsync on Windows
         if: matrix.os == 'windows-latest'
         run: |
-          ls C:\Program Files\Git\usr\bin\
           echo "performing curl!"
           curl -sLO http://repo.msys2.org/msys/x86_64/rsync-3.2.3-1-x86_64.pkg.tar.zst
           echo "decompressing!"
@@ -51,7 +50,7 @@ jobs:
           tar -xf rsync-3.2.3-1-x86_64.pkg.tar.zst
           echo "copying!"
           ls
-          cp rsync.exe C:/Program Files/Git/usr/bin/
+          cp rsync.exe "C:/Program Files/Git/usr/bin/"
 
 
       - name: Execute tests with Lerna

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -40,18 +40,18 @@ jobs:
           path: $HOME/.npm
           key: ${{ matrix.os }}-${{ hashFiles('package-lock.json') }}
 
-      - name: Install rsync on Windows
-        if: matrix.os == 'windows-latest'
-        run: |
-          ls "C:/Program Files/Git/usr/bin/"
-          echo "performing curl!"
-          curl -sLO http://repo.msys2.org/msys/x86_64/rsync-3.2.3-1-x86_64.pkg.tar.zst
-          echo "decompressing!"
-          ls
-          tar -I zstd -xf rsync-3.2.3-1-x86_64.pkg.tar.zst
-          echo "copying!"
-          ls
-          cp rsync.exe "C:/Program Files/Git/usr/bin/"
+      # - name: Install rsync on Windows
+      #   if: matrix.os == 'windows-latest'
+      #   run: |
+      #     ls "C:/Program Files/Git/usr/bin/"
+      #     echo "performing curl!"
+      #     curl -sLO http://repo.msys2.org/msys/x86_64/rsync-3.2.3-1-x86_64.pkg.tar.zst
+      #     echo "decompressing!"
+      #     ls
+      #     tar -I zstd -xf rsync-3.2.3-1-x86_64.pkg.tar.zst
+      #     echo "copying!"
+      #     ls
+      #     cp rsync.exe "C:/Program Files/Git/usr/bin/"
 
 
       - name: Execute tests with Lerna

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Install rsync on Windows
         if: matrix.os == 'windows-latest'
         run: |
+          ls "C:/Program Files/Git/usr/bin/"
           echo "performing curl!"
           curl -sLO http://repo.msys2.org/msys/x86_64/rsync-3.2.3-1-x86_64.pkg.tar.zst
           echo "decompressing!"

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -44,6 +44,7 @@ jobs:
         if: '!matrix.coverage'
         run: |
           npx lerna bootstrap --hoist
+          npx lerna run compile
           npx lerna run test
         shell: bash
         env:
@@ -55,6 +56,7 @@ jobs:
         if: matrix.coverage
         run: |
           npx lerna bootstrap --hoist
+          npx lerna run compile
           npx lerna run testcov
           npx lerna run reportcov
           echo test

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install rsync on Windows
         if: matrix.os == 'windows-latest'
         run: |
-          ls C:/Program Files/Git/usr/bin/
+          ls C:\Program Files\Git\usr\bin\
           echo "performing curl!"
           curl -sLO http://repo.msys2.org/msys/x86_64/rsync-3.2.3-1-x86_64.pkg.tar.zst
           echo "decompressing!"

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -40,20 +40,6 @@ jobs:
           path: $HOME/.npm
           key: ${{ matrix.os }}-${{ hashFiles('package-lock.json') }}
 
-      # - name: Install rsync on Windows
-      #   if: matrix.os == 'windows-latest'
-      #   run: |
-      #     ls "C:/Program Files/Git/usr/bin/"
-      #     echo "performing curl!"
-      #     curl -sLO http://repo.msys2.org/msys/x86_64/rsync-3.2.3-1-x86_64.pkg.tar.zst
-      #     echo "decompressing!"
-      #     ls
-      #     tar -I zstd -xf rsync-3.2.3-1-x86_64.pkg.tar.zst
-      #     echo "copying!"
-      #     ls
-      #     cp rsync.exe "C:/Program Files/Git/usr/bin/"
-
-
       - name: Execute tests with Lerna
         if: '!matrix.coverage'
         run: |

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
+    branches: [master, aws-v3-support]
 
 jobs:
   build:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -47,7 +47,7 @@ jobs:
           curl -sLO http://repo.msys2.org/msys/x86_64/rsync-3.2.3-1-x86_64.pkg.tar.zst
           echo "decompressing!"
           ls
-          tar -xf rsync-3.2.3-1-x86_64.pkg.tar.zst
+          tar -I zstd -xf rsync-3.2.3-1-x86_64.pkg.tar.zst
           echo "copying!"
           ls
           cp rsync.exe "C:/Program Files/Git/usr/bin/"

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -43,14 +43,14 @@ jobs:
       - name: Install rsync on Windows
         if: matrix.os == 'windows-latest'
         run: |
-          ls -al C:/Program Files/Git/usr/bin/
+          ls C:/Program Files/Git/usr/bin/
           echo "performing curl!"
           curl -sLO http://repo.msys2.org/msys/x86_64/rsync-3.2.3-1-x86_64.pkg.tar.zst
           echo "decompressing!"
-          ls -al
+          ls
           tar -xf rsync-3.2.3-1-x86_64.pkg.tar.zst
           echo "copying!"
-          ls -al
+          ls
           cp rsync.exe C:/Program Files/Git/usr/bin/
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Execute tests with Lerna
         run: |
           npx lerna bootstrap --hoist
+          npx lerna run compile
           npx lerna run test
 
       - name: Publish package to npm

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docs
 .idea/
 .nyc_output/
 *.lcov
+dist

--- a/README.md
+++ b/README.md
@@ -89,13 +89,17 @@ AWS will not:
 
 ## Testing from Source
 
-This repo uses [Lerna](https://lernajs.io) to manage multiple packages. To install Lerna:
+This repo uses [Lerna](https://lernajs.io) to manage multiple packages. To install Lerna as a CLI:
 ```
-npm install lerna
+npm install -g lerna
 ```
 To install devDependencies and peerDependencies for all packages:
 ```
 lerna bootstrap --hoist
+```
+This repo has a combination of TypeScript and JavaScript source files. To transpile the TypeScript files for testing, run:
+```
+lerna run compile
 ```
 To run tests for all packages:
 ```

--- a/README.md
+++ b/README.md
@@ -89,8 +89,6 @@ AWS will not:
 
 ## Testing from Source
 
-[rsync](https://linux.die.net/man/1/rsync) is used for builds and is a prerequisite for building the SDK.
-
 This repo uses [Lerna](https://lernajs.io) to manage multiple packages. To install Lerna as a CLI:
 ```
 npm install -g lerna

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ AWS will not:
 
 ## Testing from Source
 
+[rsync](https://linux.die.net/man/1/rsync) is used for builds and is a prerequisite for building the SDK.
+
 This repo uses [Lerna](https://lernajs.io) to manage multiple packages. To install Lerna as a CLI:
 ```
 npm install -g lerna

--- a/packages/core/lib/aws-xray.js
+++ b/packages/core/lib/aws-xray.js
@@ -9,7 +9,7 @@ var LambdaEnv = require('./env/aws_lambda');
 // pkginfo as an empty object
 var pkginfo = {}
 try {
-  pkginfo = require('../package.json');
+  pkginfo = require('../../package.json');
 } catch (err) {
   logging.getLogger().debug('Failed to load SDK data:', err);
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,8 +26,8 @@
   },
   "scripts": {
     "compile": "tsc && npm run copy-lib && npm run copy-test && cp package.json dist/",
-    "copy-lib": "rsync -a --include '*/' --include '*.d.ts'  --include '*.json' --exclude '*' lib/ dist/lib/",
-    "copy-test": "rsync -a --include '*/' --include '*.json' --exclude '*' test/ dist/test/",
+    "copy-lib": "find lib -type f \\( -name '*.d.ts' -o -name '*.json' \\) -exec ../../scripts/cp-with-structure.sh \\{\\} dist/lib \\;",
+    "copy-test": "find test -name '*.json' -exec ../../scripts/cp-with-structure.sh \\{\\} dist/test \\;",
     "test": "mocha --recursive ./dist/test/ -R spec && tsd && mocha --recursive ./dist/test_async/ -R spec",
     "test-d": "tsd",
     "test-async": "mocha --recursive ./dist/test_async/ -R spec",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,9 +25,11 @@
     "semver": "^5.3.0"
   },
   "scripts": {
-    "test": "mocha --recursive ./test/ -R spec && tsd && mocha --recursive ./test_async/ -R spec",
+    "compile": "tsc && rsync -a --prune-empty-dirs --include '*/' --include '*.d.ts'  --include '*.json' --exclude '*' lib/ dist/lib/",
+    "test": "mocha --recursive ./dist/test/ -R spec && tsd && mocha --recursive ./dist/test_async/ -R spec",
     "test-d": "tsd",
-    "test-async": "mocha --recursive ./test_async/ -R spec",
+    "test-async": "mocha --recursive ./dist/test_async/ -R spec",
+    "clean": "rm -rf dist && rm -rf node_modules",
     "testcov": "nyc npm run test",
     "reportcov": "nyc report --reporter=text-lcov > coverage.lcov && codecov"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,9 @@
     "semver": "^5.3.0"
   },
   "scripts": {
-    "compile": "tsc && rsync -a --prune-empty-dirs --include '*/' --include '*.d.ts'  --include '*.json' --exclude '*' lib/ dist/lib/",
+    "compile": "tsc && npm run copy-lib && npm run copy-test && cp package.json dist/",
+    "copy-lib": "rsync -a --include '*/' --include '*.d.ts'  --include '*.json' --exclude '*' lib/ dist/lib/",
+    "copy-test": "rsync -a --include '*/' --include '*.json' --exclude '*' test/ dist/test/",
     "test": "mocha --recursive ./dist/test/ -R spec && tsd && mocha --recursive ./dist/test_async/ -R spec",
     "test-d": "tsd",
     "test-async": "mocha --recursive ./dist/test_async/ -R spec",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,8 +26,8 @@
   },
   "scripts": {
     "compile": "tsc && npm run copy-lib && npm run copy-test && cp package.json dist/",
-    "copy-lib": "find lib -type f \\( -name '*.d.ts' -o -name '*.json' \\) -exec ../../scripts/cp-with-structure.sh \\{\\} dist \\;",
-    "copy-test": "find test -name '*.json' -exec ../../scripts/cp-with-structure.sh \\{\\} dist \\;",
+    "copy-lib": "find lib -type f \\( -name '*.d.ts' -o -name '*.json' \\) -exec sh ../../scripts/cp-with-structure.sh \\{\\} dist \\;",
+    "copy-test": "find test -name '*.json' -exec sh ../../scripts/cp-with-structure.sh \\{\\} dist \\;",
     "test": "mocha --recursive ./dist/test/ -R spec && tsd && mocha --recursive ./dist/test_async/ -R spec",
     "test-d": "tsd",
     "test-async": "mocha --recursive ./dist/test_async/ -R spec",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,8 +8,13 @@
     "William Armiros <armiros@amazon.com>",
     "Moritz Onken <onken@netcubed.de>"
   ],
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "files": [
+    "dist/lib/**/*",
+    "LICENSE",
+    "README.md"
+  ],
+  "main": "dist/lib/index.js",
+  "types": "dist/lib/index.d.ts",
   "engines": {
     "node": ">= 10.x"
   },
@@ -25,7 +30,8 @@
     "semver": "^5.3.0"
   },
   "scripts": {
-    "compile": "tsc && npm run copy-lib && npm run copy-test && cp package.json dist/",
+    "prepare": "npm run compile",
+    "compile": "tsc && npm run copy-lib && npm run copy-test",
     "copy-lib": "find lib -type f \\( -name '*.d.ts' -o -name '*.json' \\) | xargs -I % ../../scripts/cp-with-structure.sh % dist",
     "copy-test": "find test -name '*.json' | xargs -I % ../../scripts/cp-with-structure.sh % dist",
     "test": "mocha --recursive ./dist/test/ -R spec && tsd && mocha --recursive ./dist/test_async/ -R spec",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,8 +26,8 @@
   },
   "scripts": {
     "compile": "tsc && npm run copy-lib && npm run copy-test && cp package.json dist/",
-    "copy-lib": "find lib -type f \\( -name '*.d.ts' -o -name '*.json' \\) -exec ../../scripts/cp-with-structure.sh \\{\\} dist/lib \\;",
-    "copy-test": "find test -name '*.json' -exec ../../scripts/cp-with-structure.sh \\{\\} dist/test \\;",
+    "copy-lib": "find lib -type f \\( -name '*.d.ts' -o -name '*.json' \\) -exec ../../scripts/cp-with-structure.sh \\{\\} dist \\;",
+    "copy-test": "find test -name '*.json' -exec ../../scripts/cp-with-structure.sh \\{\\} dist \\;",
     "test": "mocha --recursive ./dist/test/ -R spec && tsd && mocha --recursive ./dist/test_async/ -R spec",
     "test-d": "tsd",
     "test-async": "mocha --recursive ./dist/test_async/ -R spec",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,8 +26,8 @@
   },
   "scripts": {
     "compile": "tsc && npm run copy-lib && npm run copy-test && cp package.json dist/",
-    "copy-lib": "find lib -type f \\( -name '*.d.ts' -o -name '*.json' \\) -exec sh ../../scripts/cp-with-structure.sh \\{\\} dist \\;",
-    "copy-test": "find test -name '*.json' -exec sh ../../scripts/cp-with-structure.sh \\{\\} dist \\;",
+    "copy-lib": "find lib -type f \\( -name '*.d.ts' -o -name '*.json' \\) | xargs -I % ../../scripts/cp-with-structure.sh % dist",
+    "copy-test": "find test -name '*.json' | xargs -I % ../../scripts/cp-with-structure.sh % dist",
     "test": "mocha --recursive ./dist/test/ -R spec && tsd && mocha --recursive ./dist/test_async/ -R spec",
     "test-d": "tsd",
     "test-async": "mocha --recursive ./dist/test_async/ -R spec",

--- a/packages/core/test/integration/segment_maintained_across_shared_promise.test.js
+++ b/packages/core/test/integration/segment_maintained_across_shared_promise.test.js
@@ -7,7 +7,7 @@ if (!global.Promise) {
 var assert = require('chai').assert;
 var http = require('http');
 
-var AWSXRay = require('../../');
+var AWSXRay = require('../../lib');
 var Segment = AWSXRay.Segment;
 
 AWSXRay.capturePromise();

--- a/packages/core/test/unit/aws-xray.test.js
+++ b/packages/core/test/unit/aws-xray.test.js
@@ -2,7 +2,6 @@ var assert = require('chai').assert;
 var chai = require('chai');
 var sinon = require('sinon');
 var sinonChai = require('sinon-chai');
-var upath = require('upath');
 
 var segmentUtils = require('../../lib/segments/segment_utils');
 
@@ -30,14 +29,12 @@ describe('AWSXRay', function() {
       // This test requires both index.js and aws-xray.js are first time required.
       // We should always clear the require cache for these two files so this test
       // could run independently.
-      Object.keys(require.cache).forEach(function(key) {
-        var normalisedPath = upath.toUnix(key);
-        if(normalisedPath.includes('core/lib/index.js') || normalisedPath.includes('core/lib/aws-xray.js')) {
-          delete require.cache[key];
-        }
-      });
+      const indexPath = '../../lib/index';
+      const xrayPath = '../../lib/aws-xray';
+      delete require.cache[require.resolve(indexPath)];
+      delete require.cache[require.resolve(xrayPath)];
 
-      AWSXRay = require('../../lib/index');
+      AWSXRay = require(indexPath);
 
       setSDKDataStub.should.have.been.calledWithExactly(sinon.match.object);
       setServiceDataStub.should.have.been.calledWithExactly(sinon.match.object);

--- a/packages/core/test/unit/env/aws_lambda.test.js
+++ b/packages/core/test/unit/env/aws_lambda.test.js
@@ -41,7 +41,7 @@ describe('AWSLambda', function() {
   });
 
   describe('#init', function() {
-    var disableReusableSocketStub, populateStub, sandbox, setSegmentStub, validateStub;
+    var disableReusableSocketStub, disableCentralizedSamplingStub, populateStub, sandbox, setSegmentStub, validateStub;
 
     beforeEach(function() {
       sandbox = sinon.createSandbox();

--- a/packages/core/test_async/integration/segment_maintained_across_awaited.test.js
+++ b/packages/core/test_async/integration/segment_maintained_across_awaited.test.js
@@ -1,6 +1,6 @@
 var assert = require('chai').assert;
 var http = require('http');
-var AWSXRay = require('../../');
+var AWSXRay = require('../../lib');
 var Segment = AWSXRay.Segment;
 
 AWSXRay.enableAutomaticMode();

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -4,8 +4,14 @@
     "target": "es2019",
     "strict": true,
     "strictNullChecks": true,
-    "declaration": true,
-    "esModuleInterop": true
+    "declaration": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "allowJs": true,
+    "checkJs": false,
+    "rootDir": ".",
+    "outDir": "dist",
   },
-  "files": ["lib/patchers/aws3_p.ts"]
+  "include": ["lib", "test", "test_async"],
+  "exclude": ["dist", "node_modules"]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -9,7 +9,6 @@
     "skipLibCheck": true,
     "allowJs": true,
     "checkJs": false,
-    "rootDir": ".",
     "outDir": "dist",
   },
   "include": ["lib", "test", "test_async"],

--- a/scripts/cp-with-structure.sh
+++ b/scripts/cp-with-structure.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+src=(${*: 1})
+dest=${*: -1:1}
+for filename in $src; do
+  [ -e "$filename" ] || continue
+  dirPath=$(dirname "${filename}")
+  mkdir -p $dest/$dirPath
+  cp -a $filename $dest/$dirPath
+done

--- a/scripts/cp-with-structure.sh
+++ b/scripts/cp-with-structure.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+## This script copies a file provided as the first parameter into the destination directory
+## provided by the second parameter, while maintaining the directory structure of the source
+## file. It is similar to 'cp --parents' on Linux, but usable cross-platform
 src=(${*: 1})
 dest=${*: -1:1}
 for filename in $src; do


### PR DESCRIPTION
*Issue #, if available:*
#411

*Description of changes:*
These changes allow the repo to conform to TypeScript best practices of not committing transpiled code to source control as we were doing before. Now, we have a `compile` target on the core package which should be run before testing or publishing the package. It transpiles the TypeScript in the source package, and copies the transpiled JavaScript and all other non-TS source files to a `dist` directory, which will ultimately be tested or vended to customers.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
