### PR TITLE
Update Subsegment Type Definitions to Include `namespace`

### DIFF
--- a/packages/core/lib/segments/attributes/subsegment.d.ts
+++ b/packages/core/lib/segments/attributes/subsegment.d.ts
@@ -9,6 +9,7 @@ declare class Subsegment {
   subsegments?: Array<Subsegment>;
   parent: SegmentLike;
   segment: Segment;
+  namespace?: string;
 
   constructor(name: string);
 


### PR DESCRIPTION
*Issue #, if available:*
#469 
*Description of changes:*
Allow setting the namespace property on Subsegments. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
