### PR TITLE
fix(daily-scan): scan published artifacts instead of repo source

### DIFF
--- a/.github/workflows/daily-scan.yml
+++ b/.github/workflows/daily-scan.yml
@@ -33,8 +33,11 @@ jobs:
         with:
           node-version: '18'
 
-      - name: Build Node.js project for scanning
-        run: npm install
+      - name: Install published package for scanning
+        run: |
+          mkdir -p scan-target && cd scan-target
+          npm init -y
+          npm install aws-xray-sdk
 
       - name: Install Java for dependency scan
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 #v5.0.0
@@ -68,7 +71,7 @@ jobs:
           curl -Ls "https://github.com/dependency-check/DependencyCheck/releases/download/v$VERSION/dependency-check-$VERSION-release.zip.asc" --output dependency-check.zip.asc
           gpg --verify dependency-check.zip.asc
           unzip dependency-check.zip
-          ./dependency-check/bin/dependency-check.sh --failOnCVSS 0 --nvdApiKey ${{ env.NVD_API_KEY_NVD_API_KEY }} --ossIndexUsername ${{ env.OSS_INDEX_USERNAME }} --ossIndexPassword ${{ env.OSS_INDEX_PASSWORD }} -s "."
+          ./dependency-check/bin/dependency-check.sh --failOnCVSS 0 --nvdApiKey ${{ env.NVD_API_KEY_NVD_API_KEY }} --ossIndexUsername ${{ env.OSS_INDEX_USERNAME }} --ossIndexPassword ${{ env.OSS_INDEX_PASSWORD }} -s "scan-target/"
 
       - name: Print dependency scan results on failure
         if: ${{ steps.dep_scan.outcome != 'success' }}


### PR DESCRIPTION
## Problem

DependencyCheck (DC) scans `-s "."` which includes DC's own bundled jars in `./dependency-check/lib/`, producing false positive CVEs (commons-beanutils, h2, logback, gson, httpclient5, etc.).

Additionally, scanning source code means if a vulnerability exists in the published artifact but has already been fixed on `main`, the scan gives a false negative — customers are still exposed.

## Fix

Instead of scanning the repo source tree, download/install the **published artifact** from its package registry into a dedicated `scan-target/` directory, then scan only that.

This pattern is already proven by ADOT Java and ADOT Python repos.

## Changes

- Replace the pre-scan build/install step with one that fetches the published artifact into `scan-target/`
- Change the DC scan target from `-s "."` to `-s "scan-target/"`
- All other steps (checkout, DC download/GPG/unzip, Trivy, metrics) are unchanged
- All DC flags (`--failOnCVSS 0`, `--enableExperimental`, `--nvdApiKey`, etc.) are unchanged

## Testing

Tested locally with DC v12.1.0 against NVD database. Verified:
- All reported dependencies come from the published artifact
- Zero DC tool jars in the report (no false positives)
- Dependency count matches expected published artifact contents