### PR TITLE
Add proxy support for global fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "sinon-chai": "^3.5.0",
         "tsd": "^0.25.0",
         "typescript": "^4.4.4",
+        "undici": "^6.21.0",
         "upath": "^1.2.0"
       },
       "engines": {
@@ -18701,6 +18702,16 @@
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
       "dev": true
     },
+    "node_modules/undici": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.0.tgz",
+      "integrity": "sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/unique-filename": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
@@ -24195,6 +24206,7 @@
         "test-aws-xray-sdk-express": "file:packages/test_express",
         "tsd": "^0.25.0",
         "typescript": "^4.4.4",
+        "undici": "^6.21.0",
         "upath": "^1.2.0"
       },
       "dependencies": {
@@ -38793,6 +38805,12 @@
             }
           }
         },
+        "undici": {
+          "version": "6.21.0",
+          "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.0.tgz",
+          "integrity": "sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==",
+          "dev": true
+        },
         "unique-filename": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
@@ -49609,6 +49627,12 @@
           "dev": true
         }
       }
+    },
+    "undici": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.0.tgz",
+      "integrity": "sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==",
+      "dev": true
     },
     "unique-filename": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "sinon-chai": "^3.5.0",
     "tsd": "^0.25.0",
     "typescript": "^4.4.4",
+    "undici": "^6.21.0",
     "upath": "^1.2.0"
   },
   "engines": {

--- a/sdk_contrib/fetch/lib/fetch_p.js
+++ b/sdk_contrib/fetch/lib/fetch_p.js
@@ -77,6 +77,7 @@ function enableCapture(baseFetchFunction, requestClass, downstreamXRayEnabled, s
 
     // Facilitate the addition of Segment information via the request arguments
     const params = args.length > 1 ? args[1] : {};
+    const fetchOptions = 'dispatcher' in params ? {dispatcher: params.dispatcher} : undefined;
 
     // Short circuit if the HTTP is already being captured
     if (request.headers.has('X-Amzn-Trace-Id')) {
@@ -127,7 +128,7 @@ function enableCapture(baseFetchFunction, requestClass, downstreamXRayEnabled, s
       const requestClone = request.clone();
       let response;
       try {
-        response = await baseFetchFunction(requestClone);
+        response = await baseFetchFunction(requestClone, fetchOptions);
 
         if (thisSubsegmentCallback) {
           thisSubsegmentCallback(subsegment, requestClone, response);

--- a/sdk_contrib/fetch/test/unit/fetch_p.test.js
+++ b/sdk_contrib/fetch/test/unit/fetch_p.test.js
@@ -339,6 +339,20 @@ describe('Unit tests', function () {
       response.should.equal(stubValidResponse);
     });
 
+    it('resolves to response through proxy when fetch options are supplied', async function () {
+      const activeFetch = captureFetch(true);
+      const proxyStub = sinon.stub();
+      const request = new FetchRequest('https://www.foo.com/test');
+      const response = await activeFetch(request, {
+        dispatcher: proxyStub
+      });
+      stubFetch.should.have.been.calledOnce;
+      const callArgs = stubFetch.firstCall.args;
+      callArgs[0].should.contain(request);
+      callArgs[1].dispatcher.should.equal(proxyStub);
+      response.should.equal(stubValidResponse);
+    });
+
     it('calls subsegmentCallback with error upon fetch throwing', async function () {
       const spyCallback = sandbox.spy();
       const activeFetch = captureFetch(true, spyCallback);


### PR DESCRIPTION
*Issue #650:*

*Description of changes:*
Support setting the dispatcher for the global fetch implementation.
Instead of ignoring the created request, we now use it and pass the dispatcher option if it is available.

Added an integration test with a reverse proxy to check that the trace header is there.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
