### PR TITLE
Oversampling Mitigation 

### DIFF
--- a/packages/core/lib/env/aws_lambda.js
+++ b/packages/core/lib/env/aws_lambda.js
@@ -41,7 +41,7 @@ module.exports.init = function init() {
 
 var facadeSegment = function facadeSegment() {
   var segment = new Segment('facade');
-  var whitelistFcn = ['addNewSubsegment', 'addSubsegment', 'removeSubsegment', 'toString'];
+  var whitelistFcn = ['addNewSubsegment', 'addSubsegment', 'removeSubsegment', 'toString', 'addSubsegmentWithoutSampling', 'addNewSubsegmentWithoutSampling'];
   var silentFcn = ['incrementCounter', 'decrementCounter', 'isClosed', 'close', 'format', 'flush'];
   var xAmznTraceId = process.env._X_AMZN_TRACE_ID;
 
@@ -79,6 +79,7 @@ var facadeSegment = function facadeSegment() {
     this.notTraced = true;
   };
 
+  // tracingHandler?
   segment.resolveLambdaTraceData = function resolveLambdaTraceData() {
     var xAmznLambda = process.env._X_AMZN_TRACE_ID;
 

--- a/packages/core/lib/env/sqs_message_helper.js
+++ b/packages/core/lib/env/sqs_message_helper.js
@@ -1,0 +1,17 @@
+var LambdaUtils = require('../utils').LambdaUtils;
+
+class SqsMessageHelper {
+
+    isSampled(message){ 
+        const {attributes} = message; // extract attributes from message 
+
+        if (!'AWSTraceHeader' in attributes){
+            return false; 
+        }
+
+        return attributes['AWSTraceHeader'].includes('Sampled=1');
+    }
+
+}
+
+export default SqsMessageHelper;

--- a/packages/core/lib/patchers/aws_p.js
+++ b/packages/core/lib/patchers/aws_p.js
@@ -81,7 +81,8 @@ function captureAWSRequest(req) {
 
   var buildListener = function(req) {
     req.httpRequest.headers['X-Amzn-Trace-Id'] = 'Root=' + traceId + ';Parent=' + subsegment.id +
-      ';Sampled=' + (subsegment.segment.notTraced ? '0' : '1');
+      ';Sampled=' + (subsegment.isSampled ? '1' : '0');
+      
   };
 
   var completeListener = function(res) {

--- a/packages/core/lib/patchers/http_p.js
+++ b/packages/core/lib/patchers/http_p.js
@@ -123,9 +123,9 @@ function enableCapture(module, downstreamXRayEnabled, subsegmentCallback) {
     if (!options.headers) {
       options.headers = {};
     }
-
+    
     options.headers['X-Amzn-Trace-Id'] = 'Root=' + root.trace_id + ';Parent=' + subsegment.id +
-      ';Sampled=' + (!root.notTraced ? '1' : '0');
+      ';Sampled=' + (subsegment.isSampled ? '1' : '0');
 
     const errorCapturer = function errorCapturer(e) {
       if (subsegmentCallback) {

--- a/packages/core/lib/segments/attributes/subsegment.d.ts
+++ b/packages/core/lib/segments/attributes/subsegment.d.ts
@@ -10,12 +10,17 @@ declare class Subsegment {
   parent: SegmentLike;
   segment: Segment;
   namespace?: string;
+  isSampled: boolean;
 
   constructor(name: string);
 
   addNewSubsegment(name: string): Subsegment;
 
   addSubsegment(subsegment: Subsegment): void;
+
+  addNewSubsegmentWithoutSampling(name: String): Subsegment;
+
+  addSubsegmentWithoutSampling(subsegment: Subsegment): void;
 
   removeSubsegment(subsegment: Subsegment): void;
 

--- a/packages/core/lib/segments/segment.d.ts
+++ b/packages/core/lib/segments/segment.d.ts
@@ -35,6 +35,10 @@ declare class Segment {
 
   addSubsegment(subsegment: Subsegment): void;
 
+  addSubsegmentWithoutSampling(subsegment: Subsegment): void; 
+
+  addNewSubsegmentWithoutSampling(name: String): Subsegment
+
   removeSubsegment(subsegment: Subsegment): void;
 
   addError(err: Error | string, remote?: boolean): void;
@@ -58,6 +62,8 @@ declare class Segment {
   format(): string;
 
   toString(): string;
+
+
 }
 
 export = Segment;

--- a/packages/core/lib/segments/segment.js
+++ b/packages/core/lib/segments/segment.js
@@ -233,11 +233,28 @@ Segment.prototype.addSubsegment = function addSubsegment(subsegment) {
 
   subsegment.segment = this;
   subsegment.parent = this;
-  this.subsegments.push(subsegment);
 
-  if (!subsegment.end_time) {
+  if(subsegment.isSampled){
+      this.subsegments.push(subsegment);
+  }
+
+  if (!subsegment.end_time && subsegment.isSampled) {
     this.incrementCounter(subsegment.counter);
   }
+};
+
+Segment.prototype.addSubsegmentWithoutSampling = function addSubsegmentWithoutSampling(subsegment){
+  subsegment.isSampled = false;
+  this.addSubsegment(subsegment);
+  
+};
+
+Segment.prototype.addNewSubsegmentWithoutSampling = function addNewSubsegmentWithoutSampling(name){
+  var subsegment = new Subsegment(name);
+  subsegment.isSampled = false;
+  this.addSubsegment(subsegment);
+  
+  return subsegment; 
 };
 
 /**

--- a/packages/core/test/unit/env/sqs_message_helper.test.js
+++ b/packages/core/test/unit/env/sqs_message_helper.test.js
@@ -1,0 +1,66 @@
+var assert = require('chai').assert;
+var chai = require('chai');
+var sinon = require('sinon');
+var sinonChai = require('sinon-chai');
+
+import { setAWSWhitelist } from '../../../lib/aws-xray';
+import SqsMessageHelper from '../../../lib/env/sqs_message_helper';
+
+chai.should();
+chai.use(sinonChai);
+
+describe('#SqsMessageHelper', function (){
+
+    // sample records from https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html
+    const sampleSqsMessageEvent = {
+        "Records": [
+            {
+                "messageId": "059f36b4-87a3-44ab-83d2-661975830a7d",
+                "receiptHandle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
+                "body": "Test message.",
+                "attributes": {
+                    "ApproximateReceiveCount": "1",
+                    "SentTimestamp": "1545082649183",
+                    "SenderId": "AIDAIENQZJOLO23YVJ4VO",
+                    "ApproximateFirstReceiveTimestamp": "1545082649185",
+                    "AWSTraceHeader":"Root=1-632BB806-bd862e3fe1be46a994272793;Sampled=1"
+                },
+                "messageAttributes": {},
+                "md5OfBody": "e4e68fb7bd0e697a0ae8f1bb342846b3",
+                "eventSource": "aws:sqs",
+                "eventSourceARN": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+                "awsRegion": "us-east-2"
+            },
+            {
+                "messageId": "2e1424d4-f796-459a-8184-9c92662be6da",
+                "receiptHandle": "AQEBzWwaftRI0KuVm4tP+/7q1rGgNqicHq...",
+                "body": "Test message.",
+                "attributes": {
+                    "ApproximateReceiveCount": "1",
+                    "SentTimestamp": "1545082650636",
+                    "SenderId": "AIDAIENQZJOLO23YVJ4VO",
+                    "ApproximateFirstReceiveTimestamp": "1545082650649",
+                    "AWSTraceHeader":"Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=0"
+                },
+                "messageAttributes": {},
+                "md5OfBody": "e4e68fb7bd0e697a0ae8f1bb342846b3",
+                "eventSource": "aws:sqs",
+                "eventSourceARN": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+                "awsRegion": "us-east-2"
+            }
+        ]
+    }
+    
+    it('testing sqsmessagehelper', function(){
+        let sqsMessageHelper = new SqsMessageHelper();
+        
+        it('should return true when AWSTraceHeader has Sampled=1', function(){
+            assert.equal(sqsMessageHelper.isSampled(sampleSqsMessageEvent[0]), true)
+        });
+
+        it('should return false when AWSTraceHeader has Sampled=0', function(){
+            assert.equal(sqsMessageHelper.isSampled(sampleSqsMessageEvent[1]), false)
+        });
+        
+    })
+  });

--- a/packages/core/test/unit/segments/attributes/subsegment.test.js
+++ b/packages/core/test/unit/segments/attributes/subsegment.test.js
@@ -103,6 +103,33 @@ describe('Subsegment', function() {
     });
   });
 
+  describe('#addSubsegmentWithoutSampling', function (){
+    it('should have isSampled flag set to false', function(){
+      var subsegment = new Subsegment('test');
+      var child = new Subsegment('child')
+      subsegment.addSubsegmentWithoutSampling(child);
+
+      assert.equal(subsegment.isSampled, true);
+      assert.equal(child.isSampled, false);
+    })
+
+    it('should have isSampled flag set to false for new subsegment', function(){
+      var subsegment = new Subsegment('test');
+      var child = subsegment.addNewSubsegmentWithoutSampling('child');
+
+      assert.equal(subsegment.isSampled, true);
+      assert.equal(child.isSampled, false);
+    })
+
+    it('should not contain the child subsegment if not sampled', function(){
+      var subsegment = new Subsegment('test');
+      var child = new Subsegment('child')
+      subsegment.addSubsegmentWithoutSampling(child);
+
+      assert.notEqual(subsegment.subsegments[0], child);
+    })
+  });
+
   describe('#addError', function() {
     var err, exceptionStub, sandbox, subsegment;
 

--- a/packages/core/test/unit/segments/segment.test.js
+++ b/packages/core/test/unit/segments/segment.test.js
@@ -262,6 +262,57 @@ describe('Segment', function() {
     });
   });
 
+  describe('#addSubsegmentWithoutSampling', function (){
+    it('should have isSampled flag set to false', function(){
+      var segment = new Segment('parent');
+      var child = new Subsegment('child');
+      segment.addSubsegmentWithoutSampling(child);
+
+      assert.equal(child.isSampled, false);
+    })
+
+    it('should have isSampled flag set to false for new subsegment', function(){
+      var segment = new Segment('parent');
+      var child = segment.addNewSubsegmentWithoutSampling('child');
+
+      assert.equal(child.isSampled, false);
+    })
+
+    it('should not contain the child subsegment if not sampled', function(){
+      var segment = new Segment('parent');
+      var child = new Subsegment('child');
+      segment.addSubsegmentWithoutSampling(child);
+
+      assert.notEqual(segment.subsegments[0], child);
+    })
+
+
+    it('should not sample subsegment or subsegment of subsegment', function(){
+      var segment = new Segment('parent');
+      var child = new Subsegment('child');
+      var child2 = new Subsegment('child-2');
+      segment.addSubsegmentWithoutSampling(child);
+      child.addSubsegmentWithoutSampling(child2)
+
+      assert.equal(child.isSampled, false);
+      assert.equal(child2.isSampled, false);
+    })
+
+    it('should not sample subsegment or subsegment of subsegment - mix', function(){
+      var segment = new Segment('parent');
+      var child = new Subsegment('child');
+      var child2 = new Subsegment('child-2');
+      var child3 = new Subsegment('child-3');
+      segment.addSubsegmentWithoutSampling(child);
+      child.addSubsegment(child2)
+      child.addSubsegmentWithoutSampling(child3)
+
+      assert.equal(child.isSampled, false);
+      assert.equal(child2.isSampled, true);
+      assert.equal(child3.isSampled, false);
+    })
+  });
+
   describe('#addError', function() {
     var err, exceptionStub, sandbox, segment;
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Implemented oversampling mitigation - added methods to create subsegments without sampling (control sampling decisions at the subsegment level) and an SQS message helper class 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
