### PR TITLE
fix(daily-scan): point Trivy at published artifact dependencies

### DIFF
--- a/.github/workflows/daily-scan.yml
+++ b/.github/workflows/daily-scan.yml
@@ -1,7 +1,7 @@
 ## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 ## SPDX-License-Identifier: Apache-2.0
 # Performs a daily scan of:
-# * The X-Ray Node.js SDK source code, using Trivy
+# * The X-Ray Node.js SDK published artifact dependencies, using Trivy
 # * Project dependencies, using DependencyCheck
 #
 #  Publishes results to CloudWatch Metrics.
@@ -77,23 +77,23 @@ jobs:
         if: ${{ steps.dep_scan.outcome != 'success' }}
         run: less dependency-check-report.html
 
-      - name: Perform high severity scan on source code
+      - name: Perform high severity scan on published artifact dependencies
         if: always()
         id: high_scan_latest
         uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # v0.34.2
         with:
           scan-type: 'fs'
-          scan-ref: '.'
+          scan-ref: 'scan-target/'
           severity: 'CRITICAL,HIGH'
           exit-code: '1'
 
-      - name: Perform low severity scan on source code
+      - name: Perform low severity scan on published artifact dependencies
         if: always()
         id: low_scan_latest
         uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # v0.34.2
         with:
           scan-type: 'fs'
-          scan-ref: '.'
+          scan-ref: 'scan-target/'
           severity: 'MEDIUM,LOW,UNKNOWN'
           exit-code: '1'
 


### PR DESCRIPTION
## What
Point Trivy at the published artifact dependency tree (`scan-target/`) instead of scanning the full repo source at HEAD.

## Why
Trivy was scanning `scan-ref: '.'`, which:
- Picked up 42 devDependencies from the root `package-lock.json` (mocha, sinon, eslint, fastify, koa, aws-sdk v2, typescript, etc.)
- Found CVEs in fastify and koa — dev deps that customers never install
- Scanned source at HEAD, not the released version

## How
Changed `scan-ref` from `'.'` to `'scan-target/'`, which already contains `package-lock.json` from `npm install aws-xray-sdk`. Only runtime deps.

## Local validation
- **Trivy**: Parses `package-lock.json`, 0 vulns (clean — fastify/koa/ajv CVEs correctly excluded)