### PR TITLE
add null check to AWS capturer

### DIFF
--- a/packages/core/lib/segments/attributes/aws.js
+++ b/packages/core/lib/segments/attributes/aws.js
@@ -31,7 +31,9 @@ Aws.prototype.init = function init(res, serviceName) {
     this.id_2 = res.extendedRequestId;
   }
 
-  this.addData(capturer.capture(serviceName.toLowerCase(), res));
+  if (serviceName) {
+    this.addData(capturer.capture(serviceName.toLowerCase(), res));
+  }
 };
 
 Aws.prototype.addData = function addData(data) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Just extending #444 with a check for falsiness. `serviceName` *shouldn't* be undefined or null ever, but there's no way of guaranteeing that since it's a public API, and we don't want to crash.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
