### PR TITLE
Translate service name to lower case

### DIFF
--- a/packages/core/lib/segments/attributes/aws.js
+++ b/packages/core/lib/segments/attributes/aws.js
@@ -31,7 +31,7 @@ Aws.prototype.init = function init(res, serviceName) {
     this.id_2 = res.extendedRequestId;
   }
 
-  this.addData(capturer.capture(serviceName, res));
+  this.addData(capturer.capture(serviceName.toLowerCase(), res));
 };
 
 Aws.prototype.addData = function addData(data) {


### PR DESCRIPTION
*Issue #, if available:* #443

*Description of changes:* When using the AWS SDK v3, service names are uppercase. The `call_capturer` and whitelisting works under the assumption that all services are lower case and one word (this assumption was derived from the default whitelist). Switching the service name to lowercase stopped the debug logs from saying that calls weren't whitelisted.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

fixes #443 
