### PR TITLE
[bugfix] Incorrect data variable usage + missing data injection in AWS v3 clients

### DIFF
--- a/packages/core/lib/patchers/aws3_p.ts
+++ b/packages/core/lib/patchers/aws3_p.ts
@@ -118,8 +118,9 @@ const getXRayMiddleware = (config: RegionResolvedConfig, manualSegment?: Segment
   }
   subsegment.addAttribute('namespace', 'aws');
   const parent = (segment instanceof Subsegment ? segment.segment : segment);
+  const data = parent.segment ? parent.segment.additionalTraceData : parent.additionalTraceData;
 
-  args.request.headers['X-Amzn-Trace-Id'] = stringify(
+  let traceHeader = stringify(
     {
       Root: parent.trace_id,
       Parent: subsegment.id,
@@ -127,6 +128,14 @@ const getXRayMiddleware = (config: RegionResolvedConfig, manualSegment?: Segment
     },
     ';',
   );
+
+  if (data != null) {
+    for (const [key, value] of Object.entries(data)) {
+      traceHeader += ';' + key +'=' + value;
+    }
+  }
+
+  args.request.headers['X-Amzn-Trace-Id'] = traceHeader;
 
   let res;
   try {

--- a/packages/core/lib/utils.js
+++ b/packages/core/lib/utils.js
@@ -189,7 +189,7 @@ var utils = {
       }
 
       if (traceData.data) {
-        segment.userData = traceData.data;
+        segment.additionalTraceData = traceData.data;
       }
 
       logger.getLogger().debug('Segment started: ' + JSON.stringify(traceData));

--- a/packages/core/test/unit/env/aws_lambda.test.js
+++ b/packages/core/test/unit/env/aws_lambda.test.js
@@ -222,8 +222,8 @@ describe('AWSLambda', function() {
 
       var facade = setSegmentStub.args[0][0];
       facade.resolveLambdaTraceData();
-      var userData = facade.userData;
-      assert.equal(userData['Lineage'], '1234abcd:4|3456abcd:6');
+      var additionalTraceData = facade.additionalTraceData;
+      assert.equal(additionalTraceData['Lineage'], '1234abcd:4|3456abcd:6');
     });
   });
 });

--- a/packages/core/test/unit/patchers/aws3_p.test.js
+++ b/packages/core/test/unit/patchers/aws3_p.test.js
@@ -100,6 +100,7 @@ describe('AWS v3 patcher', function() {
       })();
 
       segment = new Segment('testSegment', traceId);
+      segment.additionalTraceData = {'Foo': 'bar'};
       sub = segment.addNewSubsegment('subseg');
       stubResolve = sandbox.stub(contextUtils, 'resolveSegment').returns(segment);
       addNewSubsegmentStub = sandbox.stub(segment, 'addNewSubsegment').returns(sub);
@@ -135,7 +136,7 @@ describe('AWS v3 patcher', function() {
         assert.isTrue(addNewSubsegmentStub.calledWith('S3'));
 
 
-        const expected = new RegExp('^Root=' + traceId + ';Parent=' + sub.id + ';Sampled=1$');
+        const expected = new RegExp('^Root=' + traceId + ';Parent=' + sub.id + ';Sampled=1' + ';Foo=bar$');
         assert.match(awsRequest.request.headers['X-Amzn-Trace-Id'], expected);
       });
 
@@ -303,6 +304,7 @@ describe('AWS v3 patcher', function() {
       })();
 
       segment = new Segment('testSegment', traceId);
+      segment.additionalTraceData = {'Foo': 'bar'};
       sub = segment.addNewSubsegmentWithoutSampling('subseg');
       service = sub.addNewSubsegmentWithoutSampling('service');
 
@@ -331,7 +333,7 @@ describe('AWS v3 patcher', function() {
         assert.isTrue(addNewServiceSubsegmentStub.calledWith('S3'));
 
 
-        const expected = new RegExp('^Root=' + traceId + ';Parent=' + service.id + ';Sampled=0$');
+        const expected = new RegExp('^Root=' + traceId + ';Parent=' + service.id + ';Sampled=0' + ';Foo=bar$');
         assert.match(awsRequest.request.headers['X-Amzn-Trace-Id'], expected);
       });
     });


### PR DESCRIPTION
### Problem
[This PR](https://github.com/aws/aws-xray-sdk-node/pull/549) had a bug where I used the variable `userData` instead of `additionalData` and it made the code not work. 
Also there was a miss in adding the feature for AWS SDK v3 instrumented clients.

### Description of changes
This PR fixes the bug and extends the support to AWS SDK v3

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
