### PR TITLE
fix 648 url object

### DIFF
--- a/sdk_contrib/fetch/lib/fetch_p.js
+++ b/sdk_contrib/fetch/lib/fetch_p.js
@@ -71,7 +71,7 @@ function enableCapture(baseFetchFunction, requestClass, downstreamXRayEnabled, s
     const thisDownstreamXRayEnabled = !!downstreamXRayEnabled;
     const thisSubsegmentCallback = subsegmentCallback;
     // Standardize request information
-    const request = typeof args[0] === 'object' ?
+    const request = args[0] instanceof requestClass ?
       args[0] :
       new requestClass(...args);
 

--- a/sdk_contrib/fetch/test/integration/fetch_p.test.js
+++ b/sdk_contrib/fetch/test/integration/fetch_p.test.js
@@ -111,6 +111,26 @@ describe('Integration tests', function () {
         stubClose.should.have.been.calledOnce;
       });
 
+      it('works with stringifyable objects', async function () {
+        const spyCallback = sandbox.spy();
+        const fetch = captureFetchGlobal(true, spyCallback);
+        const response = await fetch(new URL(goodUrl), {
+          headers: {
+            'foo': 'bar'
+          }
+        });
+        response.status.should.equal(200);
+        receivedHeaders.should.to.have.property('x-amzn-trace-id');
+        receivedHeaders.should.to.have.property('foo', 'bar');
+        (await response.text()).should.contain('Example');
+        stubIsAutomaticMode.should.have.been.called;
+        stubAddNewSubsegment.should.have.been.calledOnce;
+        stubResolveSegment.should.have.been.calledOnce;
+        stubAddFetchRequestData.should.have.been.calledOnce;
+        stubAddErrorFlag.should.not.have.been.calledOnce;
+        stubClose.should.have.been.calledOnce;
+      });
+
       it('sets error flag on failed fetch when global fetch exists', async function () {
         const spyCallback = sandbox.spy();
         const fetch = captureFetchGlobal(true, spyCallback);

--- a/sdk_contrib/fetch/test/unit/fetch_p.test.js
+++ b/sdk_contrib/fetch/test/unit/fetch_p.test.js
@@ -1,4 +1,5 @@
 const { Subsegment } = require('aws-xray-sdk-core');
+const { Agent } = require('http');
 const fetch = require('node-fetch');
 
 describe('Unit tests', function () {
@@ -157,13 +158,13 @@ describe('Unit tests', function () {
 
     it('short circuits if headers include trace ID', async function () {
       const activeFetch = captureFetch(true);
-      const request = new fetchModule.Request('https://www.foo.com', {
+      const request = new Request('https://www.foo.com', {
         headers: {
           'X-Amzn-Trace-Id': '12345'
         }
       });
       await activeFetch(request);
-      stubFetch.should.have.been.calledOnceWith(request);
+      stubFetch.should.have.been.calledOnceWith(sinon.match({ url: 'https://www.foo.com/'}));
       stubResolveSegment.should.not.have.been.called;
     });
 


### PR DESCRIPTION
*Issue #, if available:*
#648
*Description of changes:*
Implementation:
`args[0]` in fetch_p.js, line 74 could be any stringifyable object, not just a string. That object should be converted to a string and used as URL. The only exception to this is if `args[0]` is already a request object.
This PR assumes that such a request object must be from the same implementation as the one given by requestClass. So if you would put a one Request object from e.g. node-fetch into the native fetch implementation, this will stringify that request object.
I couldn't find any "official" way to distinguish between a request object and a stringifyable object. But you're supposed to call fetch with the corresponding request implementation, I think this is fair game.

For that reason, the test was changed, so it will provide the native Request object.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
