### PR TITLE
Replace macos-latest with macos-13 for nodejs 14.x tests

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -26,12 +26,22 @@ jobs:
           - os: ubuntu-latest
             node-version: 16.x
             coverage: true
-        # Issue with npm6 on windows resulting in failing workflows:
-        # https://github.com/npm/cli/issues/4341#issuecomment-1040608101
-        # Since node14 is EOL, we can drop this set from our tests. 
-        # We still test node14 on other platforms.
+          - os: macos-13
+            node-version: 14.x
         exclude:
+          # Issue with npm6 on windows resulting in failing workflows:
+          # https://github.com/npm/cli/issues/4341#issuecomment-1040608101
+          # Since node14 is EOL, we can drop this set from our tests.
+          # We still test node14 on other platforms.
           - os: windows-latest
+            node-version: 14.x
+          # https://github.com/actions/runner-images/issues/9741
+          # macos-latest provides only ARM hosts
+          # https://github.com/nodejs/node/issues/36161
+          # https://github.com/nodejs/node/issues/40126
+          # Without workarounds, Node.js 14 isn't supported on ARM macos
+          # As workaround, test on macos-13 version instead
+          - os: macos-latest
             node-version: 14.x
 
     steps:


### PR DESCRIPTION
*Issue #, if available:*
Failing workflow on macos-latest w/ nodejs 14:
https://github.com/aws/aws-xray-sdk-node/actions/runs/9003814066/job/24971759228?pr=646

As of now, macos-latest provides only ARM hosts - https://github.com/actions/runner-images/issues/9741
https://github.com/actions/runner-images?tab=readme-ov-file#available-images
Without workarounds, Node.js 14 isn't supported on ARM macos.

*Description of changes:*
The fix in this PR is to test on macos-13 version instead

*Testing:*
https://github.com/jj22ee/aws-xray-sdk-node/actions/runs/9086772809


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
