### PR TITLE
Fix 648 url object not accepted and 650 dispatcher not respected

### DIFF
--- a/sdk_contrib/fetch/lib/fetch_p.js
+++ b/sdk_contrib/fetch/lib/fetch_p.js
@@ -71,7 +71,7 @@ function enableCapture(baseFetchFunction, requestClass, downstreamXRayEnabled, s
     const thisDownstreamXRayEnabled = !!downstreamXRayEnabled;
     const thisSubsegmentCallback = subsegmentCallback;
     // Standardize request information
-    const request = typeof args[0] === 'object' ?
+    const request = args[0] instanceof requestClass ?
       args[0] :
       new requestClass(...args);
 

--- a/sdk_contrib/fetch/lib/fetch_p.js
+++ b/sdk_contrib/fetch/lib/fetch_p.js
@@ -92,7 +92,7 @@ function enableCapture(baseFetchFunction, requestClass, downstreamXRayEnabled, s
     const thisDownstreamXRayEnabled = !!downstreamXRayEnabled;
     const thisSubsegmentCallback = subsegmentCallback;
     // Standardize request information
-    const request = args[0] instanceof requestClass ?
+    const request = (args[0] instanceof requestClass && args.length === 1) ?
       args[0] :
       new requestClass(...args);
 

--- a/sdk_contrib/fetch/test/integration/fetch_p.test.js
+++ b/sdk_contrib/fetch/test/integration/fetch_p.test.js
@@ -111,6 +111,26 @@ describe('Integration tests', function () {
         stubClose.should.have.been.calledOnce;
       });
 
+      it('works with stringifyable objects', async function () {
+        const spyCallback = sandbox.spy();
+        const fetch = captureFetchGlobal(true, spyCallback);
+        const response = await fetch(new URL(goodUrl), {
+          headers: {
+            'foo': 'bar'
+          }
+        });
+        response.status.should.equal(200);
+        receivedHeaders.should.to.have.property('x-amzn-trace-id');
+        receivedHeaders.should.to.have.property('foo', 'bar');
+        (await response.text()).should.contain('Example');
+        stubIsAutomaticMode.should.have.been.called;
+        stubAddNewSubsegment.should.have.been.calledOnce;
+        stubResolveSegment.should.have.been.calledOnce;
+        stubAddFetchRequestData.should.have.been.calledOnce;
+        stubAddErrorFlag.should.not.have.been.calledOnce;
+        stubClose.should.have.been.calledOnce;
+      });
+
       it('sets error flag on failed fetch when global fetch exists', async function () {
         const spyCallback = sandbox.spy();
         const fetch = captureFetchGlobal(true, spyCallback);

--- a/sdk_contrib/fetch/test/unit/fetch_p.test.js
+++ b/sdk_contrib/fetch/test/unit/fetch_p.test.js
@@ -1,4 +1,5 @@
 const { Subsegment } = require('aws-xray-sdk-core');
+const { Agent } = require('http');
 const fetch = require('node-fetch');
 
 describe('Unit tests', function () {
@@ -157,13 +158,13 @@ describe('Unit tests', function () {
 
     it('short circuits if headers include trace ID', async function () {
       const activeFetch = captureFetch(true);
-      const request = new fetchModule.Request('https://www.foo.com', {
+      const request = new Request('https://www.foo.com', {
         headers: {
           'X-Amzn-Trace-Id': '12345'
         }
       });
       await activeFetch(request);
-      stubFetch.should.have.been.calledOnceWith(request);
+      stubFetch.should.have.been.calledOnceWith(sinon.match({ url: 'https://www.foo.com/'}));
       stubResolveSegment.should.not.have.been.called;
     });
 

--- a/sdk_contrib/fetch/test/unit/fetch_p.test.js
+++ b/sdk_contrib/fetch/test/unit/fetch_p.test.js
@@ -158,7 +158,7 @@ describe('Unit tests', function () {
 
     it('short circuits if headers include trace ID', async function () {
       const activeFetch = captureFetch(true);
-      const request = new Request('https://www.foo.com', {
+      const request = new FetchRequest('https://www.foo.com', {
         headers: {
           'X-Amzn-Trace-Id': '12345'
         }
@@ -180,7 +180,7 @@ describe('Unit tests', function () {
       stubResolveSegment.should.have.been.called;
 
       // check if dispatcher was transferred
-      const dummyRequest = new Request('https://www.foo.com', {
+      const dummyRequest = new FetchRequest('https://www.foo.com', {
         dispatcher: agent
       });
       const dispatcherSymbol = Object.getOwnPropertySymbols(dummyRequest).find(symbol => symbol.description === 'dispatcher');
@@ -194,14 +194,14 @@ describe('Unit tests', function () {
       const agent = new Agent({
         maxSockets: 1234
       });
-      await activeFetch(new Request('https://www.foo.com'), {
+      await activeFetch(new FetchRequest('https://www.foo.com'), {
         dispatcher: agent
       });
       stubFetch.should.have.been.calledOnceWith(sinon.match({ url: 'https://www.foo.com/' }));
       stubResolveSegment.should.have.been.called;
 
       // check if dispatcher was transferred
-      const dummyRequest = new Request('https://www.foo.com', {
+      const dummyRequest = new FetchRequest('https://www.foo.com', {
         dispatcher: agent
       });
       const dispatcherSymbol = Object.getOwnPropertySymbols(dummyRequest).find(symbol => symbol.description === 'dispatcher');
@@ -222,7 +222,7 @@ describe('Unit tests', function () {
       stubResolveSegment.should.have.been.called;
 
       // check if dispatcher was transferred
-      const dummyRequest = new Request('https://www.foo.com', {
+      const dummyRequest = new FetchRequest('https://www.foo.com', {
         dispatcher: agent
       });
       const dispatcherSymbol = Object.getOwnPropertySymbols(dummyRequest).find(symbol => symbol.description === 'dispatcher');

--- a/sdk_contrib/fetch/test/unit/fetch_p.test.js
+++ b/sdk_contrib/fetch/test/unit/fetch_p.test.js
@@ -1,5 +1,4 @@
 const { Subsegment } = require('aws-xray-sdk-core');
-const { Agent } = require('http');
 const fetch = require('node-fetch');
 
 describe('Unit tests', function () {

--- a/sdk_contrib/fetch/test/unit/fetch_p.test.js
+++ b/sdk_contrib/fetch/test/unit/fetch_p.test.js
@@ -189,6 +189,48 @@ describe('Unit tests', function () {
       }
     });
 
+    it('transfers dispatcher property for undici with Request object', async function () {
+      const activeFetch = captureFetch(true);
+      const agent = new Agent({
+        maxSockets: 1234
+      });
+      await activeFetch(new Request('https://www.foo.com'), {
+        dispatcher: agent
+      });
+      stubFetch.should.have.been.calledOnceWith(sinon.match({ url: 'https://www.foo.com/' }));
+      stubResolveSegment.should.have.been.called;
+
+      // check if dispatcher was transferred
+      const dummyRequest = new Request('https://www.foo.com', {
+        dispatcher: agent
+      });
+      const dispatcherSymbol = Object.getOwnPropertySymbols(dummyRequest).find(symbol => symbol.description === 'dispatcher');
+      if (dispatcherSymbol) {
+        stubFetch.should.have.been.calledOnceWith(sinon.match({ [dispatcherSymbol]: agent }));
+      }
+    });
+
+    it('transfers dispatcher property for undici with url and init', async function () {
+      const activeFetch = captureFetch(true);
+      const agent = new Agent({
+        maxSockets: 1234
+      });
+      await activeFetch('https://www.foo.com', {
+        dispatcher: agent
+      });
+      stubFetch.should.have.been.calledOnceWith(sinon.match({ url: 'https://www.foo.com/' }));
+      stubResolveSegment.should.have.been.called;
+
+      // check if dispatcher was transferred
+      const dummyRequest = new Request('https://www.foo.com', {
+        dispatcher: agent
+      });
+      const dispatcherSymbol = Object.getOwnPropertySymbols(dummyRequest).find(symbol => symbol.description === 'dispatcher');
+      if (dispatcherSymbol) {
+        stubFetch.should.have.been.calledOnceWith(sinon.match({ [dispatcherSymbol]: agent }));
+      }
+    });
+
     it('calls base function when no parent and automatic mode', async function () {
       const activeFetch = captureFetch(true);
       stubResolveSegment.returns(null);


### PR DESCRIPTION
*Issue #, if available:*
#648, #650
*Description of changes:*
There is a seperate PR for #648, see description there.
For #650 when fetch is instrumented, we check now if there is a dispatcher property settable on a request which is not transferred to the cloned request. It is a bug detector for undici. If that bug is detected, a work-around is enabled, which will search for the dispatcher symbol property and copy it manually to the new request. A test for that has been added.
In the future, this work-around can be removed, once the fix in undici is sufficiently available. For now, this should resolve @Kruspe problem.
Please note that the bug detection is only done when `enableCapture` is called, so only when the program initializes. This minimizes impacts to performance.
I included my fix to #648, since not doing that would make a difference in how the unit test works.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
