### PR TITLE
Fix typo in fastify logger type declaration

### DIFF
--- a/sdk_contrib/fastify/lib/plugin.d.ts
+++ b/sdk_contrib/fastify/lib/plugin.d.ts
@@ -1,5 +1,5 @@
 import * as AWSXRay from 'aws-xray-sdk-core';
-import { FastityLoggerInstance } from 'fastify';
+import { FastifyLoggerInstance } from 'fastify';
 
 declare module 'fastify' {
   interface FastifyRequest {
@@ -12,7 +12,7 @@ export interface XRayFastifyPluginOptions {
   captureAWS: boolean;
   captureHTTP: boolean;
   capturePromises: boolean;
-  logger: FastityLoggerInstance;
+  logger: FastifyLoggerInstance;
   automaticMode: boolean;
   plugins: AWSXRay.plugins.Plugin[];
 }


### PR DESCRIPTION
*Issue #, if available:* #587

*Description of changes:* Fixes typo in import and type of `FastifyLoggerInstance` in `aws-xray-sdk-fastify` package


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
