### PR TITLE
Initialise empty exceptions array to fix unshift undefined error

### DIFF
--- a/packages/core/lib/segments/attributes/subsegment.js
+++ b/packages/core/lib/segments/attributes/subsegment.js
@@ -191,7 +191,7 @@ Subsegment.prototype.addError = function addError(err, remote) {
   if (this.segment && this.segment.exception) {
     if (err === this.segment.exception.ex) {
       this.fault = true;
-      this.cause = { id: this.segment.exception.cause };
+      this.cause = { id: this.segment.exception.cause, exceptions: [] };
       return;
     }
     delete this.segment.exception;

--- a/packages/core/test/unit/segments/attributes/subsegment.test.js
+++ b/packages/core/test/unit/segments/attributes/subsegment.test.js
@@ -137,6 +137,13 @@ describe('Subsegment', function() {
       subsegment.addError(err, true);
       exceptionStub.should.have.been.calledWithExactly(err, true);
     });
+    it('should initialise exceptions if matching errors are passed consecutively', function () {
+      subsegment.segment = { trace_id: '1-58c835af-cf6bfe9f8f2c5b84a6d1f50c', parent_id: '12345abc3456def' };
+      subsegment.addError(err);
+      subsegment.addError(err);
+      assert.equal(subsegment.cause.exceptions.length, 0);
+      assert.notEqual(subsegment.cause.exceptions, undefined);
+    });
   });
 
   describe('#incrementCounter', function() {


### PR DESCRIPTION
*Issue #, if available:* 

[448](https://github.com/aws/aws-xray-sdk-node/issues/448)

*Description of changes:* 

Fixes unshift undefined error which can occur when two identical errors are sent consecutively. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
