### PR TITLE
feat: typescript definitions for mysql2 lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5155,6 +5155,15 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.1.tgz",
+      "integrity": "sha512-+H+kuK34PfMaI9PNU/NSjBKL5hh/KDM9J72kwYeYEm0A8B1AC4fuCy3qsjnA7lxklgyXsB68yn8Z2xoZEjgwCQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/aws-xray-sdk": {
       "resolved": "packages/full_sdk",
       "link": true
@@ -6789,6 +6798,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/depd": {
       "version": "1.1.2",
@@ -8724,6 +8742,15 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -10335,6 +10362,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
@@ -11805,6 +11838,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+      "license": "Apache-2.0"
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -13008,6 +13047,68 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "node_modules/mysql2": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.11.0.tgz",
+      "integrity": "sha512-J9phbsXGvTOcRVPR95YedzVSxJecpW5A5+cQ57rhHIFXteTP10HCs+VBjS7DHIKfEaI1zQ5tlVrquCd64A6YvA==",
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.1",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.6.3",
+        "long": "^5.2.1",
+        "lru-cache": "^8.0.0",
+        "named-placeholders": "^1.1.3",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/mysql2/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mysql2/node_modules/lru-cache": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-8.0.5.tgz",
+      "integrity": "sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.3.tgz",
+      "integrity": "sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==",
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "^7.14.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/named-placeholders/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.3",
@@ -16912,8 +17013,7 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sax": {
       "version": "1.2.1",
@@ -17028,6 +17128,11 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
@@ -17535,6 +17640,15 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "node_modules/sqlstring": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/ssri": {
       "version": "9.0.1",
@@ -19419,7 +19533,8 @@
       "version": "3.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/mysql": "*"
+        "@types/mysql": "*",
+        "mysql2": "*"
       },
       "engines": {
         "node": ">= 14.x"
@@ -23854,6 +23969,11 @@
         "xml2js": "0.5.0"
       }
     },
+    "aws-ssl-profiles": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.1.tgz",
+      "integrity": "sha512-+H+kuK34PfMaI9PNU/NSjBKL5hh/KDM9J72kwYeYEm0A8B1AC4fuCy3qsjnA7lxklgyXsB68yn8Z2xoZEjgwCQ=="
+    },
     "aws-xray-sdk": {
       "version": "file:packages/full_sdk",
       "requires": {
@@ -24095,7 +24215,8 @@
     "aws-xray-sdk-mysql": {
       "version": "file:packages/mysql",
       "requires": {
-        "@types/mysql": "*"
+        "@types/mysql": "*",
+        "mysql2": "*"
       }
     },
     "aws-xray-sdk-node": {
@@ -28245,6 +28366,11 @@
             "xml2js": "0.5.0"
           }
         },
+        "aws-ssl-profiles": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.1.tgz",
+          "integrity": "sha512-+H+kuK34PfMaI9PNU/NSjBKL5hh/KDM9J72kwYeYEm0A8B1AC4fuCy3qsjnA7lxklgyXsB68yn8Z2xoZEjgwCQ=="
+        },
         "aws-xray-sdk": {
           "version": "file:packages/full_sdk",
           "requires": {
@@ -28486,7 +28612,8 @@
         "aws-xray-sdk-mysql": {
           "version": "file:packages/mysql",
           "requires": {
-            "@types/mysql": "*"
+            "@types/mysql": "*",
+            "mysql2": "*"
           }
         },
         "aws-xray-sdk-postgres": {
@@ -29720,6 +29847,11 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+        },
+        "denque": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+          "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
         },
         "depd": {
           "version": "1.1.2",
@@ -31181,6 +31313,14 @@
             "wide-align": "^1.1.5"
           }
         },
+        "generate-function": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+          "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+          "requires": {
+            "is-property": "^1.0.2"
+          }
+        },
         "gensync": {
           "version": "1.0.0-beta.2",
           "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -32363,6 +32503,11 @@
             "isobject": "^3.0.1"
           }
         },
+        "is-property": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+          "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="
+        },
         "is-regex": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
@@ -33509,6 +33654,11 @@
             "is-unicode-supported": "^0.1.0"
           }
         },
