### PR TITLE
Prepares 3.10.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,30 @@
 # Changelog for AWS X-Ray SDK for JavaScript
 <!--LATEST=3.10.0-->
 <!--ENTRYINSERT-->
+
+## 3.10.2
+View [the latest changes](https://github.com/aws/aws-xray-sdk-node/compare/aws-xray-sdk-node%403.10.1...aws-xray-sdk-node%403.10.2)
+* `aws-xray-sdk-core` updated to 3.10.2
+  *  No further changes.
+* `aws-xray-sdk-mysql` updated to 3.10.2
+  *  No further changes.
+* `aws-xray-sdk-express` updated to 3.10.2
+  * No further changes.
+* `aws-xray-sdk-postgres` updated to 3.10.2
+  *  No further changes.
+* `aws-xray-sdk-restify` updated to 3.10.2
+  * No further changes.
+* `aws-xray-sdk-fastify` updated to 3.10.2
+  * Add default export and named export for fastify plugin
+* `aws-xray-sdk-koa2` updated to 3.10.2
+  * No further changes.
+* `aws-xray-sdk-hapi` updated to 3.10.2
+  * No further changes.
+* `aws-xray-sdk-fetch` updated to 3.10.2
+  * Fix missing X-Ray headers for fetch, add export for fetch enableCapture utility
+
 ## 3.10.1
-View [the latest changes](https://github.com/aws/aws-xray-sdk-node/compare/aws-xray-sdk-node%403.9.0...aws-xray-sdk-node%403.10.0)
+View [the latest changes](https://github.com/aws/aws-xray-sdk-node/compare/aws-xray-sdk-node%403.10.0...aws-xray-sdk-node%403.10.1)
 * `aws-xray-sdk-core` updated to 3.10.1
   * Bump dependency version for body-parser, express and find-my-way
   * These dependency version changes apply to all packages
@@ -20,7 +42,7 @@ View [the latest changes](https://github.com/aws/aws-xray-sdk-node/compare/aws-x
   * No further changes.
 * `aws-xray-sdk-hapi` updated to 3.10.1
   * No further changes.
-* `aws-xray-sdk-fetch` added in 3.10.1
+* `aws-xray-sdk-fetch` updated to 3.10.1
   *  No further changes.
 
 ## 3.10.0
@@ -41,7 +63,7 @@ View [the latest changes](https://github.com/aws/aws-xray-sdk-node/compare/aws-x
   * No further changes.
 * `aws-xray-sdk-hapi` updated to 3.10.0
   * No further changes.
-* `aws-xray-sdk-fetch` added in 3.10.0
+* `aws-xray-sdk-fetch` updated to 3.10.0
   *  Pass dispatcher options to global fetch [PR #653](https://github.com/aws/aws-xray-sdk-node/pull/653)
 
 ## 3.9.0
@@ -62,7 +84,7 @@ View [the latest changes](https://github.com/aws/aws-xray-sdk-node/compare/aws-x
   * No further changes.
 * `aws-xray-sdk-hapi` updated to 3.9.0
   * No further changes.
-* `aws-xray-sdk-fetch` added in 3.9.0
+* `aws-xray-sdk-fetch` updated to 3.9.0
   * No further changes.
 
 ## 3.8.0
@@ -83,7 +105,7 @@ View [the latest changes](https://github.com/aws/aws-xray-sdk-node/compare/aws-x
   * No further changes.
 * `aws-xray-sdk-hapi` updated to 3.8.0
   * No further changes.
-* `aws-xray-sdk-fetch` added in 3.8.0
+* `aws-xray-sdk-fetch` updated to 3.8.0
   * No further changes.
 
 ## 3.7.0
@@ -105,7 +127,7 @@ View [the latest changes](https://github.com/aws/aws-xray-sdk-node/compare/aws-x
   * No further changes.
 * `aws-xray-sdk-hapi` updated to 3.7.0
   * No further changes.
-* `aws-xray-sdk-fetch` added in 3.7.0
+* `aws-xray-sdk-fetch` updated to 3.7.0
   * Fix: fix subsegment callback error parameter type [PR #644](https://github.com/aws/aws-xray-sdk-node/pull/644)
 
 ## 3.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog for AWS X-Ray SDK for JavaScript
-<!--LATEST=3.10.0-->
+<!--LATEST=3.10.2-->
 <!--ENTRYINSERT-->
 
 ## 3.10.2
@@ -24,7 +24,7 @@ View [the latest changes](https://github.com/aws/aws-xray-sdk-node/compare/aws-x
   * Fix missing X-Ray headers for fetch, add export for fetch enableCapture utility
 
 ## 3.10.1
-View [the latest changes](https://github.com/aws/aws-xray-sdk-node/compare/aws-xray-sdk-node%403.10.0...aws-xray-sdk-node%403.10.1)
+View [the latest changes](https://github.com/aws/aws-xray-sdk-node/compare/aws-xray-sdk-node%403.9.0...aws-xray-sdk-node%403.10.0)
 * `aws-xray-sdk-core` updated to 3.10.1
   * Bump dependency version for body-parser, express and find-my-way
   * These dependency version changes apply to all packages
@@ -42,7 +42,7 @@ View [the latest changes](https://github.com/aws/aws-xray-sdk-node/compare/aws-x
   * No further changes.
 * `aws-xray-sdk-hapi` updated to 3.10.1
   * No further changes.
-* `aws-xray-sdk-fetch` updated to 3.10.1
+* `aws-xray-sdk-fetch` added in 3.10.1
   *  No further changes.
 
 ## 3.10.0
@@ -63,7 +63,7 @@ View [the latest changes](https://github.com/aws/aws-xray-sdk-node/compare/aws-x
   * No further changes.
 * `aws-xray-sdk-hapi` updated to 3.10.0
   * No further changes.
-* `aws-xray-sdk-fetch` updated to 3.10.0
+* `aws-xray-sdk-fetch` added in 3.10.0
   *  Pass dispatcher options to global fetch [PR #653](https://github.com/aws/aws-xray-sdk-node/pull/653)
 
 ## 3.9.0
@@ -84,7 +84,7 @@ View [the latest changes](https://github.com/aws/aws-xray-sdk-node/compare/aws-x
   * No further changes.
 * `aws-xray-sdk-hapi` updated to 3.9.0
   * No further changes.
-* `aws-xray-sdk-fetch` updated to 3.9.0
+* `aws-xray-sdk-fetch` added in 3.9.0
   * No further changes.
 
 ## 3.8.0
@@ -105,7 +105,7 @@ View [the latest changes](https://github.com/aws/aws-xray-sdk-node/compare/aws-x
   * No further changes.
 * `aws-xray-sdk-hapi` updated to 3.8.0
   * No further changes.
-* `aws-xray-sdk-fetch` updated to 3.8.0
+* `aws-xray-sdk-fetch` added in 3.8.0
   * No further changes.
 
 ## 3.7.0
@@ -127,7 +127,7 @@ View [the latest changes](https://github.com/aws/aws-xray-sdk-node/compare/aws-x
   * No further changes.
 * `aws-xray-sdk-hapi` updated to 3.7.0
   * No further changes.
-* `aws-xray-sdk-fetch` updated to 3.7.0
+* `aws-xray-sdk-fetch` added in 3.7.0
   * Fix: fix subsegment callback error parameter type [PR #644](https://github.com/aws/aws-xray-sdk-node/pull/644)
 
 ## 3.6.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-xray-sdk-node",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-xray-sdk-node",
-      "version": "3.10.1",
+      "version": "3.10.2",
       "license": "Apache-2.0",
       "dependencies": {
         "aws-xray-sdk": "file:packages/full_sdk",
@@ -37,8 +37,8 @@
         "@typescript-eslint/eslint-plugin": "^4.25.0",
         "@typescript-eslint/parser": "^4.25.0",
         "aws-sdk": "^2.304.0",
-        "aws-xray-sdk-core": "3.10.1",
-        "aws-xray-sdk-express": "3.10.1",
+        "aws-xray-sdk-core": "3.10.2",
+        "aws-xray-sdk-express": "3.10.2",
         "chai": "^4.2.0",
         "cls-hooked": "^4.2.2",
         "codecov": "^3.8.3",
@@ -19397,7 +19397,7 @@
     },
     "packages/core": {
       "name": "aws-xray-sdk-core",
-      "version": "3.10.1",
+      "version": "3.10.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.4.1",
@@ -19426,7 +19426,7 @@
     },
     "packages/express": {
       "name": "aws-xray-sdk-express",
-      "version": "3.10.1",
+      "version": "3.10.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/express": "*"
@@ -19435,12 +19435,12 @@
         "node": ">= 14.x"
       },
       "peerDependencies": {
-        "aws-xray-sdk-core": "^3.10.1"
+        "aws-xray-sdk-core": "^3.10.2"
       }
     },
     "packages/full_sdk": {
       "name": "aws-xray-sdk",
-      "version": "3.10.1",
+      "version": "3.10.2",
       "license": "Apache-2.0",
       "dependencies": {
         "aws-xray-sdk-core": "file:../core",
@@ -19454,7 +19454,7 @@
     },
     "packages/mysql": {
       "name": "aws-xray-sdk-mysql",
-      "version": "3.10.1",
+      "version": "3.10.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/mysql": "*"
@@ -19463,12 +19463,12 @@
         "node": ">= 14.x"
       },
       "peerDependencies": {
-        "aws-xray-sdk-core": "^3.10.1"
+        "aws-xray-sdk-core": "^3.10.2"
       }
     },
     "packages/postgres": {
       "name": "aws-xray-sdk-postgres",
-      "version": "3.10.1",
+      "version": "3.10.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/pg": "*"
@@ -19477,12 +19477,12 @@
         "node": ">= 14.x"
       },
       "peerDependencies": {
-        "aws-xray-sdk-core": "^3.10.1"
+        "aws-xray-sdk-core": "^3.10.2"
       }
     },
     "packages/restify": {
       "name": "aws-xray-sdk-restify",
-      "version": "3.10.1",
+      "version": "3.10.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/restify": "*"
@@ -19491,12 +19491,12 @@
         "node": ">= 14.x"
       },
       "peerDependencies": {
-        "aws-xray-sdk-core": "^3.10.1"
+        "aws-xray-sdk-core": "^3.10.2"
       }
     },
     "packages/test_express": {
       "name": "test-aws-xray-sdk-express",
-      "version": "3.10.1",
+      "version": "3.10.2",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 14.x"
@@ -19504,20 +19504,20 @@
     },
     "sdk_contrib/fastify": {
       "name": "aws-xray-sdk-fastify",
-      "version": "3.10.1",
+      "version": "3.10.2",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 14.x"
       },
       "peerDependencies": {
-        "aws-xray-sdk-core": "^3.10.1",
+        "aws-xray-sdk-core": "^3.10.2",
         "fastify": "^4.0.1",
         "fastify-plugin": "^4.2.0"
       }
     },
     "sdk_contrib/fetch": {
       "name": "aws-xray-sdk-fetch",
-      "version": "3.10.1",
+      "version": "3.10.2",
       "license": "Apache-2.0",
       "dependencies": {
         "tsd": "^0.28.1"
@@ -19532,7 +19532,7 @@
         "node": ">= 14.x"
       },
       "peerDependencies": {
-        "aws-xray-sdk-core": "^3.10.1"
+        "aws-xray-sdk-core": "^3.10.2"
       }
     },
     "sdk_contrib/fetch/node_modules/@tsd/typescript": {
@@ -19783,25 +19783,25 @@
     },
     "sdk_contrib/hapi": {
       "name": "aws-xray-sdk-hapi",
-      "version": "3.10.1",
+      "version": "3.10.2",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 14.x"
       },
       "peerDependencies": {
         "@hapi/hapi": ">=18.x",
-        "aws-xray-sdk-core": "^3.10.1"
+        "aws-xray-sdk-core": "^3.10.2"
       }
     },
     "sdk_contrib/koa": {
       "name": "aws-xray-sdk-koa2",
-      "version": "3.10.1",
+      "version": "3.10.2",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 14.x"
       },
       "peerDependencies": {
-        "aws-xray-sdk-core": "^3.10.1",
+        "aws-xray-sdk-core": "^3.10.2",
         "koa": "^2.0.0"
       }
     }
@@ -24154,8 +24154,8 @@
         "@typescript-eslint/parser": "^4.25.0",
         "aws-sdk": "^2.304.0",
         "aws-xray-sdk": "file:packages/full_sdk",
-        "aws-xray-sdk-core": "3.10.1",
-        "aws-xray-sdk-express": "3.10.1",
+        "aws-xray-sdk-core": "3.10.2",
+        "aws-xray-sdk-express": "3.10.2",
         "aws-xray-sdk-fastify": "file:sdk_contrib/fastify",
         "aws-xray-sdk-fetch": "file:sdk_contrib/fetch",
         "aws-xray-sdk-hapi": "file:sdk_contrib/hapi",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-node",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "private": true,
   "license": "Apache-2.0",
   "overrides": {
@@ -23,8 +23,8 @@
     "@typescript-eslint/eslint-plugin": "^4.25.0",
     "@typescript-eslint/parser": "^4.25.0",
     "aws-sdk": "^2.304.0",
-    "aws-xray-sdk-core": "3.10.1",
-    "aws-xray-sdk-express": "3.10.1",
+    "aws-xray-sdk-core": "3.10.2",
+    "aws-xray-sdk-express": "3.10.2",
     "chai": "^4.2.0",
     "cls-hooked": "^4.2.2",
     "codecov": "^3.8.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-core",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "AWS X-Ray SDK for Javascript",
   "author": "Amazon Web Services",
   "contributors": [

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-express",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "AWS X-Ray Middleware for Express (Javascript)",
   "author": "Amazon Web Services",
   "contributors": [
@@ -18,7 +18,7 @@
     "@types/express": "*"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^3.10.1"
+    "aws-xray-sdk-core": "^3.10.2"
   },
   "scripts": {
     "test": "mocha --recursive ./test/ -R spec && tsd",

--- a/packages/full_sdk/package.json
+++ b/packages/full_sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "AWS X-Ray SDK for Javascript",
   "author": "Amazon Web Services",
   "contributors": [

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-mysql",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "AWS X-Ray Patcher for MySQL (Javascript)",
   "author": "Amazon Web Services",
   "contributors": [
@@ -18,7 +18,7 @@
     "@types/mysql": "*"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^3.10.1"
+    "aws-xray-sdk-core": "^3.10.2"
   },
   "scripts": {
     "test": "mocha --recursive ./test/ -R spec && tsd",

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-postgres",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "AWS X-Ray Patcher for Postgres (Javascript)",
   "author": "Amazon Web Services",
   "contributors": [
@@ -18,7 +18,7 @@
     "@types/pg": "*"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^3.10.1"
+    "aws-xray-sdk-core": "^3.10.2"
   },
   "scripts": {
     "test": "mocha --recursive ./test/ -R spec && tsd",

--- a/packages/restify/package.json
+++ b/packages/restify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-restify",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "Enables AWS X-Ray for Restify (Javascript)",
   "author": "Amazon Web Services",
   "contributors": [
@@ -18,7 +18,7 @@
     "@types/restify": "*"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^3.10.1"
+    "aws-xray-sdk-core": "^3.10.2"
   },
   "scripts": {
     "test": "mocha --recursive ./test/ -R spec && tsd",

--- a/packages/test_express/package.json
+++ b/packages/test_express/package.json
@@ -1,7 +1,7 @@
 {
   "name": "test-aws-xray-sdk-express",
   "private": true,
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "AWS X-Ray Middleware for Express (Javascript)",
   "author": "Amazon Web Services",
   "contributors": [

--- a/sdk_contrib/fastify/package.json
+++ b/sdk_contrib/fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-fastify",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "AWS X-Ray plugin for Fastify",
   "author": "Amazon Web Services",
   "contributors": [
@@ -22,7 +22,7 @@
     "node": ">= 14.x"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^3.10.1",
+    "aws-xray-sdk-core": "^3.10.2",
     "fastify": "^4.0.1",
     "fastify-plugin": "^4.2.0"
   },

--- a/sdk_contrib/fetch/package.json
+++ b/sdk_contrib/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-fetch",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "AWS X-Ray plugin for node-fetch",
   "author": "Amazon Web Services",
   "contributors": [
@@ -21,7 +21,7 @@
     "node": ">= 14.x"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^3.10.1"
+    "aws-xray-sdk-core": "^3.10.2"
   },
   "keywords": [
     "amazon",

--- a/sdk_contrib/hapi/package.json
+++ b/sdk_contrib/hapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-hapi",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "AWS X-Ray plugin for Hapi.JS",
   "author": "Amazon Web Services",
   "contributors": [
@@ -24,7 +24,7 @@
   },
   "peerDependencies": {
     "@hapi/hapi": ">=18.x",
-    "aws-xray-sdk-core": "^3.10.1"
+    "aws-xray-sdk-core": "^3.10.2"
   },
   "keywords": [
     "amazon",

--- a/sdk_contrib/koa/package.json
+++ b/sdk_contrib/koa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-xray-sdk-koa2",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "AWS X-Ray Middleware for koa (Javascript)",
   "author": "Amazon Web Services",
   "contributors": [
@@ -22,7 +22,7 @@
     "node": ">= 14.x"
   },
   "peerDependencies": {
-    "aws-xray-sdk-core": "^3.10.1",
+    "aws-xray-sdk-core": "^3.10.2",
     "koa": "^2.0.0"
   },
   "keywords": [


### PR DESCRIPTION
*Description of changes:*
Bump AWS X-Ray Node SDK components to version 3.10.2 and update CHANGELOG.md

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
