### PR TITLE
Updated semver to latest version

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,7 @@
     "@types/cls-hooked": "^4.3.3",
     "atomic-batcher": "^1.0.2",
     "cls-hooked": "^4.2.2",
-    "semver": "^5.3.0"
+    "semver": "^7.3.8"
   },
   "scripts": {
     "prepare": "npm run compile",


### PR DESCRIPTION
Update semver dependency in core. There is a problem when using this package in combination with other packages that have a dependency on semver. Later versions of semver expose every function (like gte) as separate imports.
Current version of semver is fully backwards compatible.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
