### PR TITLE
Remove support for Node 12.x

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -17,7 +17,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         node-version:
-          - 12.x
           - 14.x
           - 16.x
         include:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you want additional features when tracing your Node.js applications, please [
 
 ## Installing
 
-The AWS X-Ray SDK for Node.js is compatible with Node.js version 12.x and later.
+The AWS X-Ray SDK for Node.js is compatible with Node.js version 14.x and later.
 There may be issues when running on the latest odd-numbered release of Node.js.
 
 The latest stable version of the SDK is available from NPM. For local development, install the SDK in your project directory with npm.

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "upath": "^1.2.0"
   },
   "engines": {
-    "node": ">= 12.x",
+    "node": ">= 14.x",
     "npm": ">= 2.x"
   },
   "dependencies": {

--- a/packages/core/lib/patchers/http_p.js
+++ b/packages/core/lib/patchers/http_p.js
@@ -143,15 +143,6 @@ function enableCapture(module, downstreamXRayEnabled, subsegmentCallback) {
         subsegment.addRemoteRequestData(this, null, madeItToDownstream && downstreamXRayEnabled);
         subsegment.close(e);
       }
-
-      // Only need to remove our listener & re-emit if we're not listening using the errorMonitor,
-      // e.g. the app is running on Node 10. Otherwise the errorMonitor will re-emit automatically.
-      // See: https://github.com/aws/aws-xray-sdk-node/issues/318
-      // TODO: Remove this logic once node 12 support is deprecated
-      if (!events.errorMonitor && this.listenerCount('error') <= 1) {
-        this.removeListener('error', errorCapturer);
-        this.emit('error', e);
-      }
     };
 
     const optionsCopy = Utils.objectWithoutProperties(options, ['Segment'], true);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",
   "engines": {
-    "node": ">= 12.x"
+    "node": ">= 14.x"
   },
   "directories": {
     "test": "test"

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -9,7 +9,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "engines": {
-    "node": ">= 12.x"
+    "node": ">= 14.x"
   },
   "directories": {
     "test": "test"

--- a/packages/full_sdk/package.json
+++ b/packages/full_sdk/package.json
@@ -10,7 +10,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "engines": {
-    "node": ">= 12.x"
+    "node": ">= 14.x"
   },
   "dependencies": {
     "aws-xray-sdk-core": "file:../core",

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -9,7 +9,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "engines": {
-    "node": ">= 12.x"
+    "node": ">= 14.x"
   },
   "directories": {
     "test": "test"

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -9,7 +9,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "engines": {
-    "node": ">= 12.x"
+    "node": ">= 14.x"
   },
   "directories": {
     "test": "test"

--- a/packages/restify/package.json
+++ b/packages/restify/package.json
@@ -9,7 +9,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "engines": {
-    "node": ">= 12.x"
+    "node": ">= 14.x"
   },
   "directories": {
     "test": "test"

--- a/packages/test_express/package.json
+++ b/packages/test_express/package.json
@@ -9,7 +9,7 @@
   ],
   "main": "lib/index.js",
   "engines": {
-    "node": ">= 12.x"
+    "node": ">= 14.x"
   },
   "directories": {
     "test": "test"

--- a/sdk_contrib/fastify/package.json
+++ b/sdk_contrib/fastify/package.json
@@ -19,7 +19,7 @@
     "sample": "node sample"
   },
   "engines": {
-    "node": ">= 12.x"
+    "node": ">= 14.x"
   },
   "peerDependencies": {
     "aws-xray-sdk-core": "^3.3.8",

--- a/sdk_contrib/hapi/package.json
+++ b/sdk_contrib/hapi/package.json
@@ -20,7 +20,7 @@
     "sample": "node sample"
   },
   "engines": {
-    "node": ">= 12.x"
+    "node": ">= 14.x"
   },
   "peerDependencies": {
     "@hapi/hapi": ">=18.x",

--- a/sdk_contrib/koa/package.json
+++ b/sdk_contrib/koa/package.json
@@ -19,7 +19,7 @@
     "test-d": "tsd"
   },
   "engines": {
-    "node": ">= 12.x"
+    "node": ">= 14.x"
   },
   "peerDependencies": {
     "aws-xray-sdk-core": "^3.3.8",

--- a/smoke_test/package.json
+++ b/smoke_test/package.json
@@ -4,7 +4,7 @@
   "description": "Smoke Test for AWS XRay SDK",
   "main": "index.js",
   "engines": {
-    "node": ">= 12.x"
+    "node": ">= 14.x"
   },
   "dependencies": {
     "aws-xray-sdk": "*",


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Remove support for Node 12.x to fix continuous build workflow error


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
