### PR TITLE
Fix incorrect typescript types

### DIFF
--- a/packages/full_sdk/lib/index.d.ts
+++ b/packages/full_sdk/lib/index.d.ts
@@ -1,6 +1,6 @@
 import * as express from 'aws-xray-sdk-express';
-import { captureMySQL } from 'aws-xray-sdk-mysql';
-import { capturePostgres } from 'aws-xray-sdk-postgres';
+import captureMySQL from 'aws-xray-sdk-mysql';
+import capturePostgres from 'aws-xray-sdk-postgres';
 
 export * from 'aws-xray-sdk-core';
 

--- a/packages/full_sdk/test-d/index.test-d.ts
+++ b/packages/full_sdk/test-d/index.test-d.ts
@@ -1,6 +1,6 @@
 import * as express from 'aws-xray-sdk-express';
-import { captureMySQL } from 'aws-xray-sdk-mysql';
-import { capturePostgres } from 'aws-xray-sdk-postgres';
+import captureMySQL from 'aws-xray-sdk-mysql';
+import capturePostgres from 'aws-xray-sdk-postgres';
 import { expectType } from 'tsd';
 import * as AWSXRay from '../lib';
 

--- a/packages/mysql/lib/index.d.ts
+++ b/packages/mysql/lib/index.d.ts
@@ -1,1 +1,2 @@
-export * from './mysql_p';
+import captureMySQL from './mysql_p';
+export = captureMySQL;

--- a/packages/mysql/lib/mysql_p.d.ts
+++ b/packages/mysql/lib/mysql_p.d.ts
@@ -1,7 +1,8 @@
 import * as AWSXRay from 'aws-xray-sdk-core';
 import * as MySQL from 'mysql';
 
-export function captureMySQL(mysql: typeof MySQL): captureMySQL.PatchedMySQL;
+declare function captureMySQL(mysql: typeof MySQL): captureMySQL.PatchedMySQL;
+export = captureMySQL;
 
 declare namespace captureMySQL {
   interface PatchedQueryFunction {

--- a/packages/mysql/test-d/index.test-d.ts
+++ b/packages/mysql/test-d/index.test-d.ts
@@ -2,7 +2,7 @@
 import * as AWSXRay from 'aws-xray-sdk-core';
 import * as MySQL from 'mysql';
 import { expectType } from 'tsd';
-import { captureMySQL } from '../lib';
+import captureMySQL from '../lib';
 
 const segment = AWSXRay.getSegment();
 

--- a/packages/postgres/lib/index.d.ts
+++ b/packages/postgres/lib/index.d.ts
@@ -1,1 +1,2 @@
-export * from './postgres_p';
+import capturePostgres from './postgres_p';
+export = capturePostgres

--- a/packages/postgres/lib/postgres_p.d.ts
+++ b/packages/postgres/lib/postgres_p.d.ts
@@ -1,7 +1,8 @@
 import * as AWSXRay from 'aws-xray-sdk-core';
 import * as PG from 'pg';
 
-export function capturePostgres(pg: typeof PG): capturePostgres.PatchedPostgres;
+declare function capturePostgres(pg: typeof PG): capturePostgres.PatchedPostgres
+export = capturePostgres;
 
 declare namespace capturePostgres {
   interface CaptureQueryMethod {

--- a/packages/postgres/test-d/index.test-d.ts
+++ b/packages/postgres/test-d/index.test-d.ts
@@ -2,7 +2,7 @@
 import * as AWSXRay from 'aws-xray-sdk-core';
 import * as PG from 'pg';
 import { expectType } from 'tsd';
-import { capturePostgres } from '../lib';
+import capturePostgres from '../lib';
 
 const segment = AWSXRay.getSegment();
 


### PR DESCRIPTION
*Issue #, if available:* #450

*Description of changes:*

The types are wrong because the javascript exports the functions using `module.exports = function` and the types declare a named export.

Fixed according to Definitely Typed [Best Practices][1], using `export = ...`.

  [1]: https://github.com/DefinitelyTyped/DefinitelyTyped?tab=readme-ov-file#arethetypeswrongcli-attw-checks

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
