### PR TITLE
Added CI smoke test workflow

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           node-version: '14.x'
 
+      # Use npm pack to bundle individual packages into their final distribution tarball form
+      # Then aggregate all of those tarballs in the full_sdk package, to be used by smoke test
       - name: Pack SDK packages
         id: package
         run: |

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -22,24 +22,23 @@ jobs:
         run: |
           npm install typescript
           core_tar=$(cd packages/core && npm pack | tail -1)
-          echo "::set-output name=core::$core_tar"
           express_tar=$(cd packages/express && npm pack | tail -1)
-          echo "::set-output name=express::$express_tar"
           mysql_tar=$(cd packages/mysql && npm pack | tail -1)
-          echo "::set-output name=mysql::$mysql_tar"
           postgres_tar=$(cd packages/postgres && npm pack | tail -1)
-          echo "::set-output name=postgres::$postgres_tar"
-          full_tar=$(cd packages/full_sdk && npm pack | tail -1)
-          echo "::set-output name=full::$full_tar"
+          cd packages/full_sdk
+          npm install ../core/$core_tar
+          npm install ../express/$express_tar
+          npm install ../mysql/$mysql_tar
+          npm install ../postgres/$postgres_tar
+          full_tar=$(npm pack | tail -1)
+          echo "::set-output name=full_sdk::$full_tar"
 
       # Manually install the locally bundled packages first, then pull in other test dependencies from NPM
+      # Remove the entire source code directory to force smoke test to depend on packed tarball
       - name: Run smoke test
         run: |
           cd smoke_test
-          npm install ../packages/core/${{ steps.package.outputs.core }}
-          npm install ../packages/express/${{ steps.package.outputs.express }}
-          npm install ../packages/mysql/${{ steps.package.outputs.mysql }}
-          npm install ../packages/postgres/${{ steps.package.outputs.postgres }}
-          npm install ../packages/full_sdk/${{ steps.package.outputs.full }}
+          npm install ../packages/full_sdk/${{ steps.package.outputs.full_sdk }}
           npm install
+          rm -rf ../packages/
           npm run test-smoke

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Pack SDK packages
         id: package
         run: |
+          npm install typescript
           core_tar=$(cd packages/core && npm pack | tail -1)
           echo "::set-output name=core::$core_tar"
           express_tar=$(cd packages/express && npm pack | tail -1)

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,44 @@
+name: Node.js Continuous Integration Smoke Test
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  smoke-test:
+    name: Run smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout AWS XRay SDK Node Repository @ default branch latest
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+
+      - name: Pack SDK packages
+        id: package
+        run: |
+          core_tar=$(cd packages/core && npm pack | tail -1)
+          echo "::set-output name=core::$core_tar"
+          express_tar=$(cd packages/express && npm pack | tail -1)
+          echo "::set-output name=express::$express_tar"
+          mysql_tar=$(cd packages/mysql && npm pack | tail -1)
+          echo "::set-output name=mysql::$mysql_tar"
+          postgres_tar=$(cd packages/postgres && npm pack | tail -1)
+          echo "::set-output name=postgres::$postgres_tar"
+          full_tar=$(cd packages/full_sdk && npm pack | tail -1)
+          echo "::set-output name=full::$full_tar"
+
+      # Manually install the locally bundled packages first, then pull in other test dependencies from NPM
+      - name: Run smoke test
+        run: |
+          cd smoke_test
+          npm install ../packages/core/${{ steps.package.outputs.core }}
+          npm install ../packages/express/${{ steps.package.outputs.express }}
+          npm install ../packages/mysql/${{ steps.package.outputs.mysql }}
+          npm install ../packages/postgres/${{ steps.package.outputs.postgres }}
+          npm install ../packages/full_sdk/${{ steps.package.outputs.full }}
+          npm install
+          npm run test-smoke

--- a/packages/express/lib/express_mw.js
+++ b/packages/express/lib/express_mw.js
@@ -1,4 +1,5 @@
 const AWSXRay = require('aws-xray-sdk-core');
+const { logger } = require('aws-xray-sdk-core/lib/middleware/sampling/service_connector');
 
 const mwUtils = AWSXRay.middleware;
 

--- a/packages/express/lib/express_mw.js
+++ b/packages/express/lib/express_mw.js
@@ -1,5 +1,4 @@
 const AWSXRay = require('aws-xray-sdk-core');
-const { logger } = require('aws-xray-sdk-core/lib/middleware/sampling/service_connector');
 
 const mwUtils = AWSXRay.middleware;
 

--- a/smoke_test/package.json
+++ b/smoke_test/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "aws-xray-sdk": "*",
     "chai": "^4.3.4",
-    "mocha": "^8.0.1"
+    "mocha": "^8.0.1",
+    "typescript": "4.2.4"
   },
   "scripts": {
     "test-smoke": "mocha ./test/ -R spec"

--- a/smoke_test/test/smoke.test.js
+++ b/smoke_test/test/smoke.test.js
@@ -3,8 +3,8 @@ const AWSXRay = require('aws-xray-sdk');
 const Segment = AWSXRay.Segment;
 
 describe('Smoke Test', () => {
-	it('Segment', () => {
-		const segment = new Segment('test');
-		assert.equal(segment.name, 'test');
-	});
+  it('Segment', () => {
+    const segment = new Segment('test');
+    assert.equal(segment.name, 'test');
+  });
 });

--- a/smoke_test/test/smoke.test.js
+++ b/smoke_test/test/smoke.test.js
@@ -1,10 +1,10 @@
-var assert = require('chai').assert;
-var AWSXRay = require('aws-xray-sdk');
-var Segment = AWSXRay.Segment;
+const assert = require('chai').assert;
+const AWSXRay = require('aws-xray-sdk');
+const Segment = AWSXRay.Segment;
 
-describe('Smoke Test', function() {
-	it('Segment', function() {
-		var segment = new Segment('test');
-        assert.equal(segment.name, 'test');
+describe('Smoke Test', () => {
+	it('Segment', () => {
+		const segment = new Segment('test');
+		assert.equal(segment.name, 'test');
 	});
 });


### PR DESCRIPTION
*Issue #, if available:*
Prevent another #427

*Description of changes:*
Introduces a new workflow to be ran on all PRs, which runs our simple smoke test against the locally-packaged bundles that are identical to what the end-user would receive. We also remove all the original source code to ensure there are no conflicts with running the tests from within the repo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
