### PR TITLE
Add workflow to deprecate SDK version

### DIFF
--- a/.github/workflows/deprecate_version.yml
+++ b/.github/workflows/deprecate_version.yml
@@ -1,0 +1,31 @@
+name: Deprecate X-Ray Node SDK Version
+on:
+  workflow_dispatch:
+
+jobs:
+  deprecate_xray_node_sdk_version:
+    name: Deprecate X-Ray Node SDK version in NPM registry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm install -g npm@8.19.4
+
+      - name: Deprecate Version 3.7.0
+        run: |
+          npm deprecate aws-xray-sdk@3.7.0 "3.7.0 is deprecated due to known issue in Lambda"
+          npm deprecate aws-xray-sdk-core@3.7.0 "3.7.0 is deprecated due to known issue in Lambda"
+          npm deprecate aws-xray-sdk-express@3.7.0 "3.7.0 is deprecated due to known issue in Lambda"
+          npm deprecate aws-xray-sdk-postgres@3.7.0 "3.7.0 is deprecated due to known issue in Lambda"
+          npm deprecate aws-xray-sdk-mysql@3.7.0 "3.7.0 is deprecated due to known issue in Lambda"
+          npm deprecate aws-xray-sdk-restify@3.7.0 "3.7.0 is deprecated due to known issue in Lambda"
+          npm deprecate aws-xray-sdk-hapi@3.7.0 "3.7.0 is deprecated due to known issue in Lambda"
+          npm deprecate aws-xray-sdk-koa2@3.7.0 "3.7.0 is deprecated due to known issue in Lambda"
+          npm deprecate aws-xray-sdk-fastify@3.7.0 "3.7.0 is deprecated due to known issue in Lambda"
+          npm deprecate aws-xray-sdk-fetch@3.7.0 "3.7.0 is deprecated due to known issue in Lambda"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add workflow to specifically Deprecate v3.7.0 of the SDK. In the future, this workflow can be made more generic (add deprecation version and message as workflow input), but for now, 3.7.0 is specified. 

Similar deprecation workflow: https://github.com/aws-observability/aws-rum-web/blob/main/.github/workflows/npm_deprecate.yaml

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