+        "long": {
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+          "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+        },
         "lru-cache": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -34413,6 +34563,52 @@
           "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
           "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
           "dev": true
+        },
+        "mysql2": {
+          "version": "3.11.0",
+          "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.11.0.tgz",
+          "integrity": "sha512-J9phbsXGvTOcRVPR95YedzVSxJecpW5A5+cQ57rhHIFXteTP10HCs+VBjS7DHIKfEaI1zQ5tlVrquCd64A6YvA==",
+          "requires": {
+            "aws-ssl-profiles": "^1.1.1",
+            "denque": "^2.1.0",
+            "generate-function": "^2.3.1",
+            "iconv-lite": "^0.6.3",
+            "long": "^5.2.1",
+            "lru-cache": "^8.0.0",
+            "named-placeholders": "^1.1.3",
+            "seq-queue": "^0.0.5",
+            "sqlstring": "^2.3.2"
+          },
+          "dependencies": {
+            "iconv-lite": {
+              "version": "0.6.3",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+              "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+              }
+            },
+            "lru-cache": {
+              "version": "8.0.5",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-8.0.5.tgz",
+              "integrity": "sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA=="
+            }
+          }
+        },
+        "named-placeholders": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.3.tgz",
+          "integrity": "sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==",
+          "requires": {
+            "lru-cache": "^7.14.1"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "7.18.3",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+              "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
+            }
+          }
         },
         "nanoid": {
           "version": "3.3.3",
@@ -37346,8 +37542,7 @@
         "safer-buffer": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-          "dev": true
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "sax": {
           "version": "1.2.1",
@@ -37448,6 +37643,11 @@
               "dev": true
             }
           }
+        },
+        "seq-queue": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+          "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
         },
         "serialize-javascript": {
           "version": "6.0.0",
@@ -37854,6 +38054,11 @@
           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
           "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
           "dev": true
+        },
+        "sqlstring": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+          "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg=="
         },
         "ssri": {
           "version": "9.0.1",
@@ -40512,6 +40717,11 @@
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
+    "denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -41972,6 +42182,14 @@
         "wide-align": "^1.1.5"
       }
     },
+    "generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "requires": {
+        "is-property": "^1.0.2"
+      }
+    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -43154,6 +43372,11 @@
         "isobject": "^3.0.1"
       }
     },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="
+    },
     "is-regex": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
@@ -44300,6 +44523,11 @@
         "is-unicode-supported": "^0.1.0"
       }
     },
+    "long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -45204,6 +45432,52 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "mysql2": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.11.0.tgz",
+      "integrity": "sha512-J9phbsXGvTOcRVPR95YedzVSxJecpW5A5+cQ57rhHIFXteTP10HCs+VBjS7DHIKfEaI1zQ5tlVrquCd64A6YvA==",
+      "requires": {
+        "aws-ssl-profiles": "^1.1.1",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.6.3",
+        "long": "^5.2.1",
+        "lru-cache": "^8.0.0",
+        "named-placeholders": "^1.1.3",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "8.0.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-8.0.5.tgz",
+          "integrity": "sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA=="
+        }
+      }
+    },
+    "named-placeholders": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.3.tgz",
+      "integrity": "sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==",
+      "requires": {
+        "lru-cache": "^7.14.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "7.18.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+          "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
+        }
+      }
     },
     "nanoid": {
       "version": "3.3.3",
@@ -48137,8 +48411,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sax": {
       "version": "1.2.1",
@@ -48239,6 +48512,11 @@
           "dev": true
         }
       }
