### PR TITLE
Update HAPI Readme to use the aws-xray-sdk

### DIFF
--- a/sdk_contrib/hapi/README.md
+++ b/sdk_contrib/hapi/README.md
@@ -17,7 +17,7 @@ Simply register as a normal Hapi plugin
 const AWSXRay = require('aws-xray-sdk');
 
 await server.register({
-  plugin: require('hapi-xray'),
+  plugin: require('aws-xray-sdk-hapi'),
   options: {
     captureAWS: true,
     plugins: [AWSXRay.plugins.ECSPlugin]


### PR DESCRIPTION
*Description of changes:*
Update the HAPI plugin readme to use the `aws-xray-sdk` plugin in the example instead of the old `hapi-xray` package.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
