### PR TITLE
Update type declaration of captureAWSv3Client to fix TS errors

### DIFF
--- a/packages/core/lib/patchers/aws3_p.d.ts
+++ b/packages/core/lib/patchers/aws3_p.d.ts
@@ -1,4 +1,3 @@
-import { Client } from '@aws-sdk/types';
 import { SegmentLike } from '../aws-xray';
 /**
  * Instruments AWS SDK V3 clients with X-Ray via middleware.
@@ -7,4 +6,4 @@ import { SegmentLike } from '../aws-xray';
  * @param manualSegment - Parent segment or subsegment that is passed in for manual mode users
  * @returns - the client with the X-Ray instrumentation middleware added to its middleware stack
  */
-export declare function captureAWSClient<T extends Client<any, any, any>>(client: T, manualSegment?: SegmentLike): T
+export declare function captureAWSClient<T extends { middlewareStack: { remove: any, use: any }, config: any }>(client: T, manualSegment?: SegmentLike): T

--- a/packages/core/lib/patchers/aws3_p.ts
+++ b/packages/core/lib/patchers/aws3_p.ts
@@ -1,6 +1,5 @@
 import {
   Pluggable,
-  Client,
   BuildMiddleware,
   MiddlewareStack,
   BuildHandlerOptions,
@@ -189,7 +188,7 @@ const getXRayPlugin = (config: RegionResolvedConfig, manualSegment?: SegmentLike
  * @param manualSegment - Parent segment or subsegment that is passed in for manual mode users
  * @returns - the client with the X-Ray instrumentation middleware added to its middleware stack
  */
-export function captureAWSClient<T extends Client<any, any, any>>(client: T, manualSegment?: SegmentLike): T {
+export function captureAWSClient<T extends { middlewareStack: { remove: any, use: any }, config: any }>(client: T, manualSegment?: SegmentLike): T {
   // Remove existing middleware to ensure operation is idempotent
   client.middlewareStack.remove(XRAY_PLUGIN_NAME);
   client.middlewareStack.use(getXRayPlugin(client.config, manualSegment));


### PR DESCRIPTION
*Issue #, if available:* #439, #547

*Description of changes:* This PR updates the TypeScript definition of `captureAWSv3Client` to fix errors reported by customers in the issues above:
```
Argument of type 'SSMClient' is not assignable to parameter of type 'Client<any, any, any>'.
  The types of 'middlewareStack.concat' are incompatible between these types.
     ... and many other lines...
```

This error was due to an incompatibility between the `middlewareStack` types used by the `Client` type defined in the `@aws-sdk/types` package. The root cause behind this incompatibility is conflicting nested versions of the `@aws-sdk/types` package being used in this repo. These versions can be verified using the following command: 
```
npm ls @aws-sdk/types 
```
Which currently produces the following output: 
```
├─┬ @aws-sdk/config-resolver@3.12.0
│ ├─┬ @aws-sdk/signature-v4@3.12.0
│ │ └── @aws-sdk/types@3.12.0 
│ └── @aws-sdk/types@3.12.0 
├─┬ @aws-sdk/node-config-provider@3.12.0
│ ├─┬ @aws-sdk/property-provider@3.12.0
│ │ └── @aws-sdk/types@3.12.0 
│ └── @aws-sdk/types@3.12.0 
├─┬ @aws-sdk/smithy-client@3.15.0
│ └── @aws-sdk/types@3.15.0 
└─┬ aws-xray-sdk-core@3.4.1 
  └── @aws-sdk/types@3.6.1 
```

To fix the error reported above, a minimal type can be used to extract the `middlewareStack` from the AWS client being passed into `captureAWSv3client`. This will ensure that `middlewareStack.use` and `middlewareStack.remove` exist on the client (which are the necessary components for the implementation) while avoiding the minor version incompatibilities between their types. 

This change was tested using the following sample app:
```
import { DynamoDB, ListTablesCommand } from "@aws-sdk/client-dynamodb";
import {enableManualMode, setDaemonAddress, captureAWSv3Client, Segment} from "aws-xray-sdk"

(async () => {
  const dynamoDBClient = new DynamoDB({ region: "us-west-2" });
  
  enableManualMode();
  setDaemonAddress('0.0.0.0:2000');

  const segment = new Segment('myApplication'); 
  const instrumentedClient = captureAWSv3Client(dynamoDBClient, segment)

  try {
    const results = await instrumentedClient.send(new ListTablesCommand({}));
    console.log(results.TableNames.join("\n"));
  } catch (err) {
    console.error(err);
  } 

  segment.close();

})();
```

Prior to the changes, the `const instrumentedClient = captureAWSv3Client(dynamoDBClient, segment)` generated the error reported above. The error no longer persists after these changes. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
