### PR TITLE
Prepares 3.5.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Changelog for AWS X-Ray SDK for JavaScript
-<!--LATEST=3.5.1-->
+<!--LATEST=3.5.2-->
 <!--ENTRYINSERT-->
+
+## 3.5.2
+View [the latest changes](https://github.com/aws/aws-xray-sdk-node/compare/aws-xray-sdk-node%403.5.1...aws-xray-sdk-node%403.5.2)
+* `aws-xray-sdk-core` updated to 3.5.2
+  * fix: capture command data for SDK v3 clients [PR #611](https://github.com/aws/aws-xray-sdk-node/pull/611)
+  * fix: memory leaks caused by cls-hooked [PR #595](https://github.com/aws/aws-xray-sdk-node/pull/595)
+* `aws-xray-sdk-mysql` updated to 3.5.2
+  * No further changes.
+* `aws-xray-sdk-express` updated to 3.5.2
+  * No further changes.
+* `aws-xray-sdk-postgres` updated to 3.5.2
+  * No further changes.
+* `aws-xray-sdk-restify` updated to 3.5.2
+  * No further changes.
+* `aws-xray-sdk-fastify` updated to 3.5.2
+  * No further changes.
+* `aws-xray-sdk-koa2` updated to 3.5.2
+  * No further changes.
+* `aws-xray-sdk-hapi` updated to 3.5.2
+  * No further changes.
 
 ## 3.5.1
 View [the latest changes](https://github.com/aws/aws-xray-sdk-node/compare/aws-xray-sdk-node%403.5.0...aws-xray-sdk-node%403.5.1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-xray-sdk-node",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-xray-sdk-node",
-      "version": "3.5.1",
+      "version": "3.5.2",
       "license": "Apache-2.0",
       "dependencies": {
         "aws-xray-sdk": "file:packages/full_sdk",
@@ -36,8 +36,8 @@
         "@typescript-eslint/eslint-plugin": "^4.25.0",
         "@typescript-eslint/parser": "^4.25.0",
         "aws-sdk": "^2.304.0",
-        "aws-xray-sdk-core": "3.5.1",
-        "aws-xray-sdk-express": "3.5.1",
+        "aws-xray-sdk-core": "3.5.2",
+        "aws-xray-sdk-express": "3.5.2",
         "chai": "^4.2.0",
         "cls-hooked": "^4.2.2",
         "codecov": "^3.8.3",
@@ -16945,7 +16945,7 @@
     },
     "packages/core": {
       "name": "aws-xray-sdk-core",
-      "version": "3.5.1",
+      "version": "3.5.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/service-error-classification": "^3.4.1",
@@ -16974,7 +16974,7 @@
     },
     "packages/express": {
       "name": "aws-xray-sdk-express",
-      "version": "3.5.1",
+      "version": "3.5.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/express": "*"
@@ -16983,12 +16983,12 @@
         "node": ">= 14.x"
       },
       "peerDependencies": {
-        "aws-xray-sdk-core": "^3.5.1"
+        "aws-xray-sdk-core": "^3.5.2"
       }
     },
     "packages/full_sdk": {
       "name": "aws-xray-sdk",
-      "version": "3.5.1",
+      "version": "3.5.2",
       "license": "Apache-2.0",
       "dependencies": {
         "aws-xray-sdk-core": "file:../core",
@@ -17002,7 +17002,7 @@
     },
     "packages/mysql": {
       "name": "aws-xray-sdk-mysql",
-      "version": "3.5.1",
+      "version": "3.5.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/mysql": "*"
@@ -17011,12 +17011,12 @@
         "node": ">= 14.x"
       },
       "peerDependencies": {
-        "aws-xray-sdk-core": "^3.5.1"
+        "aws-xray-sdk-core": "^3.5.2"
       }
     },
     "packages/postgres": {
       "name": "aws-xray-sdk-postgres",
-      "version": "3.5.1",
+      "version": "3.5.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/pg": "*"
@@ -17025,12 +17025,12 @@
         "node": ">= 14.x"
       },
       "peerDependencies": {
-        "aws-xray-sdk-core": "^3.5.1"
+        "aws-xray-sdk-core": "^3.5.2"
       }
     },
     "packages/restify": {
       "name": "aws-xray-sdk-restify",
-      "version": "3.5.1",
+      "version": "3.5.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/restify": "*"
@@ -17039,12 +17039,12 @@
         "node": ">= 14.x"
       },
       "peerDependencies": {
-        "aws-xray-sdk-core": "^3.5.1"
+        "aws-xray-sdk-core": "^3.5.2"
       }
     },
     "packages/test_express": {
       "name": "test-aws-xray-sdk-express",
-      "version": "3.5.1",
+      "version": "3.5.2",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 14.x"
@@ -17052,38 +17052,38 @@
     },
     "sdk_contrib/fastify": {
       "name": "aws-xray-sdk-fastify",
-      "version": "3.5.1",
+      "version": "3.5.2",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 14.x"
       },
       "peerDependencies": {
-        "aws-xray-sdk-core": "^3.5.1",
+        "aws-xray-sdk-core": "^3.5.2",
         "fastify": "^3.29.0",
         "fastify-plugin": "^4.2.0"
       }
     },
     "sdk_contrib/hapi": {
       "name": "aws-xray-sdk-hapi",
-      "version": "3.5.1",
+      "version": "3.5.2",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 14.x"
       },
       "peerDependencies": {
         "@hapi/hapi": ">=18.x",
-        "aws-xray-sdk-core": "^3.5.1"
+        "aws-xray-sdk-core": "^3.5.2"
       }
     },
     "sdk_contrib/koa": {
       "name": "aws-xray-sdk-koa2",
-      "version": "3.5.1",
+      "version": "3.5.2",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 14.x"
       },
       "peerDependencies": {
-        "aws-xray-sdk-core": "^3.5.1",
+        "aws-xray-sdk-core": "^3.5.2",
         "koa": "^2.0.0"
       }
     }
