### PR TITLE
Pass dispatcher options to global fetch

### DIFF
--- a/sdk_contrib/fetch/lib/fetch_p.js
+++ b/sdk_contrib/fetch/lib/fetch_p.js
@@ -63,6 +63,10 @@ const enableCapture = function enableCapture(baseFetchFunction, requestClass, do
     const request = typeof args[0] === 'object' ?
       args[0] :
       new requestClass(...args);
+    let fetchOptions = undefined;
+    if (args[1] && 'dispatcher' in args[1]) {
+      fetchOptions = { dispatcher: args[1].dispatcher };
+    }
 
     // Facilitate the addition of Segment information via the request arguments
     const params = args.length > 1 ? args[1] : {};
@@ -116,7 +120,7 @@ const enableCapture = function enableCapture(baseFetchFunction, requestClass, do
       const requestClone = request.clone();
       let response;
       try {
-        response = await baseFetchFunction(requestClone);
+        response = await baseFetchFunction(requestClone, fetchOptions);
 
         if (thisSubsegmentCallback) {
           thisSubsegmentCallback(subsegment, requestClone, response);

--- a/sdk_contrib/fetch/lib/fetch_p.js
+++ b/sdk_contrib/fetch/lib/fetch_p.js
@@ -63,10 +63,6 @@ const enableCapture = function enableCapture(baseFetchFunction, requestClass, do
     const request = typeof args[0] === 'object' ?
       args[0] :
       new requestClass(...args);
-    let fetchOptions = undefined;
-    if (args[1] && 'dispatcher' in args[1]) {
-      fetchOptions = { dispatcher: args[1].dispatcher };
-    }
 
     // Facilitate the addition of Segment information via the request arguments
     const params = args.length > 1 ? args[1] : {};
@@ -120,7 +116,7 @@ const enableCapture = function enableCapture(baseFetchFunction, requestClass, do
       const requestClone = request.clone();
       let response;
       try {
-        response = await baseFetchFunction(requestClone, fetchOptions);
+        response = await baseFetchFunction(...args);
 
         if (thisSubsegmentCallback) {
           thisSubsegmentCallback(subsegment, requestClone, response);

--- a/sdk_contrib/fetch/test/unit/fetch_p.test.js
+++ b/sdk_contrib/fetch/test/unit/fetch_p.test.js
@@ -339,6 +339,17 @@ describe('Unit tests', function () {
       response.should.equal(stubValidResponse);
     });
 
+    it('resolves to response through proxy when fetch options are supplied', async function() {
+      const activeFetch = captureFetch(true);
+      const proxyStub = sinon.stub();
+      const request = new FetchRequest('https://www.foo.com/test');
+      const response = await activeFetch(request, {
+        dispatcher: proxyStub
+      });
+      stubFetch.should.have.been.calledOnceWith(request, {dispatcher: proxyStub});
+      response.should.equal(stubValidResponse);
+    });
+
     it('calls subsegmentCallback with error upon fetch throwing', async function () {
       const spyCallback = sandbox.spy();
       const activeFetch = captureFetch(true, spyCallback);


### PR DESCRIPTION
*Issue: #650

*Description of changes:*
As the global fetch in node follows the [undici fetch](https://github.com/nodejs/undici?tab=readme-ov-file#undicifetchinput-init-promise) implementation there is an extra dispatcher option that can be passed but is not supported by the Request class.
We check if the extra option is supplied and if so pass the option directly to the global fetch call. All other paths already pass all options as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
