### PR TITLE
Remove support for Node 10.x

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -17,7 +17,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         node-version:
-          - 10.x
           - 12.x
           - 14.x
           - 15.x

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Installing
 
-The AWS X-Ray SDK for Node.js is compatible with Node.js version 10.x and later.
+The AWS X-Ray SDK for Node.js is compatible with Node.js version 12.x and later.
 There may be issues when running on the latest odd-numbered release of Node.js.
 
 The latest stable version of the SDK is available from NPM. For local development, install the SDK in your project directory with npm.

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "upath": "^1.2.0"
   },
   "engines": {
-    "node": ">= 10.x",
+    "node": ">= 12.x",
     "npm": ">= 2.x"
   },
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",
   "engines": {
-    "node": ">= 10.x"
+    "node": ">= 12.x"
   },
   "directories": {
     "test": "test"

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -9,7 +9,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "engines": {
-    "node": ">= 10.x"
+    "node": ">= 12.x"
   },
   "directories": {
     "test": "test"

--- a/packages/full_sdk/package.json
+++ b/packages/full_sdk/package.json
@@ -10,7 +10,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "engines": {
-    "node": ">= 10.x"
+    "node": ">= 12.x"
   },
   "dependencies": {
     "aws-xray-sdk-core": "file:../core",

--- a/packages/mysql/lib/mysql_p.js
+++ b/packages/mysql/lib/mysql_p.js
@@ -237,12 +237,6 @@ function captureOperation(name) {
     if (!args.callback) {
       var errorCapturer = function (err) {
         subsegment.close(err);
-
-        // TODO: Remove this logic once Node 10 is deprecated
-        if (!events.errorMonitor && this.listenerCount('error') <= 1) {
-          this.removeListener('error', errorCapturer);
-          this.emit('error', err);
-        }
       };
 
       if (isPromise(command)) {

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -9,7 +9,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "engines": {
-    "node": ">= 10.x"
+    "node": ">= 12.x"
   },
   "directories": {
     "test": "test"

--- a/packages/postgres/lib/postgres_p.js
+++ b/packages/postgres/lib/postgres_p.js
@@ -111,12 +111,6 @@ function captureQuery() {
 
       var errorCapturer = function (err) {
         subsegment.close(err);
-
-        // TODO: Remove this logic once Node 10 is deprecated
-        if (!events.errorMonitor && this.listenerCount('error') <= 1) {
-          this.removeListener('error', errorCapturer);
-          this.emit('error', err);
-        }
       };
 
       query.on(events.errorMonitor || 'error', errorCapturer);

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -9,7 +9,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "engines": {
-    "node": ">= 10.x"
+    "node": ">= 12.x"
   },
   "directories": {
     "test": "test"

--- a/packages/restify/package.json
+++ b/packages/restify/package.json
@@ -9,7 +9,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "engines": {
-    "node": ">= 10.x"
+    "node": ">= 12.x"
   },
   "directories": {
     "test": "test"

--- a/packages/test_express/package.json
+++ b/packages/test_express/package.json
@@ -9,7 +9,7 @@
   ],
   "main": "lib/index.js",
   "engines": {
-    "node": ">= 10.x"
+    "node": ">= 12.x"
   },
   "directories": {
     "test": "test"

--- a/sdk_contrib/hapi/package.json
+++ b/sdk_contrib/hapi/package.json
@@ -20,7 +20,7 @@
     "sample": "node sample"
   },
   "engines": {
-    "node": ">= 10.x"
+    "node": ">= 12.x"
   },
   "peerDependencies": {
     "@hapi/hapi": ">=18.x",

--- a/sdk_contrib/koa/package.json
+++ b/sdk_contrib/koa/package.json
@@ -19,7 +19,7 @@
     "test-d": "tsd"
   },
   "engines": {
-    "node": ">= 10.x"
+    "node": ">= 12.x"
   },
   "peerDependencies": {
     "aws-xray-sdk-core": "^3.3.5",

--- a/smoke_test/package.json
+++ b/smoke_test/package.json
@@ -4,7 +4,7 @@
   "description": "Smoke Test for AWS XRay SDK",
   "main": "index.js",
   "engines": {
-    "node": ">= 10.x"
+    "node": ">= 12.x"
   },
   "dependencies": {
     "aws-xray-sdk": "*",


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

We recently noticed this error on the AWS Java X-Ray SDK [Continuous build workflows](https://github.com/aws/aws-xray-sdk-node/actions/runs/2393563159)

```
npx: installed 650 in 39.37s
Object.fromEntries is not a function
```

We have a package called `fromentries` but I don’t see it used anywhere…

We found online that [there is an issue with Node v10](https://stackoverflow.com/a/67551131/7460739) in which this error will show up. We are testing with Node v10 GitHub Actions so our solution is to drop Node v10 support to unblock our CI. [Node 10 is not supported by Node themselves](https://nodejs.org/en/about/releases/) according to their page

This is blocking us from releasing the Node X-Ray SDK.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
