### PR TITLE
capturePostgres is the default function

### DIFF
--- a/packages/postgres/lib/postgres_p.d.ts
+++ b/packages/postgres/lib/postgres_p.d.ts
@@ -1,7 +1,7 @@
 import * as AWSXRay from 'aws-xray-sdk-core';
 import * as PG from 'pg';
 
-export function capturePostgres(pg: typeof PG): capturePostgres.PatchedPostgres;
+export default function capturePostgres(pg: typeof PG): capturePostgres.PatchedPostgres;
 
 declare namespace capturePostgres {
   interface CaptureQueryMethod {


### PR DESCRIPTION
It must be equivalent to require import:

```js
var capturePostgres = require('aws-xray-sdk-postgres');
```

I get this error when try to follow the type definition of this package with TypeScript

```ts
import { capturePostgres } from "aws-xray-sdk-postgres";
```

Then I get this error:

```sh
TypeError: (0 , external_aws_xray_sdk_postgres_namespaceObject.capturePostgres) is not a function
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
