### PR TITLE
Add Trivy and DependencyCheck suppression files

### DIFF
--- a/.github/dependency-check-suppressions.xml
+++ b/.github/dependency-check-suppressions.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+</suppressions>

--- a/.github/trivy/daily-scan.trivyignore.yaml
+++ b/.github/trivy/daily-scan.trivyignore.yaml
@@ -1,0 +1,13 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Trivy ignore file for daily scans.
+# This file is intentionally empty. Daily scans should flag all CVEs.
+# See: https://aquasecurity.github.io/trivy/latest/docs/configuration/filtering/
+
+# Format:
+# - id: <CVE-###>
+#   statement: "<Why are we excluding?> <link to CVE where we can track status>"
+#   expired_at: <required - YYYY-MM-DD>
+
+vulnerabilities: []

--- a/.github/workflows/daily-scan.yml
+++ b/.github/workflows/daily-scan.yml
@@ -71,7 +71,7 @@ jobs:
           curl -Ls "https://github.com/dependency-check/DependencyCheck/releases/download/v$VERSION/dependency-check-$VERSION-release.zip.asc" --output dependency-check.zip.asc
           gpg --verify dependency-check.zip.asc
           unzip dependency-check.zip
-          ./dependency-check/bin/dependency-check.sh --failOnCVSS 0 --nvdApiKey ${{ env.NVD_API_KEY_NVD_API_KEY }} --ossIndexUsername ${{ env.OSS_INDEX_USERNAME }} --ossIndexPassword ${{ env.OSS_INDEX_PASSWORD }} -s "scan-target/"
+          ./dependency-check/bin/dependency-check.sh --failOnCVSS 0 --nvdApiKey ${{ env.NVD_API_KEY_NVD_API_KEY }} --ossIndexUsername ${{ env.OSS_INDEX_USERNAME }} --ossIndexPassword ${{ env.OSS_INDEX_PASSWORD }} --suppression .github/dependency-check-suppressions.xml -s "scan-target/"
 
       - name: Print dependency scan results on failure
         if: ${{ steps.dep_scan.outcome != 'success' }}
@@ -86,6 +86,8 @@ jobs:
           scan-ref: '.'
           severity: 'CRITICAL,HIGH'
           exit-code: '1'
+        env:
+          TRIVY_IGNOREFILE: .github/trivy/daily-scan.trivyignore.yaml
 
       - name: Perform low severity scan on source code
         if: always()
@@ -96,6 +98,8 @@ jobs:
           scan-ref: '.'
           severity: 'MEDIUM,LOW,UNKNOWN'
           exit-code: '1'
+        env:
+          TRIVY_IGNOREFILE: .github/trivy/daily-scan.trivyignore.yaml
 
       - name: Configure AWS Credentials for emitting metrics
         if: always()


### PR DESCRIPTION
Add empty suppression files for Trivy (daily-scan.trivyignore.yaml) and DependencyCheck (dependency-check-suppressions.xml), and wire them into the daily scan workflow.

This allows us to suppress false positives without code changes to the workflow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.