### PR TITLE
aws-xray-sdk-fetch: fix subsegment callback error parameter type

### DIFF
--- a/sdk_contrib/fetch/lib/fetch_p.d.ts
+++ b/sdk_contrib/fetch/lib/fetch_p.d.ts
@@ -8,12 +8,12 @@ type fetchModuleFetch = (url: URL | fetchModule.RequestInfo, init?: fetchModule.
 
 export function captureFetchGlobal(
   downstreamXRayEnabled?: boolean,
-  subsegmentCallback?: (subsegment: AWSXRay.Subsegment, req: Request, res: Response | null, error: Error) => void):
+  subsegmentCallback?: (subsegment: AWSXRay.Subsegment, req: Request, res: Response | null, error?: Error | undefined) => void):
   typeof globalThis.fetch;
 
 export function captureFetchModule(
   fetch: FetchModuleType,
   downstreamXRayEnabled?: boolean,
-  subsegmentCallback?: (subsegment: AWSXRay.Subsegment, req: fetchModule.Request, res: fetchModule.Response | null, error: Error) => void):
+  subsegmentCallback?: (subsegment: AWSXRay.Subsegment, req: fetchModule.Request, res: fetchModule.Response | null, error?: Error | undefined) => void):
   (url: URL | fetchModule.RequestInfo, init?: fetchModule.RequestInit | undefined) => Promise<fetchModule.Response>;
 

--- a/sdk_contrib/fetch/test-d/index.test-d.ts
+++ b/sdk_contrib/fetch/test-d/index.test-d.ts
@@ -6,7 +6,7 @@ import { captureFetchGlobal, captureFetchModule } from '../lib/fetch_p';
 type ModuleFetch = (url: URL | fetchModule.RequestInfo, init?: fetchModule.RequestInit | undefined) => Promise<fetchModule.Response>;
 
 if (globalThis.fetch !== undefined) {
-  function fetchGlobalCallback(subsegment: AWSXRay.Subsegment, req: Request, res: Response | null, error: Error) {
+  function fetchGlobalCallback(subsegment: AWSXRay.Subsegment, req: Request, res: Response | null, error?: Error | undefined) {
     console.log({ subsegment, req, res, error });
   }
 
@@ -17,7 +17,7 @@ if (globalThis.fetch !== undefined) {
   expectType<typeof globalThis.fetch>(captureFetchGlobal(false, fetchGlobalCallback));
 }
 
-function fetchModuleCallback(subsegment: AWSXRay.Subsegment, req: fetchModule.Request, res: fetchModule.Response | null, error: Error) {
+function fetchModuleCallback(subsegment: AWSXRay.Subsegment, req: fetchModule.Request, res: fetchModule.Response | null, error?: Error | undefined) {
   console.log({ subsegment, req, res, error });
 }
 


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Error can be `undefined` when `subSegmentCallback` is called in this scenario, lines `119` to `121` in `fetch_p.js`.
```
if (thisSubsegmentCallback) {
    thisSubsegmentCallback(subsegment, requestClone, response);
}
```

These changes update the type from `error: Error` to `error?: Error | undefined`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.