### PR TITLE
Update semver dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3409,13 +3409,22 @@
         "@aws-sdk/types": "^3.4.1",
         "@types/cls-hooked": "^4.3.3",
         "atomic-batcher": "^1.0.2",
-        "cls-hooked": "^4.2.2"
+        "cls-hooked": "^4.2.2",
+        "semver": "^7.5.3"
       },
       "dependencies": {
         "@aws-sdk/types": {
           "version": "3.6.1",
           "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
           "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
+        "semver": {
+          "version": "7.5.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         }
       }
     },
@@ -8274,7 +8283,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -13345,8 +13353,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.10.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,7 @@
     "@types/cls-hooked": "^4.3.3",
     "atomic-batcher": "^1.0.2",
     "cls-hooked": "^4.2.2",
-    "semver": "^7.3.8"
+    "semver": "^7.5.3"
   },
   "scripts": {
     "prepare": "npm run compile",


### PR DESCRIPTION
*Description of changes:*

Update the version of the semver package. The old package version has vulnerability [CVE-2022-25883](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2022-25883).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
