### PR TITLE
Fix prototype pollution issue

### DIFF
--- a/packages/core/lib/segments/attributes/subsegment.js
+++ b/packages/core/lib/segments/attributes/subsegment.js
@@ -172,7 +172,9 @@ Subsegment.prototype.addMetadata = function(key, value, namespace) {
     this.metadata[ns] = {};
   }
 
-  this.metadata[ns][key] = value !== null && value !== undefined ? value : '';
+  if (ns !== '__proto__') {
+    this.metadata[ns][key] = value !== null && value !== undefined ? value : '';
+  }
 };
 
 Subsegment.prototype.addSqlData = function addSqlData(sqlData) {

--- a/packages/core/lib/segments/segment.js
+++ b/packages/core/lib/segments/segment.js
@@ -143,7 +143,9 @@ Segment.prototype.addMetadata = function(key, value, namespace) {
     this.metadata[ns] = {};
   }
 
-  this.metadata[ns][key] = value !== null && value !== undefined ? value : '';
+  if (ns !== '__proto__') {
+    this.metadata[ns][key] = value !== null && value !== undefined ? value : '';
+  }
 };
 
 /**

--- a/packages/core/test/unit/segments/attributes/subsegment.test.js
+++ b/packages/core/test/unit/segments/attributes/subsegment.test.js
@@ -47,6 +47,12 @@ describe('Subsegment', function() {
       subsegment.addMetadata(key, value, 'hello');
       assert.propertyVal(subsegment.metadata[namespace], key, value);
     });
+
+    it('should not add key value pair to metadata[namespace] if a namespace is "__proto__"', function () {
+      let namespace = '__proto__';
+      subsegment.addMetadata(key, value, namespace);
+      assert.notProperty(subsegment.metadata[namespace], key);
+    });
   });
 
   describe('#addSubsegment', function() {

--- a/packages/core/test/unit/segments/segment.test.js
+++ b/packages/core/test/unit/segments/segment.test.js
@@ -112,6 +112,12 @@ describe('Segment', function() {
       segment.addMetadata(key, value, 'hello');
       assert.propertyVal(segment.metadata[namespace], key, value);
     });
+
+    it('should not add key value pair to metadata[namespace] if a namespace is "__proto__"', function () {
+      let namespace = '__proto__';
+      segment.addMetadata(key, value, namespace);
+      assert.notProperty(segment.metadata[namespace], key);
+    });
   });
 
   describe('#addSDKData', function() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change fixes the possible prototype pollution in the `addMetadata` method in segment.js and subsegment.js and adds corresponding unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
