### PR TITLE
Fix TS declaration of TraceId to match definition

### DIFF
--- a/packages/core/lib/segments/attributes/trace_id.d.ts
+++ b/packages/core/lib/segments/attributes/trace_id.d.ts
@@ -3,7 +3,7 @@ declare class TraceID {
   timestamp: string;
   id: string;
 
-  constructor();
+  constructor(tsHex?: string, numberhex?: string);
 
   static Invalid(): TraceID;
 

--- a/packages/core/test-d/index.test-d.ts
+++ b/packages/core/test-d/index.test-d.ts
@@ -41,11 +41,13 @@ expectType<void>(AWSXRay.setDaemonAddress('192.168.0.23:8080'));
 
 const traceId = '1-57fbe041-2c7ad569f5d6ff149137be86';
 const traceId2 = new TraceID();
+const traceId3 = new TraceID("0", "0");
 const segment = new AWSXRay.Segment('test', traceId);
 
 expectType<TraceID>(TraceID.FromString(traceId));
 expectType<TraceID>(TraceID.Invalid());
 expectType<string>(traceId2.toString());
+expectType<string>(traceId3.toString());
 
 expectType<string>(AWSXRay.captureFunc('tracedFcn', () => 'OK', segment));
 expectType<void>(AWSXRay.captureFunc('tracedFcn', () => {

--- a/packages/core/test-d/index.test-d.ts
+++ b/packages/core/test-d/index.test-d.ts
@@ -41,7 +41,7 @@ expectType<void>(AWSXRay.setDaemonAddress('192.168.0.23:8080'));
 
 const traceId = '1-57fbe041-2c7ad569f5d6ff149137be86';
 const traceId2 = new TraceID();
-const traceId3 = new TraceID("0", "0");
+const traceId3 = new TraceID('0', '0');
 const segment = new AWSXRay.Segment('test', traceId);
 
 expectType<TraceID>(TraceID.FromString(traceId));


### PR DESCRIPTION
*Issue #, if available:* Fixes issue #519 

*Description of changes:* Updated constructor arguments in TypeScript TraceID class declaration to match the ones used in the class definition.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
