### PR TITLE
Lambda PassThrough trace header support

### DIFF
--- a/packages/core/lib/patchers/aws3_p.ts
+++ b/packages/core/lib/patchers/aws3_p.ts
@@ -140,7 +140,9 @@ const getXRayMiddleware = (config: RegionResolvedConfig, manualSegment?: Segment
     }
   }
 
-  args.request.headers['X-Amzn-Trace-Id'] = traceHeader;
+  if (!segment.noOp) {
+    args.request.headers['X-Amzn-Trace-Id'] = traceHeader;
+  }
 
   let res;
   try {

--- a/packages/core/lib/patchers/aws_p.js
+++ b/packages/core/lib/patchers/aws_p.js
@@ -88,6 +88,9 @@ function captureAWSRequest(req) {
   const data = parent.segment ? parent.segment.additionalTraceData : parent.additionalTraceData;
 
   var buildListener = function(req) {
+    if (parent.noOp) {
+      return;
+    }
     let traceHeader = 'Root=' + traceId + ';Parent=' + subsegment.id +
       ';Sampled=' + (subsegment.notTraced ? '0' : '1');
     if (data != null) {

--- a/packages/core/lib/patchers/http_p.js
+++ b/packages/core/lib/patchers/http_p.js
@@ -130,8 +130,10 @@ function enableCapture(module, downstreamXRayEnabled, subsegmentCallback) {
       options.headers = {};
     }
 
-    options.headers['X-Amzn-Trace-Id'] = 'Root=' + root.trace_id + ';Parent=' + subsegment.id +
-      ';Sampled=' + (subsegment.notTraced ? '0' : '1');
+    if (!parent.noOp) {
+      options.headers['X-Amzn-Trace-Id'] = 'Root=' + root.trace_id + ';Parent=' + subsegment.id +
+        ';Sampled=' + (subsegment.notTraced ? '0' : '1');
+    }
 
     const errorCapturer = function errorCapturer(e) {
       if (subsegmentCallback) {

--- a/packages/core/lib/segments/attributes/subsegment.js
+++ b/packages/core/lib/segments/attributes/subsegment.js
@@ -74,6 +74,7 @@ Subsegment.prototype.addSubsegment = function(subsegment) {
   subsegment.parent = this;
 
   subsegment.notTraced = subsegment.parent.notTraced;
+  subsegment.noOp = subsegment.parent.noOp;
 
   if (subsegment.end_time === undefined) {
     this.incrementCounter(subsegment.counter);

--- a/packages/core/lib/segments/segment.js
+++ b/packages/core/lib/segments/segment.js
@@ -248,6 +248,7 @@ Segment.prototype.addSubsegment = function addSubsegment(subsegment) {
   subsegment.parent = this;
 
   subsegment.notTraced = subsegment.parent.notTraced;
+  subsegment.noOp = subsegment.parent.noOp;
   this.subsegments.push(subsegment);
 
   if (!subsegment.end_time) {

--- a/packages/core/lib/utils.js
+++ b/packages/core/lib/utils.js
@@ -168,6 +168,10 @@ var utils = {
       if (!traceData) {
         traceData = {};
         logger.getLogger().error('_X_AMZN_TRACE_ID is empty or has an invalid format');
+      } else if (traceData.root && !traceData.parent && !traceData.sampled) {
+        // Lambda PassThrough only has root, treat as valid in this case and mark the segment
+        segment.noOp = true;
+        valid = true;
       } else if (!traceData.root || !traceData.parent || !traceData.sampled) {
         logger.getLogger().error('_X_AMZN_TRACE_ID is missing required information');
       } else {

--- a/sdk_contrib/fetch/lib/fetch_p.js
+++ b/sdk_contrib/fetch/lib/fetch_p.js
@@ -104,10 +104,12 @@ const enableCapture = function enableCapture(baseFetchFunction, requestClass, do
 
     subsegment.namespace = 'remote';
 
-    request.headers.set('X-Amzn-Trace-Id',
-      'Root=' + (parent.segment ? parent.segment : parent).trace_id +
-      ';Parent=' + subsegment.id +
-      ';Sampled=' + (subsegment.notTraced ? '0' : '1'));
+    if (!parent.noOp) {
+      request.headers.set('X-Amzn-Trace-Id',
+        'Root=' + (parent.segment ? parent.segment : parent).trace_id +
+        ';Parent=' + subsegment.id +
+        ';Sampled=' + (subsegment.notTraced ? '0' : '1'));
+    }
 
     // Set up fetch call and capture any thrown errors
     const capturedFetch = async () => {


### PR DESCRIPTION
Lambda trace header with passthrough will be missing parent and sampled attributes, we should be able to support this.

#651 was reverted and this PR works to do the same in a simpler way.

*Description of changes:*
- Detect lambda trace context and mark segments with `noOp` attribute, signifying passthrough mode
- Propagate this attribute to subsegments when they are added
- Detect `noOp` attribute to stop trace context propagation in passthrough mode
- Unit test checking if segment generated with passthrough behaviour (`segment.noOp == true`) results in the trace header not being propagated as expected

Testing:
Tested appropriate behaviour using two lambda functions:
- Lambda A (passthrough) calls Lambda B (active): [x]
- Lambda A (active) calls Lambda B (active):

And tested combinations of the following:
- Lambda function with old passthrough behaviour
- Lambda function with new passthrough behaviour
- Lambda function with AWS SDK v2
- Lambda function with AWS SDK v3


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