@@ -20547,8 +20547,8 @@
         "@typescript-eslint/parser": "^4.25.0",
         "aws-sdk": "^2.304.0",
         "aws-xray-sdk": "file:packages/full_sdk",
-        "aws-xray-sdk-core": "3.5.1",
-        "aws-xray-sdk-express": "3.5.1",
+        "aws-xray-sdk-core": "3.5.2",
+        "aws-xray-sdk-express": "3.5.2",
         "aws-xray-sdk-fastify": "file:sdk_contrib/fastify",
         "aws-xray-sdk-hapi": "file:sdk_contrib/hapi",
         "aws-xray-sdk-koa2": "file:sdk_contrib/koa",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-node",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "private": true,
   "license": "Apache-2.0",
   "overrides": {
@@ -23,8 +23,8 @@
     "@typescript-eslint/eslint-plugin": "^4.25.0",
     "@typescript-eslint/parser": "^4.25.0",
     "aws-sdk": "^2.304.0",
-    "aws-xray-sdk-core": "3.5.1",
-    "aws-xray-sdk-express": "3.5.1",
+    "aws-xray-sdk-core": "3.5.2",
+    "aws-xray-sdk-express": "3.5.2",
     "chai": "^4.2.0",
     "cls-hooked": "^4.2.2",
     "codecov": "^3.8.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-core",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "AWS X-Ray SDK for Javascript",
   "author": "Amazon Web Services",
   "contributors": [

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-express",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "AWS X-Ray Middleware for Express (Javascript)",
   "author": "Amazon Web Services",
   "contributors": [
@@ -18,7 +18,7 @@
     "@types/express": "*"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^3.5.1"
+    "aws-xray-sdk-core": "^3.5.2"
   },
   "scripts": {
     "test": "mocha --recursive ./test/ -R spec && tsd",

--- a/packages/full_sdk/package.json
+++ b/packages/full_sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "AWS X-Ray SDK for Javascript",
   "author": "Amazon Web Services",
   "contributors": [

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-mysql",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "AWS X-Ray Patcher for MySQL (Javascript)",
   "author": "Amazon Web Services",
   "contributors": [
@@ -18,7 +18,7 @@
     "@types/mysql": "*"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^3.5.1"
+    "aws-xray-sdk-core": "^3.5.2"
   },
   "scripts": {
     "test": "mocha --recursive ./test/ -R spec && tsd",

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-postgres",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "AWS X-Ray Patcher for Postgres (Javascript)",
   "author": "Amazon Web Services",
   "contributors": [
@@ -18,7 +18,7 @@
     "@types/pg": "*"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^3.5.1"
+    "aws-xray-sdk-core": "^3.5.2"
   },
   "scripts": {
     "test": "mocha --recursive ./test/ -R spec && tsd",

--- a/packages/restify/package.json
+++ b/packages/restify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-restify",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Enables AWS X-Ray for Restify (Javascript)",
   "author": "Amazon Web Services",
   "contributors": [
@@ -18,7 +18,7 @@
     "@types/restify": "*"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^3.5.1"
+    "aws-xray-sdk-core": "^3.5.2"
   },
   "scripts": {
     "test": "mocha --recursive ./test/ -R spec && tsd",

--- a/packages/test_express/package.json
+++ b/packages/test_express/package.json
@@ -1,7 +1,7 @@
 {
   "name": "test-aws-xray-sdk-express",
   "private": true,
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "AWS X-Ray Middleware for Express (Javascript)",
   "author": "Amazon Web Services",
   "contributors": [

--- a/sdk_contrib/fastify/package.json
+++ b/sdk_contrib/fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-fastify",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "AWS X-Ray plugin for Fastify",
   "author": "Amazon Web Services",
   "contributors": [
@@ -22,7 +22,7 @@
     "node": ">= 14.x"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^3.5.1",
+    "aws-xray-sdk-core": "^3.5.2",
     "fastify": "^3.29.0",
     "fastify-plugin": "^4.2.0"
   },

--- a/sdk_contrib/hapi/package.json
+++ b/sdk_contrib/hapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-hapi",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "AWS X-Ray plugin for Hapi.JS",
   "author": "Amazon Web Services",
   "contributors": [
@@ -24,7 +24,7 @@
   },
   "peerDependencies": {
     "@hapi/hapi": ">=18.x",
-    "aws-xray-sdk-core": "^3.5.1"
+    "aws-xray-sdk-core": "^3.5.2"
   },
   "keywords": [
     "amazon",

--- a/sdk_contrib/koa/package.json
+++ b/sdk_contrib/koa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-koa2",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "AWS X-Ray Middleware for koa (Javascript)",
   "author": "Amazon Web Services",
   "contributors": [
@@ -22,7 +22,7 @@
     "node": ">= 14.x"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^3.5.1",
+    "aws-xray-sdk-core": "^3.5.2",
     "koa": "^2.0.0"
   },
   "keywords": [


### PR DESCRIPTION
*Description of changes:*
Bump AWS X-Ray Node SDK components to version 3.5.2 and update CHANGELOG.md

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
