### PR TITLE
Stop throwing unnecessary errors with adding annotations, metadata, errors

### DIFF
--- a/packages/core/lib/segments/attributes/subsegment.js
+++ b/packages/core/lib/segments/attributes/subsegment.js
@@ -122,11 +122,11 @@ Subsegment.prototype.addPrecursorId = function(id) {
  */
 
 Subsegment.prototype.addAnnotation = function(key, value) {
-  if (!(typeof value === 'boolean' || typeof value === 'string' || (typeof value === 'number' && isFinite(value)))) {
-    throw new Error('Failed to add annotation key: ' + key + ' value: ' + value + ' to subsegment ' +
+  if (typeof value !== 'boolean' && typeof value !== 'string' && !isFinite(value)) {
+    logger.getLogger().error('Failed to add annotation key: ' + key + ' value: ' + value + ' to subsegment ' +
       this.name + '. Value must be of type string, number or boolean.');
   } else if (typeof key !== 'string') {
-    throw new Error('Failed to add annotation key: ' + key + ' value: ' + value + ' to subsegment ' +
+    logger.getLogger().error('Failed to add annotation key: ' + key + ' value: ' + value + ' to subsegment ' +
       this.name + '. Key must be of type string.');
   }
 
@@ -147,10 +147,10 @@ Subsegment.prototype.addAnnotation = function(key, value) {
 
 Subsegment.prototype.addMetadata = function(key, value, namespace) {
   if (typeof key !== 'string') {
-    throw new Error('Failed to add annotation key: ' + key + ' value: ' + value + ' to subsegment ' +
+    logger.getLogger().error('Failed to add metadata key: ' + key + ' value: ' + value + ' to subsegment ' +
       this.name + '. Key must be of type string.');
   } else if (namespace && typeof namespace !== 'string') {
-    throw new Error('Failed to add annotation key: ' + key + ' value: ' + value + 'namespace: ' + namespace + ' to subsegment ' +
+    logger.getLogger().error('Failed to add metadata key: ' + key + ' value: ' + value + ' to subsegment ' +
       this.name + '. Namespace must be of type string.');
   }
 
@@ -164,7 +164,7 @@ Subsegment.prototype.addMetadata = function(key, value, namespace) {
     this.metadata[ns] = {};
   }
 
-  this.metadata[ns][key] = value;
+  this.metadata[ns][key] = value || '';
 };
 
 Subsegment.prototype.addSqlData = function addSqlData(sqlData) {
@@ -182,8 +182,9 @@ Subsegment.prototype.addSqlData = function addSqlData(sqlData) {
 
 Subsegment.prototype.addError = function addError(err, remote) {
   if (err == null || typeof err !== 'object' && typeof(err) !== 'string') {
-    throw new Error('Failed to add error:' + err + ' to subsegment "' + this.name +
-      '".  Not an object or string literal.');
+    logger.getLogger().error('Failed to add error:' + err + ' to subsegment "' + this.name +
+    '".  Not an object or string literal.');
+    return;
   }
 
   this.addFaultFlag();
@@ -323,8 +324,9 @@ Subsegment.prototype.isClosed = function isClosed() {
 
 Subsegment.prototype.flush = function flush() {
   if (!this.parent || !this.segment) {
-    throw new Error('Failed to flush subsegment: ' + this.name + '. Subsegment must be added ' +
+    logger.getLogger().error('Failed to flush subsegment: ' + this.name + '. Subsegment must be added ' +
       'to a segment chain to flush.');
+    return;
   }
 
   if (this.segment.trace_id) {

--- a/packages/core/lib/segments/attributes/subsegment.js
+++ b/packages/core/lib/segments/attributes/subsegment.js
@@ -125,9 +125,13 @@ Subsegment.prototype.addAnnotation = function(key, value) {
   if (typeof value !== 'boolean' && typeof value !== 'string' && !isFinite(value)) {
     logger.getLogger().error('Failed to add annotation key: ' + key + ' value: ' + value + ' to subsegment ' +
       this.name + '. Value must be of type string, number or boolean.');
-  } else if (typeof key !== 'string') {
+    return;
+  }
+
+  if (typeof key !== 'string') {
     logger.getLogger().error('Failed to add annotation key: ' + key + ' value: ' + value + ' to subsegment ' +
       this.name + '. Key must be of type string.');
+    return;
   }
 
   if (this.annotations === undefined) {
@@ -149,9 +153,13 @@ Subsegment.prototype.addMetadata = function(key, value, namespace) {
   if (typeof key !== 'string') {
     logger.getLogger().error('Failed to add metadata key: ' + key + ' value: ' + value + ' to subsegment ' +
       this.name + '. Key must be of type string.');
-  } else if (namespace && typeof namespace !== 'string') {
+    return;
+  }
+
+  if (namespace && typeof namespace !== 'string') {
     logger.getLogger().error('Failed to add metadata key: ' + key + ' value: ' + value + ' to subsegment ' +
       this.name + '. Namespace must be of type string.');
+    return;
   }
 
   var ns = namespace || 'default';
@@ -164,7 +172,7 @@ Subsegment.prototype.addMetadata = function(key, value, namespace) {
     this.metadata[ns] = {};
   }
 
-  this.metadata[ns][key] = value || '';
+  this.metadata[ns][key] = value !== null && value !== undefined ? value : '';
 };
 
 Subsegment.prototype.addSqlData = function addSqlData(sqlData) {

--- a/packages/core/lib/segments/segment.js
+++ b/packages/core/lib/segments/segment.js
@@ -116,10 +116,10 @@ Segment.prototype.setUser = function (user) {
 
 Segment.prototype.addMetadata = function(key, value, namespace) {
   if (typeof key !== 'string') {
-    throw new Error('Failed to add annotation key: ' + key + ' value: ' + value + ' to subsegment ' +
+    logger.getLogger().error('Failed to add metadata key: ' + key + ' value: ' + value + ' to segment ' +
       this.name + '. Key must be of type string.');
   } else if (namespace && typeof namespace !== 'string') {
-    throw new Error('Failed to add annotation key: ' + key + ' value: ' + value + 'namespace: ' + namespace + ' to subsegment ' +
+    logger.getLogger().error('Failed to add metadata key: ' + key + ' value: ' + value + ' to segment ' +
       this.name + '. Namespace must be of type string.');
   }
 
@@ -133,7 +133,7 @@ Segment.prototype.addMetadata = function(key, value, namespace) {
     this.metadata[ns] = {};
   }
 
-  this.metadata[ns][key] = value;
+  this.metadata[ns][key] = value || '';
 };
 
 /**
@@ -255,8 +255,9 @@ Segment.prototype.removeSubsegment = function removeSubsegment(subsegment) {
 
 Segment.prototype.addError = function addError(err, remote) {
   if (err == null || typeof err !== 'object' && typeof(err) !== 'string') {
-    throw new Error('Failed to add error:' + err + ' to subsegment "' + this.name +
-      '".  Not an object or string literal.');
+    logger.getLogger().error('Failed to add error:' + err + ' to subsegment "' + this.name +
+    '".  Not an object or string literal.');
+    return;
   }
 
   this.addFaultFlag();

--- a/packages/core/lib/segments/segment.js
+++ b/packages/core/lib/segments/segment.js
@@ -82,8 +82,14 @@ Segment.prototype.addIncomingRequestData = function addIncomingRequestData(data)
 
 Segment.prototype.addAnnotation = function addAnnotation(key, value) {
   if (typeof value !== 'boolean' && typeof value !== 'string' && !isFinite(value)) {
-    logger.getLogger().error('Add annotation key: ' + key + ' value: ' + value + ' failed.' +
-      ' Annotations must be of type string, number or boolean.');
+    logger.getLogger().error('Failed to add annotation key: ' + key + ' value: ' + value + ' to subsegment ' +
+      this.name + '. Value must be of type string, number or boolean.');
+    return;
+  }
+
+  if (typeof key !== 'string') {
+    logger.getLogger().error('Failed to add annotation key: ' + key + ' value: ' + value + ' to subsegment ' +
+      this.name + '. Key must be of type string.');
     return;
   }
 
@@ -118,9 +124,13 @@ Segment.prototype.addMetadata = function(key, value, namespace) {
   if (typeof key !== 'string') {
     logger.getLogger().error('Failed to add metadata key: ' + key + ' value: ' + value + ' to segment ' +
       this.name + '. Key must be of type string.');
-  } else if (namespace && typeof namespace !== 'string') {
+    return;
+  }
+
+  if (namespace && typeof namespace !== 'string') {
     logger.getLogger().error('Failed to add metadata key: ' + key + ' value: ' + value + ' to segment ' +
       this.name + '. Namespace must be of type string.');
+    return;
   }
 
   var ns = namespace || 'default';
@@ -133,7 +143,7 @@ Segment.prototype.addMetadata = function(key, value, namespace) {
     this.metadata[ns] = {};
   }
 
-  this.metadata[ns][key] = value || '';
+  this.metadata[ns][key] = value !== null && value !== undefined ? value : '';
 };
 
 /**

--- a/packages/core/test/unit/segments/segment.test.js
+++ b/packages/core/test/unit/segments/segment.test.js
@@ -8,6 +8,7 @@ var SegmentEmitter = require('../../../lib/segment_emitter');
 var SegmentUtils = require('../../../lib/segments/segment_utils');
 var Segment = require('../../../lib/segments/segment');
 var Subsegment = require('../../../lib/segments/attributes/subsegment');
+var logger = require('../../../lib/logger');
 
 chai.should();
 chai.use(sinonChai);
@@ -280,10 +281,12 @@ describe('Segment', function() {
       assert.equal(segment.cause.exceptions.length, 2);
     });
 
-    it('should throw an error on other types', function() {
-      assert.throws(function() {
-        segment.addError(3);
-      });
+    it('should accept invalid types and log an error', function() {
+      const loggerMock = sandbox.mock(logger.getLogger());
+      loggerMock.expects('error').once();
+      segment.addError(3);
+      loggerMock.verify();
+      assert.notEqual(segment.fault, true);
     });
 
     it('should set fault to true by default', function() {


### PR DESCRIPTION
*Description of changes:*
Adding annotations, metadata, and errors with malformed data, will be logged as an error instead of hard crashing the caller. XRay Segments are not production critical code and therefore should never throw an exception when it can be avoided. This changes default values and keys to something xray can handle, but won't crash the caller.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
