### PR TITLE
fix(core): serialize bigint in metadata to string

### DIFF
--- a/packages/core/lib/segments/attributes/subsegment.d.ts
+++ b/packages/core/lib/segments/attributes/subsegment.d.ts
@@ -61,6 +61,8 @@ declare class Subsegment {
   toString(): string;
 
   toJSON(): { [key: string]: any };
+
+  serialize(object?: Subsegment): string;
 }
 
 export = Subsegment;

--- a/packages/core/lib/segments/attributes/subsegment.d.ts
+++ b/packages/core/lib/segments/attributes/subsegment.d.ts
@@ -62,7 +62,7 @@ declare class Subsegment {
 
   toJSON(): { [key: string]: any };
 
-  serialize(object?: Subsegment): string;
+  serialize(subsegment?: Subsegment): string;
 }
 
 export = Subsegment;

--- a/packages/core/lib/segments/attributes/subsegment.js
+++ b/packages/core/lib/segments/attributes/subsegment.js
@@ -432,13 +432,10 @@ Subsegment.prototype.toJSON = function toJSON() {
  * Returns the serialized subsegment JSON string, replacing any BigInts with strings.
  */
 Subsegment.prototype.serialize = function serialize(object) {
-  return JSON.stringify(object ?? this, (_, value) => {
-    if (typeof value === 'bigint') {
-      return value.toString();
-    }
-
-    return value;
-  });
+  return JSON.stringify(
+    object ?? this,
+    SegmentUtils.getJsonStringifyReplacer()
+  );
 };
 
 module.exports = Subsegment;

--- a/packages/core/lib/segments/attributes/subsegment.js
+++ b/packages/core/lib/segments/attributes/subsegment.js
@@ -401,7 +401,7 @@ Subsegment.prototype.format = function format() {
     this.trace_id = this.segment.trace_id;
   }
 
-  return JSON.stringify(this);
+  return this.serialize();
 };
 
 /**
@@ -409,7 +409,7 @@ Subsegment.prototype.format = function format() {
  */
 
 Subsegment.prototype.toString = function toString() {
-  return JSON.stringify(this);
+  return this.serialize();
 };
 
 Subsegment.prototype.toJSON = function toJSON() {
@@ -426,6 +426,19 @@ Subsegment.prototype.toJSON = function toJSON() {
   );
 
   return thisCopy;
+};
+
+/**
+ * Returns the serialized subsegment JSON string, replacing any BigInts with strings.
+ */
+Subsegment.prototype.serialize = function serialize(object) {
+  return JSON.stringify(object ?? this, (_, value) => {
+    if (typeof value === 'bigint') {
+      return value.toString();
+    }
+
+    return value;
+  });
 };
 
 module.exports = Subsegment;

--- a/packages/core/lib/segments/segment.d.ts
+++ b/packages/core/lib/segments/segment.d.ts
@@ -64,6 +64,8 @@ declare class Segment {
   format(): string;
 
   toString(): string;
+
+  serialize(object?: Segment): string;
 }
 
 export = Segment;

--- a/packages/core/lib/segments/segment.d.ts
+++ b/packages/core/lib/segments/segment.d.ts
@@ -65,7 +65,7 @@ declare class Segment {
 
   toString(): string;
 
-  serialize(object?: Segment): string;
+  serialize(segment?: Segment): string;
 }
 
 export = Segment;

--- a/packages/core/lib/segments/segment.js
+++ b/packages/core/lib/segments/segment.js
@@ -439,13 +439,10 @@ Segment.prototype.toString = function toString() {
 };
 
 Segment.prototype.serialize = function serialize(object) {
-  return JSON.stringify(object ?? this, (_, value) => {
-    if (typeof value === 'bigint') {
-      return value.toString();
-    }
-
-    return value;
-  });
+  return JSON.stringify(
+    object ?? this,
+    SegmentUtils.getJsonStringifyReplacer()
+  );
 };
 
 module.exports = Segment;

--- a/packages/core/lib/segments/segment.js
+++ b/packages/core/lib/segments/segment.js
@@ -431,11 +431,21 @@ Segment.prototype.format = function format() {
     false
   );
 
-  return JSON.stringify(thisCopy);
+  return this.serialize(thisCopy);
 };
 
 Segment.prototype.toString = function toString() {
-  return JSON.stringify(this);
+  return this.serialize();
+};
+
+Segment.prototype.serialize = function serialize(object) {
+  return JSON.stringify(object ?? this, (_, value) => {
+    if (typeof value === 'bigint') {
+      return value.toString();
+    }
+
+    return value;
+  });
 };
 
 module.exports = Segment;

--- a/packages/core/lib/segments/segment_utils.d.ts
+++ b/packages/core/lib/segments/segment_utils.d.ts
@@ -17,3 +17,5 @@ export function setStreamingThreshold(threshold: number): void;
 export function getStreamingThreshold(): number;
 
 export function getHttpResponseData(res: http.ServerResponse): object;
+
+export function getJsonStringifyReplacer(): (key: string, value: any) => any;

--- a/packages/core/lib/segments/segment_utils.js
+++ b/packages/core/lib/segments/segment_utils.js
@@ -67,6 +67,14 @@ var utils = {
       ret.content_length = safeParseInt(res.headers['content-length']);
     }
     return ret;
+  },
+
+  getJsonStringifyReplacer: () => (_, value) => {
+    if (typeof value === 'bigint') {
+      return value.toString();
+    }
+
+    return value;
   }
 };
 

--- a/packages/core/test/unit/segments/attributes/subsegment.test.js
+++ b/packages/core/test/unit/segments/attributes/subsegment.test.js
@@ -332,6 +332,12 @@ describe('Subsegment', function() {
       child.flush();
       emitStub.should.have.been.called;
     });
+
+    it('should stringify bigint objects correctly', function() {
+      child.addMetadata('key', BigInt(9007199254740991));
+      child.flush();
+      emitStub.should.have.been.calledOnce;
+    });
   });
 
   describe('#streamSubsegments', function() {

--- a/packages/core/test/unit/segments/segment_utils.test.js
+++ b/packages/core/test/unit/segments/segment_utils.test.js
@@ -43,4 +43,14 @@ describe('SegmentUtils', function() {
       assert.deepEqual(emptyRes, {});
     });
   });
+
+  describe('#getJsonStringifyReplacer', () => {
+    it('should stringify BigInts', () => {
+      const obj = {foo: 1n, bar: BigInt(2)};
+      const replacer = SegmentUtils.getJsonStringifyReplacer();
+      const result = JSON.stringify(obj, replacer);
+
+      assert.equal(result, '{"foo":"1","bar":"2"}');
+    });
+  });
 });


### PR DESCRIPTION
*Issue #, if available:* closes #616

*Description of changes:*

This PR introduces a new method called `serialize` to the prototype of the `Segment` and `Subsegment` objects. This method wraps the `JSON.stringify()` call that was previously made by the `toString()` and `format()` methods of these two classes.

When calling the `JSON.stringify()` function, the method also passes a replacer function. This replacer for now includes an `if` statement that casts `BigInt` objects to `string`. This avoids runtimes errors described in the linked issue.

By extracting the method, customers can easily override it and extend the replacer to suit their needs.

In addition to the method, the PR includes also changes to the type definition and the addition of a test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
