### PR TITLE
[CI] Keep lerna version consistent. Test on Node20. And more.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,40 @@
+name: Lint
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  lint:
+    name: Check code style
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout AWS XRay SDK Node Repository @ default branch latest
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+
+      - run: npm install -g npm@latest
+
+      - name: Cache NPM modules
+        uses: actions/cache@v3
+        with:
+          path: |
+            node_modules
+            package-lock.json
+            packages/*/node_modules
+            packages/*/package-lock.json
+          key: lint-${{ runner.os }}-${{ hashFiles('package.json', 'packages/*/package.json') }}-06142023
+
+      - name: Bootstrap
+        run: |
+          npm install
+          npx lerna bootstrap --no-ci --hoist
+
+      - name: Lint
+        run: npx lerna run lint

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -45,7 +45,7 @@ jobs:
             package-lock.json
             packages/*/node_modules
             packages/*/package-lock.json
-          key: ${{ matrix.os }}-${{ matrix.node_version }}-${{ hashFiles('package.json', 'packages/*/package.json') }}-06142023
+          key: ${{ matrix.os }}-${{ matrix.node-version }}-${{ hashFiles('package.json', 'packages/*/package.json') }}-06142023
 
       - name: Bootstrap
         run: |
@@ -55,11 +55,13 @@ jobs:
       - name: Build
         run: |
           npx lerna run compile
+        shell: bash
 
       - name: Execute tests with Lerna
         if: '!matrix.coverage'
         run: |
           npx lerna run test
+        shell: bash
 
       # Only need to report coverage once, so only run instrumented tests on one Node version/OS
       # Use lerna to get reports from all packages

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -45,9 +45,9 @@ jobs:
       - name: Execute tests with Lerna
         if: '!matrix.coverage'
         run: |
-          npx lerna@5.5.2 bootstrap --hoist
-          npx lerna@5.5.2 run compile
-          npx lerna@5.5.2 run test
+          npx lerna@6.6.2 bootstrap --hoist
+          npx lerna run compile
+          npx lerna run test
         shell: bash
         env:
           CI: true
@@ -57,9 +57,9 @@ jobs:
       - name: Report coverage
         if: matrix.coverage
         run: |
-          npx lerna@5.5.2 bootstrap --hoist
-          npx lerna@5.5.2 run testcov
-          npx lerna@5.5.2 run reportcov
+          npx lerna@6.6.2 bootstrap --hoist
+          npx lerna run testcov
+          npx lerna run reportcov
           echo test
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -85,5 +85,5 @@ jobs:
 
       - name: Lint repository
         run: |
-          npx lerna@5.5.2 bootstrap --hoist
-          npx lerna@5.5.2 run lint
+          npx lerna@6.6.2 bootstrap --hoist
+          npx lerna run lint

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -103,5 +103,5 @@ jobs:
 
       - name: Lint repository
         run: |
-          npx lerna@6.6.2 bootstrap --hoist
+          npx lerna bootstrap --hoist
           npx lerna run lint

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -21,10 +21,19 @@ jobs:
           - 14.x
           - 16.x
           - 18.x
+          - 20.x
         include:
           - os: ubuntu-latest
             node-version: 16.x
             coverage: true
+        # Issue with npm6 on windows resulting in failing workflows:
+        # https://github.com/srprash/aws-xray-sdk-node/actions/runs/5272315465
+        # Since node14 is EOL, we can drop this set from our tests. 
+        # We still test node14 on other platforms.
+        exclude:
+          - os: windows-latest
+            node-version: 14.x
+
     steps:
       - name: Checkout AWS XRay SDK Node Repository @ default branch latest
         uses: actions/checkout@v3

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -27,7 +27,7 @@ jobs:
             node-version: 16.x
             coverage: true
         # Issue with npm6 on windows resulting in failing workflows:
-        # https://github.com/srprash/aws-xray-sdk-node/actions/runs/5272315465
+        # https://github.com/npm/cli/issues/4341#issuecomment-1040608101
         # Since node14 is EOL, we can drop this set from our tests. 
         # We still test node14 on other platforms.
         exclude:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -35,32 +35,39 @@ jobs:
           node-version: ${{ matrix.node-version }}
           check-latest: true
 
+      - run: npm install -g npm@latest
 
       - name: Cache NPM modules
         uses: actions/cache@v3
         with:
