### PR TITLE
TraceId timestamp supports string starts with '0'

### DIFF
--- a/packages/core/lib/segments/attributes/trace_id.js
+++ b/packages/core/lib/segments/attributes/trace_id.js
@@ -56,6 +56,8 @@ class TraceID {
     if (timestamp === 'NaN') {
       logger.getLogger().error('Trace ID timestamp must be a hex-encoded value');
       return traceID;
+    } else {
+      timestamp = timestamp.padStart(8, '0');
     }
 
     traceID.version = version;

--- a/packages/core/test/unit/segments/attributes/trace_id.test.js
+++ b/packages/core/test/unit/segments/attributes/trace_id.test.js
@@ -44,4 +44,12 @@ describe('TraceID', function() {
     var traceId = TraceID.FromString(traceStr);
     assert.equal(traceId.toString(), traceStr);
   });
+
+  it('should keep leading 0\'s for trace ID from given string', function() {
+    const traceStr = '1-00fbe041-2c7ad569f5d6ff149137be86';
+    var traceId = TraceID.FromString(traceStr);
+    assert.equal(traceId.version, 1);
+    assert.equal(traceId.timestamp, '00fbe041');
+    assert.equal(traceId.id, '2c7ad569f5d6ff149137be86');
+  });
 });


### PR DESCRIPTION
*Issue #, if available:*
If upstream is sending X-Ray like trace id but with timestamp section starts with `0`, such as "1-0074e2eb-694001932729d04067bb5440"
**Actual,**
The bug is: the trace id is parsed to "1-74e2eb-694001932729d04067bb5440".
**Expected**
The expected behavior is: the trace id is parsed to "1-0074e2eb-694001932729d04067bb5440".

*Description of changes:*
If the timestamp section in X-Ray like trace id less than 8 digits, pad `0`s as prefix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

*Description of changes:*
Unit Test
