### PR TITLE
Modified context missing strategy default to log error

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -57,7 +57,7 @@ section for different usages.
     AWS_XRAY_TRACING_NAME            For overriding the default segment name to use
     with the middleware. See 'dynamic and fixed naming modes'.
     AWS_XRAY_DAEMON_ADDRESS          For setting the daemon address and port.
-    AWS_XRAY_CONTEXT_MISSING         For setting the SDK behavior when trace context is missing. Valid values are 'RUNTIME_ERROR', 'IGNORE_ERROR' or 'LOG_ERROR'. The SDK's default behavior is 'RUNTIME_ERROR'.
+    AWS_XRAY_CONTEXT_MISSING         For setting the SDK behavior when trace context is missing. Valid values are 'RUNTIME_ERROR', 'IGNORE_ERROR' or 'LOG_ERROR'. The SDK's default behavior is 'LOG_ERROR'.
     AWS_XRAY_LOG_LEVEL               Sets a log level for the SDK built in logger. This value is ignored if AWS_XRAY_DEBUG_MODE is set.
     AWS_XRAY_COLLECT_SQL_QUERIES     Enables SQL query capture (currently only Postgres supported)
 

--- a/packages/core/lib/context_utils.js
+++ b/packages/core/lib/context_utils.js
@@ -212,8 +212,8 @@ if (process.env.AWS_XRAY_CONTEXT_MISSING) {
   contextUtils.setContextMissingStrategy(process.env.AWS_XRAY_CONTEXT_MISSING);
   contextOverride = true;
 } else {
-  contextUtils.contextMissingStrategy.contextMissing = contextUtils.CONTEXT_MISSING_STRATEGY.RUNTIME_ERROR.contextMissing;
-  logger.getLogger().debug('Using default context missing strategy: RUNTIME_ERROR');
+  contextUtils.contextMissingStrategy.contextMissing = contextUtils.CONTEXT_MISSING_STRATEGY.LOG_ERROR.contextMissing;
+  logger.getLogger().debug('Using default context missing strategy: LOG_ERROR');
 }
 
 module.exports = contextUtils;

--- a/packages/core/test/unit/context_utils.test.js
+++ b/packages/core/test/unit/context_utils.test.js
@@ -37,8 +37,8 @@ describe('ContextUtils', function() {
       assert.equal(ContextUtils.getNamespace().name, 'AWSXRay');
     });
 
-    it('should set the contextMissingStrategy to RUNTIME_ERROR by default', function() {
-      assert.equal(ContextUtils.contextMissingStrategy.contextMissing.name, RUNTIME_ERROR_FCN_NAME);
+    it('should set the contextMissingStrategy to LOG_ERROR by default', function() {
+      assert.equal(ContextUtils.contextMissingStrategy.contextMissing.name, LOG_ERROR_FCN_NAME);
     });
 
     it('should set the contextMissingStrategy to the process.env.AWS_XRAY_CONTEXT_MISSING strategy if present', function() {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*  To maintain consistency across SDKs and to prevent malformed trace headers from breaking services, this PR sets the default context missing strategy to `'LOG_ERROR'` instead of `'RUNTIME_ERROR'`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
