### PR TITLE
remove html5shiv to support legacy IE versions

### DIFF
--- a/packages/core/doc-src/templates/layout.tmpl
+++ b/packages/core/doc-src/templates/layout.tmpl
@@ -6,9 +6,7 @@
 
     <script src="scripts/prettify/prettify.js"> </script>
     <script src="scripts/prettify/lang-css.js"> </script>
-    <!--[if lt IE 9]>
-      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
+    
     <link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
     <link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
 </head>


### PR DESCRIPTION

Pulling in this script for HTML5 shiv to support legacy IE version has been raising security concerns internally. I think we can remove it from creeping into our generated docs.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
