### PR TITLE
Fix (aws-xray-sdk-fastify): enable automatic mode and expose hooks

### DIFF
--- a/sdk_contrib/fastify/lib/hooks/on-request.hook.js
+++ b/sdk_contrib/fastify/lib/hooks/on-request.hook.js
@@ -16,6 +16,7 @@ module.exports = function onRequestHook(request, reply, done) {
 
     ns.run(() => {
       AWSXRay.setSegment(segment);
+      done();
     });
   } else {
     request.log.info('Manual mode, skipping segment');
@@ -25,7 +26,7 @@ module.exports = function onRequestHook(request, reply, done) {
     } else {
       request.log.warn('Request already has a segment, skipping');
     }
-  }
 
-  done();
+    done();
+  }
 };

--- a/sdk_contrib/fastify/lib/plugin.js
+++ b/sdk_contrib/fastify/lib/plugin.js
@@ -1,11 +1,12 @@
 // @ts-check
+const fp = require('fastify-plugin').default;
 const configureAWSXRaySync = require('./private/configure-aws-x-ray-sync');
 const onRequestHook = require('./hooks/on-request.hook');
 const onResponseHook = require('./hooks/on-response.hook');
 const onErrorHook = require('./hooks/on-error.hook');
 
 /** @type {import('fastify').FastifyPluginAsync} */
-const xRayFastifyPlugin = async (fastify, opts) => {
+const xRayFastifyPlugin = fp(async (fastify, opts) => {
   configureAWSXRaySync(fastify, opts);
 
   fastify.decorateRequest('segment', null);
@@ -13,7 +14,7 @@ const xRayFastifyPlugin = async (fastify, opts) => {
     .addHook('onRequest', onRequestHook)
     .addHook('onResponse', onResponseHook)
     .addHook('onError', onErrorHook);
-};
+});
 
 module.exports = xRayFastifyPlugin;
 


### PR DESCRIPTION
*Issue #, if available:* #701, #702

*Description of changes:*

- In automatic mode, call `done()` at inside of the active namespace context (cls-hooked). Fixes #701 
- Make hooks accessible in the same fastify context. Fixes #702 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