-          path: $HOME/.npm
-          key: ${{ matrix.os }}-${{ hashFiles('package-lock.json') }}
+          path: |
+            node_modules
+            package-lock.json
+            packages/*/node_modules
+            packages/*/package-lock.json
+          key: ${{ matrix.os }}-${{ matrix.node_version }}-${{ hashFiles('package.json', 'packages/*/package.json') }}-06142023
+
+      - name: Bootstrap
+        run: |
+          npm install
+          npx lerna bootstrap --no-ci --hoist
+
+      - name: Build
+        run: |
+          npx lerna run compile
 
       - name: Execute tests with Lerna
         if: '!matrix.coverage'
         run: |
-          npx lerna@6.6.2 bootstrap --hoist
-          npx lerna run compile
           npx lerna run test
-        shell: bash
-        env:
-          CI: true
 
       # Only need to report coverage once, so only run instrumented tests on one Node version/OS
       # Use lerna to get reports from all packages
       - name: Report coverage
         if: matrix.coverage
         run: |
-          npx lerna@6.6.2 bootstrap --hoist
           npx lerna run testcov
           npx lerna run reportcov
-          echo test
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           CI: true

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -45,9 +45,9 @@ jobs:
       - name: Execute tests with Lerna
         if: '!matrix.coverage'
         run: |
-          npx lerna bootstrap --hoist
-          npx lerna run compile
-          npx lerna run test
+          npx lerna@6.6.2 bootstrap --hoist
+          npx lerna@6.6.2 run compile
+          npx lerna@6.6.2 run test
         shell: bash
         env:
           CI: true
@@ -57,9 +57,9 @@ jobs:
       - name: Report coverage
         if: matrix.coverage
         run: |
-          npx lerna bootstrap --hoist
-          npx lerna run testcov
-          npx lerna run reportcov
+          npx lerna@6.6.2 bootstrap --hoist
+          npx lerna@6.6.2 run testcov
+          npx lerna@6.6.2 run reportcov
           echo test
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -45,9 +45,9 @@ jobs:
       - name: Execute tests with Lerna
         if: '!matrix.coverage'
         run: |
-          npx lerna@6.6.2 bootstrap --hoist
-          npx lerna@6.6.2 run compile
-          npx lerna@6.6.2 run test
+          npx lerna@5.5.2 bootstrap --hoist
+          npx lerna@5.5.2 run compile
+          npx lerna@5.5.2 run test
         shell: bash
         env:
           CI: true
@@ -57,9 +57,9 @@ jobs:
       - name: Report coverage
         if: matrix.coverage
         run: |
-          npx lerna@6.6.2 bootstrap --hoist
-          npx lerna@6.6.2 run testcov
-          npx lerna@6.6.2 run reportcov
+          npx lerna@5.5.2 bootstrap --hoist
+          npx lerna@5.5.2 run testcov
+          npx lerna@5.5.2 run reportcov
           echo test
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -85,5 +85,5 @@ jobs:
 
       - name: Lint repository
         run: |
-          npx lerna bootstrap --hoist
-          npx lerna run lint
+          npx lerna@5.5.2 bootstrap --hoist
+          npx lerna@5.5.2 run lint

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -82,26 +82,3 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           CI: true
-
-  lint:
-    name: Check code style
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout AWS XRay SDK Node Repository @ default branch latest
-        uses: actions/checkout@v3
-
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
-
-      - name: Cache NPM modules
-        uses: actions/cache@v3
-        with:
-          path: $HOME/.npm
-          key: ${{ hashFiles('package-lock.json') }}
-
-      - name: Lint repository
-        run: |
-          npx lerna bootstrap --hoist
-          npx lerna run lint


### PR DESCRIPTION
### Problem
Recently lerna v7 got released and it broke our CI due to backward incompatible command. Upon investigation, I found that although we specify lerna v5.5.2 in our package.json, the latest version was being used for builds.

### Solution
Use the lerna version that is defined in the package.json. This is currently v5.5.2 which can be used for our build without any problems. In the future, we may think of migrating to a newer mechanism as per [this doc](https://lerna.js.org/docs/legacy-package-management).

### Changes
- Use `npm install` before using lerna to ensure that the one from our dependency is being used.
- Add testing on Node20
- Drop testing for Node14 on Windows due to [an issue with npm](https://github.com/npm/cli/issues/4341#issuecomment-1040608101) that the upstream will not fix.
- Minor refactors to the workflow, including moving lint to a separate workflow from build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