+    },
+    "seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
     },
     "serialize-javascript": {
       "version": "6.0.0",
@@ -48645,6 +48923,11 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "sqlstring": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg=="
     },
     "ssri": {
       "version": "9.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12359,11 +12359,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -33927,11 +33928,11 @@
           "dev": true
         },
         "micromatch": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-          "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+          "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
           "requires": {
-            "braces": "^3.0.2",
+            "braces": "^3.0.3",
             "picomatch": "^2.3.1"
           },
           "dependencies": {
@@ -44718,11 +44719,11 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "requires": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "dependencies": {

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -4,6 +4,7 @@
   "description": "AWS X-Ray Patcher for MySQL (Javascript)",
   "author": "Amazon Web Services",
   "contributors": [
+    "Ross Rhodes",
     "Sandra McMullen <mcmuls@amazon.com>"
   ],
   "main": "lib/index.js",
@@ -15,7 +16,8 @@
     "test": "test"
   },
   "dependencies": {
-    "@types/mysql": "*"
+    "@types/mysql": "*",
+    "mysql2": "*"
   },
   "peerDependencies": {
     "aws-xray-sdk-core": "^3.10.0"

--- a/packages/mysql/test-d/index.test-d.ts
+++ b/packages/mysql/test-d/index.test-d.ts
@@ -1,36 +1,59 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as AWSXRay from 'aws-xray-sdk-core';
 import * as MySQL from 'mysql';
+import * as MySQL2 from 'mysql2';
 import { expectType } from 'tsd';
 import { captureMySQL } from '../lib';
 
 const segment = AWSXRay.getSegment();
 
 const mysql = captureMySQL(MySQL);
+const mysql2 = captureMySQL(MySQL2);
 
 const config = {};
 
-const connection: captureMySQL.PatchedConnection = mysql.createConnection(config);
-const pool: captureMySQL.PatchedPool = mysql.createPool(config);
-const poolCluster: captureMySQL.PatchedPoolCluster = mysql.createPoolCluster(config);
-
-const queryCallback: MySQL.queryCallback = function(err: MySQL.MysqlError | null, rows: any) {
+const queryCallback: MySQL.queryCallback = function (err: MySQL.MysqlError | null, rows: any) {
 };
 
-const getConnectionCallback = function(err: MySQL.MysqlError, conn: captureMySQL.PatchedConnection) {
+const getConnectionCallback = function (err: MySQL.MysqlError, conn: captureMySQL.PatchedConnection) {
 };
 
-expectType<MySQL.Query>(connection.query('SELECT * FROM cats', queryCallback));
-expectType<MySQL.Query>(connection.query('SELECT * FROM cats', queryCallback, segment));
+const connectionMySQL: captureMySQL.PatchedConnection = mysql.createConnection(config);
+const poolMySQL: captureMySQL.PatchedPool = mysql.createPool(config);
+const poolClusterMySQL: captureMySQL.PatchedPoolCluster = mysql.createPoolCluster(config);
 
-expectType<MySQL.Query>(pool.query('SELECT * FROM cats', queryCallback));
-expectType<MySQL.Query>(pool.query('SELECT * FROM cats', queryCallback, segment));
-expectType<void>(pool.getConnection(getConnectionCallback));
+const poolMySQL2: captureMySQL.PatchedMySQL2Pool = mysql2.createPool(config);
+const poolClusterMySQL2: captureMySQL.PatchedMySQL2PoolCluster = mysql2.createPoolCluster(config);
 
-expectType<void>(poolCluster.getConnection(getConnectionCallback));
-expectType<void>(poolCluster.getConnection('pattern', getConnectionCallback));
-expectType<void>(poolCluster.getConnection('pattern', 'selector', getConnectionCallback));
+mysql2.createConnection(config).then(result => {
+  const connectionMySQL2: captureMySQL.PatchedConnection = result;
 
-expectType<captureMySQL.PatchedPool>(poolCluster.of('pattern'));
-expectType<captureMySQL.PatchedPool>(poolCluster.of('pattern', 'selector'));
-expectType<captureMySQL.PatchedPool>(poolCluster.of(null, 'selector'));
+  expectType<MySQL.Query>(connectionMySQL2.query('SELECT * FROM cats', queryCallback));
+  expectType<MySQL.Query>(connectionMySQL2.query('SELECT * FROM cats', queryCallback, segment));
+});
+
+expectType<MySQL.Query>(connectionMySQL.query('SELECT * FROM cats', queryCallback));
+expectType<MySQL.Query>(connectionMySQL.query('SELECT * FROM cats', queryCallback, segment));
+
+expectType<MySQL.Query>(poolMySQL.query('SELECT * FROM cats', queryCallback));
+expectType<MySQL.Query>(poolMySQL.query('SELECT * FROM cats', queryCallback, segment));
+expectType<void>(poolMySQL.getConnection(getConnectionCallback));
+
+expectType<MySQL.Query>(poolMySQL2.query('SELECT * FROM cats', queryCallback));
+expectType<MySQL.Query>(poolMySQL2.query('SELECT * FROM cats', queryCallback, segment));
+poolMySQL2.getConnection().then(result => { expectType<captureMySQL.PatchedConnection>(result); });
+
+expectType<void>(poolClusterMySQL.getConnection(getConnectionCallback));
+expectType<void>(poolClusterMySQL.getConnection('pattern', getConnectionCallback));
+expectType<void>(poolClusterMySQL.getConnection('pattern', 'selector', getConnectionCallback));
+
+poolClusterMySQL2.getConnection().then(result => { expectType<captureMySQL.PatchedConnection>(result) });
+poolClusterMySQL2.getConnection('pattern').then(result => { expectType<captureMySQL.PatchedConnection>(result) });
+poolClusterMySQL2.getConnection('pattern', 'selector').then(result => { expectType<captureMySQL.PatchedConnection>(result) });
+
+expectType<captureMySQL.PatchedPool>(poolClusterMySQL.of('pattern'));
+expectType<captureMySQL.PatchedPool>(poolClusterMySQL.of('pattern', 'selector'));
+expectType<captureMySQL.PatchedPool>(poolClusterMySQL.of(null, 'selector'));
+
+expectType<captureMySQL.PatchedMySQL2Pool>(poolClusterMySQL2.of('pattern'));
+expectType<captureMySQL.PatchedMySQL2Pool>(poolClusterMySQL2.of('pattern', 'selector'));


### PR DESCRIPTION
Closes #387.

Adding TypeScript definitions for patched MySQL2 connections, pools, and pool clusters. These definitions are derived from [promise.d.ts](https://github.com/sidorares/node-mysql2/blob/master/promise.d.ts) in `node-mysql2`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
