### PR TITLE
fix collection of queries for mysql2

### DIFF
--- a/packages/mysql/README.md
+++ b/packages/mysql/README.md
@@ -18,6 +18,7 @@ Manual mode requires that you pass around the segment reference. See the example
 
     MYSQL_DATABASE_VERSION           Sets additional data for the sql subsegment.
     MYSQL_DRIVER_VERSION             Sets additional data for the sql subsegment.
+    AWS_XRAY_COLLECT_SQL_QUERIES     Add query to the subsegments sql data.
 
 ### Lambda Example
 

--- a/packages/mysql/lib/mysql_p.js
+++ b/packages/mysql/lib/mysql_p.js
@@ -165,8 +165,8 @@ function resolveArguments(argsObj) {
       // Patch for mysql2
       if (argsObj[0].values) {
         args.values = argsObj[0].values; // mysql implementation
-      } else if (typeof argsObj[2] === 'function') {
-        args.values = typeof argsObj[1] !== 'function' ? argsObj[1] : null; // mysql2 implementation
+      } else if (typeof argsObj[1] !== 'function') {
+        args.values = argsObj[1]; // mysql2 implementation
       }
       args.callback = typeof argsObj[1] === 'function'
         ? argsObj[1]
@@ -261,12 +261,12 @@ function captureOperation(name) {
 
 /**
  * Generate a SQL data object.  Note that this implementation differs from
- * that in postgres_p.js because the posgres client structures commands
+ * that in postgres_p.js because the postgres client structures commands
  * and prepared statements differently than mysql/mysql2.
  *
  * @param {object} config
  * @param {any} values
- * @param {string} sql
+ * @param {string|Object} sql
  * @returns SQL data object
  */
 function createSqlData(config, values, sql) {
@@ -276,7 +276,7 @@ function createSqlData(config, values, sql) {
     commandType);
 
   if (process.env.AWS_XRAY_COLLECT_SQL_QUERIES && sql) {
-    data.sanitized_query = sql;
+    data.sanitized_query = typeof sql === 'object' ? sql.sql : sql;
   }
 
   return data;

--- a/packages/mysql/test/unit/mysql_p.test.js
+++ b/packages/mysql/test/unit/mysql_p.test.js
@@ -260,6 +260,19 @@ describe('captureMySQL', function() {
         stubAddSql.should.have.been.calledWithExactly(sinon.match.instanceOf(SqlData));
         stubAddSql.should.have.been.calledWithExactly(sinon.match.has('sanitized_query', 'sql here'));
       });
+      it('should add query to the subsegments sql data when query options are used', function () {
+        sandbox.stub(process, 'env').value({ ...AWSXRay, 'AWS_XRAY_COLLECT_SQL_QUERIES': true });
+        var stubAddSql = sandbox.stub(subsegment, 'addSqlData');
+        var stubDataInit = sandbox.stub(SqlData.prototype, 'init');
+        var conParam = connectionObj.config;
+
+        query.call(connectionObj, { sql: 'sql with values binding = ?' }, [1]);
+
+        stubDataInit.should.have.been.calledWithExactly(process.env.MYSQL_DATABASE_VERSION, process.env.MYSQL_DRIVER_VERSION,
+          conParam.user, conParam.host + ':' + conParam.port + '/' + conParam.database, 'statement');
+        stubAddSql.should.have.been.calledWithExactly(sinon.match.instanceOf(SqlData));
+        stubAddSql.should.have.been.calledWithExactly(sinon.match.has('sanitized_query', 'sql with values binding = ?'));
+      });
       it('should NOT add query to the subsegments sql data when AWS_XRAY_COLLECT_SQL_QUERIES is not set', function () {
         sandbox.stub(process, 'env').value({ ...AWSXRay, 'AWS_XRAY_COLLECT_SQL_QUERIES': undefined });
         var stubAddSql = sandbox.stub(subsegment, 'addSqlData');


### PR DESCRIPTION
*Issue #, if available:*
I recently ran into an issue in using xray for mysql2 through Knex . Basically Knex uses query options for first parameter (`{ sql: 'sql here'}`) and sanitized_query expects a sql string.


*Description of changes:*

- Check for sql param type and use `sql` property if type object.
- Add docs for AWS_XRAY_COLLECT_SQL_QUERIES

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
