### PR TITLE
Fix crash when http/https libraries use getters

### DIFF
--- a/packages/core/lib/patchers/http_p.js
+++ b/packages/core/lib/patchers/http_p.js
@@ -196,14 +196,19 @@ function enableCapture(module, downstreamXRayEnabled, subsegmentCallback) {
   }
 
   module.__request = module.request;
-  module.request = function captureHTTPsRequest(...args) {
+  function captureHTTPsRequest(...args) {
     return captureOutgoingHTTPs(module.__request, ...args);
-  };
+  }
 
   module.__get = module.get;
-  module.get = function captureHTTPsGet(...args) {
+  function captureHTTPsGet(...args) {
     return captureOutgoingHTTPs(module.__get, ...args);
-  };
+  }
+
+  Object.defineProperties(module, {
+    request: { value: captureHTTPsRequest, configurable: true, enumerable: true, writable: true },
+    get: { value: captureHTTPsGet, configurable: true, enumerable: true, writable: true },
+  });
 }
 
 module.exports.captureHTTPsGlobal = captureHTTPsGlobal;


### PR DESCRIPTION
*Issue: #433*

*Description of changes:*

This works around an issue when using esbuild to bundle (e.g. using aws-lambda-nodejs)

The fix is adapted from:
https://github.com/follow-redirects/follow-redirects/pull/146

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

fixes #433 