### PR TITLE
Add TS declaration file for SegmentEmitter

### DIFF
--- a/packages/core/lib/segment_emitter.d.ts
+++ b/packages/core/lib/segment_emitter.d.ts
@@ -1,0 +1,13 @@
+import Segment = require('./segments/segment');
+
+export function format(segment: Segment): string;
+
+export function send(segment: Segment): void;
+
+export function setDaemonAddress(address: string): void;
+
+export function getIp(): string;
+
+export function getPort(): number;
+
+export function disableReusableSocket(): void;

--- a/packages/core/lib/segment_emitter.js
+++ b/packages/core/lib/segment_emitter.js
@@ -106,6 +106,7 @@ var SegmentEmitter = {
 
   /**
    * Returns the formatted segment JSON string.
+   * @param {Segment} segment - The segment to format.
    */
 
   format: function format(segment) {


### PR DESCRIPTION
*Issue #, if available:* [#576](https://github.com/aws/aws-xray-sdk-node/issues/576)

*Description of changes:* This PR adds a TypeScript declaration file (.d.ts) for the SegmentEmitter module to fix TS errors reported in the issue above. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
