### PR TITLE
Prepare release 3.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 # Changelog for AWS X-Ray SDK for JavaScript
-<!--LATEST=3.3.5-->
+<!--LATEST=3.3.6-->
 <!--ENTRYINSERT-->
+## 3.3.6
+View [the latest changes](https://github.com/aws/aws-xray-sdk-node/compare/aws-xray-sdk-node%403.3.5...aws-xray-sdk-node%403.3.6)
+* `aws-xray-sdk-core` updated to 3.3.6
+  * fix: Check `serviceName` is null even if it should never be [PR #457](https://github.com/aws/aws-xray-sdk-node/pull/457)
+  * fix: Populate vars to avoid `unshift undefined` error [PR #508](https://github.com/aws/aws-xray-sdk-node/pull/508)
+* `aws-xray-sdk-mysql` updated to 3.3.6
+  * fix: avoid fake .then() method on mysql2 Query class [PR #501](https://github.com/aws/aws-xray-sdk-node/pull/501)
+* `aws-xray-sdk-express` updated to 3.3.6
+  * No further changes.
+* `aws-xray-sdk-postgres` updated to 3.3.6
+  * No further changes.
+* `aws-xray-sdk-restify` updated to 3.3.6
+  * No further changes.
+* `aws-xray-sdk-koa2` updated to 3.3.6
+  * No further changes.
+* `aws-xray-sdk-hapi` updated to 3.3.6
+  * No further changes.
+
 ## 3.3.5
 * change: Updated aws-xray-sdk-core to 3.3.5.
   * bugfix: added ids to exception objects [PR #475](https://github.com/aws/aws-xray-sdk-node/pull/475)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-node",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-node",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "private": true,
   "license": "Apache-2.0",
   "devDependencies": {
@@ -18,8 +18,8 @@
     "@typescript-eslint/eslint-plugin": "^4.25.0",
     "@typescript-eslint/parser": "^4.25.0",
     "aws-sdk": "^2.304.0",
-    "aws-xray-sdk-core": "3.3.5",
-    "aws-xray-sdk-express": "3.3.5",
+    "aws-xray-sdk-core": "3.3.6",
+    "aws-xray-sdk-express": "3.3.6",
     "chai": "^4.2.0",
     "cls-hooked": "^4.2.2",
     "codecov": "^3.8.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-core",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "description": "AWS X-Ray SDK for Javascript",
   "author": "Amazon Web Services",
   "contributors": [

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-express",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "description": "AWS X-Ray Middleware for Express (Javascript)",
   "author": "Amazon Web Services",
   "contributors": [
@@ -18,7 +18,7 @@
     "@types/express": "*"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^3.3.5"
+    "aws-xray-sdk-core": "^3.3.6"
   },
   "scripts": {
     "test": "mocha --recursive ./test/ -R spec && tsd",

--- a/packages/full_sdk/package.json
+++ b/packages/full_sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "description": "AWS X-Ray SDK for Javascript",
   "author": "Amazon Web Services",
   "contributors": [

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-mysql",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "description": "AWS X-Ray Patcher for MySQL (Javascript)",
   "author": "Amazon Web Services",
   "contributors": [
@@ -18,7 +18,7 @@
     "@types/mysql": "*"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^3.3.5"
+    "aws-xray-sdk-core": "^3.3.6"
   },
   "scripts": {
     "test": "mocha --recursive ./test/ -R spec && tsd",

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-postgres",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "description": "AWS X-Ray Patcher for Postgres (Javascript)",
   "author": "Amazon Web Services",
   "contributors": [
@@ -18,7 +18,7 @@
     "@types/pg": "*"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^3.3.5"
+    "aws-xray-sdk-core": "^3.3.6"
   },
   "scripts": {
     "test": "mocha --recursive ./test/ -R spec && tsd",

--- a/packages/restify/package.json
+++ b/packages/restify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-restify",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "description": "Enables AWS X-Ray for Restify (Javascript)",
   "author": "Amazon Web Services",
   "contributors": [
@@ -18,7 +18,7 @@
     "@types/restify": "*"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^3.3.5"
+    "aws-xray-sdk-core": "^3.3.6"
   },
   "scripts": {
     "test": "mocha --recursive ./test/ -R spec && tsd",

--- a/packages/test_express/package.json
+++ b/packages/test_express/package.json
@@ -1,7 +1,7 @@
 {
   "name": "test-aws-xray-sdk-express",
   "private": true,
-  "version": "3.3.5",
+  "version": "3.3.6",
   "description": "AWS X-Ray Middleware for Express (Javascript)",
   "author": "Amazon Web Services",
   "contributors": [

--- a/sdk_contrib/hapi/package.json
+++ b/sdk_contrib/hapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-hapi",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "description": "AWS X-Ray plugin for Hapi.JS",
   "author": "Amazon Web Services",
   "contributors": [
@@ -24,7 +24,7 @@
   },
   "peerDependencies": {
     "@hapi/hapi": ">=18.x",
-    "aws-xray-sdk-core": "^3.3.5"
+    "aws-xray-sdk-core": "^3.3.6"
   },
   "keywords": [
     "amazon",

--- a/sdk_contrib/koa/package.json
+++ b/sdk_contrib/koa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-koa2",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "description": "AWS X-Ray Middleware for koa (Javascript)",
   "author": "Amazon Web Services",
   "contributors": [
@@ -22,7 +22,7 @@
     "node": ">= 12.x"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^3.3.5",
+    "aws-xray-sdk-core": "^3.3.6",
     "koa": "^2.0.0"
   },
   "keywords": [


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Similar to #500.

Bump AWS X-Ray JavaScript SDK components to version `3.3.6`.

Updates were included in the [CHANGELOG.md](https://github.com/aws/aws-xray-sdk-node/blob/master/CHANGELOG.md#336).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
